### PR TITLE
Add lint and publish check CI jobs.

### DIFF
--- a/.github/scripts/verify_tag.sh
+++ b/.github/scripts/verify_tag.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+
+err() {
+    echo -e "\e[31m\e[1merror:\e[0m $@" 1>&2;
+}
+
+status() {
+    WIDTH=12
+    printf "\e[32m\e[1m%${WIDTH}s\e[0m %s\n" "$1" "$2"
+}
+
+REF=$1
+MANIFEST=$2
+
+if [ -z "$REF" ]; then
+    err "Expected ref to be set"
+    exit 1
+fi
+
+if [ -z "$MANIFEST" ]; then
+    err "Expected manifest to be set"
+    exit 1
+fi
+
+# strip preceeding 'v' if it exists on tag
+REF=${REF/#v}
+TOML_VERSION=$(cat $MANIFEST | dasel -r toml 'package.version')
+
+if [ "$TOML_VERSION" != "$REF" ]; then
+    err "Crate version $TOML_VERSION, doesn't match tag version $REF"
+    exit 1
+else
+  status "Crate version matches tag $TOML_VERSION"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,78 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  lint-toml-files:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install Cargo.toml linter
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-toml-lint
+          version: "0.1"
+
+      - name: Run Cargo.toml linter
+        run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
+
+      - name: Notify if Job Fails
+        uses: ravsamhq/notify-slack-action@v1
+        if: always() && github.ref == 'refs/heads/master'
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "{workflow} has {status_message}"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
+          footer: ""
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
+
+  publish-check:
+    # Only do this job if publishing a release
+    needs:
+      [cancel-previous-runs, cargo-clippy, cargo-fmt-check, lint-toml-files]
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Verify tag version
+        run: |
+          curl -sSLf "https://github.com/TomWright/dasel/releases/download/v1.24.3/dasel_linux_amd64" -L -o dasel && chmod +x dasel
+          mv ./dasel /usr/local/bin/dasel
+          ./.github/workflows/scripts/verify_tag.sh ${{ github.ref_name }} Cargo.toml
+
+      - name: Notify if Job Fails
+        uses: ravsamhq/notify-slack-action@v1
+        if: always()
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: "{workflow} has {status_message}"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}> : <{run_url}|View Run Results>"
+          footer: ""
+          notify_when: "failure"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NOTIFY_BUILD }}
+
   build-release:
     name: build fuelup release binaries
     runs-on: ${{ matrix.job.os }}
@@ -87,7 +159,7 @@ jobs:
           cache-on-failure: true
           key: "${{ matrix.job.target }}"
 
-      - name: Use Cross 
+      - name: Use Cross
         uses: baptiste0928/cargo-install@v1
         with:
           crate: cross

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "3.1", features = ["cargo", "derive", "env"] }
+dirs = "4"
 flate2 = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-dirs = "4"
 tar = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }


### PR DESCRIPTION
Adds 2 jobs:
1. toml linter to make sure the toml is formatted correctly.
2. version checker on publish. When publishing a release, will make sure the `version` in the manifest file matches the release version.