### PR TITLE
Add CI to publish `fuelup-init.sh`

### DIFF
--- a/.github/workflows/gh-pages-init.yml
+++ b/.github/workflows/gh-pages-init.yml
@@ -1,0 +1,36 @@
+name: Publish fuelup-init.sh
+
+on:
+  release:
+    types: [published]
+
+env:
+  FUELUP_DIR: ./fuelup-init.sh.d/
+
+jobs:
+  cancel-previous-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+  deploy:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Copy fuelup-init.sh
+        run: |
+          mkdir -p ${{ env.FUELUP_DIR }}
+          cp fuelup-init.sh ${{ env.FUELUP_DIR }}
+
+      - name: Deploy latest
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true
+          publish_dir: ${{ env.FUELUP_DIR }}
+          destination_dir: ./

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# fuelup: the Fuel toolchain installer
+# Fuelup: the Fuel toolchain installer
 
 `fuelup` installs the Fuel toolchain from our official release channels, enabling you to easily keep the toolchain updated.
 
 ## Installation
 
-Currently, this script supports Linux/macOS systems only. For other systems, please [install from cargo](https://fuellabs.github.io/sway/latest/introduction/installation.html#installing-from-cargo) or, alternatively, [build from source](https://fuellabs.github.io/sway/latest/introduction/installation.html#building-from-source).
+Currently, this script supports Linux/macOS systems only. For other systems, please [install from source](https://fuellabs.github.io/sway/latest/introduction/installation.html#installing-from-source).
 
 Installation is simple: all you need is `fuelup-init.sh`, which downloads the core Fuel binaries needed to get you started on development.
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/FuelLabs/fuelup/master/fuelup-init.sh | sh -s install
+curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh -s install
 ```
 
 This will install `forc`, `forc-fmt`, `forc-explore`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. You will have to add `~/.fuelup/bin` to your `PATH`.
@@ -30,4 +30,4 @@ In future, `fuelup` will also let you switch between toolchains, allowing for a 
 
 ## License
 
-Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <https://www.apache.org/licenses/LICENSE-2.0>)


### PR DESCRIPTION
I ran this in CI before force-pushing to clean up the very ugly history 😂

You can find the file here! https://github.com/FuelLabs/fuelup/tree/gh-pages, and the command in the readme works as of this PR:

```sh
curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh
```