### PR TITLE
Add fuelup installation message at the end

### DIFF
--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -60,7 +60,7 @@ main() {
     ignore rmdir "$_dir/fuelup-${_fuelup_version}-${_arch}"
     ignore rmdir "$_dir"
 
-    echo "\nfuelup ${_fuelup_version} has been installed in $FUELUP_DIR/bin. To fetch the latest forc and fuel-core binaries, you can do 'fuelup install' in future."
+    echo "\nfuelup ${_fuelup_version} has been installed in $FUELUP_DIR/bin. To fetch the latest forc and fuel-core binaries, run 'fuelup install'."
 
     return "$_retval"
 }

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -60,6 +60,8 @@ main() {
     ignore rmdir "$_dir/fuelup-${_fuelup_version}-${_arch}"
     ignore rmdir "$_dir"
 
+    echo "\nfuelup ${_fuelup_version} has been installed in $FUELUP_DIR/bin. To fetch the latest forc and fuel-core binaries, you can do 'fuelup install' in future."
+
     return "$_retval"
 }
 


### PR DESCRIPTION
Add a simple message to let users know that `fuelup` has been installed and that they can use `fuelup install` to fetch the latest binaries