### PR TITLE
Update err message to handle failed download

### DIFF
--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -227,7 +227,7 @@ downloader() {
         if [ -n "$_err" ]; then
             echo "$_err" >&2
             if echo "$_err" | grep -q 404; then
-		err "fuelup was not found - either the release is not ready yet or the tag is invalid. You can check if the release is available here: https://github.com/FuelLabs/fuelup/releases"
+		err "fuelup ${_fuelup_version} was not found - either the release is not ready yet or the tag is invalid. You can check if the release is available here: https://github.com/FuelLabs/fuelup/releases/${_fuelup_version}"
             fi
         fi
 

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -79,9 +79,9 @@ main() {
     done
 
     if $_ansi_escapes_are_valid; then
-        printf "\33[1minfo:\33[0m downloading installer\n" 1>&2
+        printf "\33[1minfo:\33[0m downloading fuelup %s\n" $_fuelup_version 1>&2
     else
-        printf '%s\n' 'info: downloading installer' 1>&2
+        printf 'info: downloading fuelup %s\n' $_fuelup_version 1>&2
     fi
 
     ensure downloader "$_fuelup_url" "$_file" "$_arch"
@@ -226,8 +226,8 @@ downloader() {
         fi
         if [ -n "$_err" ]; then
             echo "$_err" >&2
-            if echo "$_err" | grep -q 404$; then
-                err "installer for platform '$3' not found, this may be unsupported"
+            if echo "$_err" | grep -q 404; then
+		err "fuelup was not found - either the release is not ready yet or the tag is invalid. You can check if the release is available here: https://github.com/FuelLabs/fuelup/releases"
             fi
         fi
 


### PR DESCRIPTION
Closes #44 

- Add `_fuelup_version` to the info printed, so that users can check versioning at the release page
- Clearer err message so that users know what went wrong and where to check instead of just 'unsupported arch' -> actually, in the case of 'unsupported arch', that check should've failed at `get_architecture` already
- also removed the `$` matching in `grep` - i'm not sure why matching `$` didn't work on my machine, but matching `404` should be sufficient either way since there would be nowhere else in the message that should have a `404`