### PR TITLE
Remove verbose option from tar

### DIFF
--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -29,7 +29,7 @@ main() {
 
     ensure downloader "$_fuelup_url" "$_file" "$_arch"
 
-    ignore tar -xvf "$_file" -C "$_dir"
+    ignore tar -xf "$_file" -C "$_dir"
 
     ensure mv "$_dir/fuelup-${_fuelup_version}-${_arch}/fuelup" "$FUELUP_DIR/bin/fuelup"
     ensure chmod u+x "$FUELUP_DIR/bin/fuelup"


### PR DESCRIPTION
Remove `-v` from the script to stop the extraction output from showing when running the script.

```
❯ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/FuelLabs/fuelup/master/fuelup-init.sh | sh -s install

x fuelup-0.1.0-x86_64-apple-darwin/ <-- removes this
x fuelup-0.1.0-x86_64-apple-darwin/fuelup <-- removes this

Downloading the Forc toolchain

...
```
