### PR TITLE
replace jq with cut

### DIFF
--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -24,7 +24,7 @@ main() {
     mkdir -p "$FUELUP_DIR/bin"
 
     local _fuelup_version
-    _fuelup_version="$(curl -s https://api.github.com/repos/FuelLabs/fuelup/releases/latest | grep -r "tag_name" | cut -d "\"" -f4 | cut -c 2-)"
+    _fuelup_version="$(curl -s https://api.github.com/repos/FuelLabs/fuelup/releases/latest | grep "tag_name" | cut -d "\"" -f4 | cut -c 2-)"
     local _fuelup_url="https://github.com/FuelLabs/fuelup/releases/download/v${_fuelup_version}/fuelup-${_fuelup_version}-${_arch}.tar.gz"
 
     local _dir

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -25,8 +25,7 @@ main() {
     mkdir -p "$FUELUP_DIR/bin"
 
     local _fuelup_version
-    _fuelup_version="$(curl -s https://api.github.com/repos/FuelLabs/fuelup/releases/latest | jq -r ".tag_name")"
-    _fuelup_version="$(echo "${_fuelup_version}" | cut -c 2-)"
+    _fuelup_version="$(curl -s https://api.github.com/repos/FuelLabs/fuelup/releases/latest | grep -r "tag_name" | cut -d "\"" -f4 | cut -c 2-)"
     local _fuelup_url="https://github.com/FuelLabs/fuelup/releases/download/v${_fuelup_version}/fuelup-${_fuelup_version}-${_arch}.tar.gz"
 
     local _dir

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -10,7 +10,6 @@ main() {
     need_cmd mkdir
     need_cmd rm
     need_cmd rmdir
-    need_cmd jq
 
     check_cargo_bin forc
     check_cargo_bin forc-fmt

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -126,7 +126,7 @@ main() {
 get_architecture() {
     local _ostype _cputype
     _ostype="$(uname -s)"
-    _arch="$(uname -m)"
+    _cputype="$(uname -m)"
 
     case "$_ostype" in
     Linux)
@@ -140,19 +140,19 @@ get_architecture() {
         ;;
     esac
 
-    case "$_arch" in
+    case "$_cputype" in
     x86_64 | x86-64 | x64 | amd64)
-        _arch="x86_64"
+        _cputype="x86_64"
         ;;
     aarch64 | arm64)
-        _arch="aarch64"
+        _cputype="aarch64"
         ;;
     *)
         err "unsupported cpu type: $_cputype"
         ;;
     esac
 
-    _arch="${_arch}-${_ostype}"
+    _arch="${_cputype}-${_ostype}"
 
     RETVAL="$_arch"
 }


### PR DESCRIPTION
Closes #52 

We use a combination of `grep` and `cut` instead of `jq`.

`"tag_name": "v0.1.2"`

The above is the output of the grep, then:

`cut -d "\"" -f4 | cut -c 2-`

this splits the above string with the `"` delimiter, getting the `v0.1.2` portion and cutting off the `v`

This may not also be the ideal way, but it's one solution as well, unless the solution described in the issue is preferred.