### PR TITLE
`fuelup self update`

### DIFF
--- a/src/commands/fuelup.rs
+++ b/src/commands/fuelup.rs
@@ -3,14 +3,13 @@ use clap::Parser;
 use tracing::info;
 
 use crate::{
-    commands::install::unpack_extracted_bins,
     constants::{FUELUP_RELEASE_DOWNLOAD_URL, GITHUB_API_REPOS_BASE_URL, RELEASES_LATEST},
-    download::{download_file_and_unpack, fuelup_bin_dir, get_latest_tag},
+    download::{download_file_and_unpack, fuelup_bin_dir, get_latest_tag, unpack_extracted_bins},
 };
 
 #[derive(Debug, Parser)]
 pub enum FuelupSubcommand {
-    /// Updates the fuelup tool.
+    /// Updates fuelup
     Update,
 }
 
@@ -35,8 +34,6 @@ fn fuelup_bin_tarball_name(version: &str) -> Result<String> {
         unsupported_os => bail!("Unsupported os: {}", unsupported_os),
     };
 
-    println!("{:?}", version);
-
     Ok(format!(
         "fuelup-{}-{}-{}-{}.tar.gz",
         // strip the 'v' from the version string to match the file name of the releases
@@ -48,12 +45,6 @@ fn fuelup_bin_tarball_name(version: &str) -> Result<String> {
 }
 
 pub fn self_update() -> Result<()> {
-    // get latest fuelup tag
-    //
-    // download to a tmp directory
-    //
-    // replace with current fuelup
-    //
     let proc = std::process::Command::new("fuelup")
         .arg("--version")
         .output()
@@ -69,8 +60,9 @@ pub fn self_update() -> Result<()> {
         Ok(t) => t,
         Err(_) => bail!("Failed to fetch latest fuelup release tag from GitHub API"),
     };
-    if &fuelup_release_latest_tag.split_at(1).1 != &current_version {
-        println!("fuelup unchanged - at latest version ({})", current_version);
+
+    if &fuelup_release_latest_tag.split_at(1).1 == &current_version {
+        info!("fuelup unchanged - at latest version ({})", current_version);
         return Ok(());
     }
 

--- a/src/commands/fuelup.rs
+++ b/src/commands/fuelup.rs
@@ -1,0 +1,89 @@
+use anyhow::{bail, Result};
+use clap::Parser;
+use tracing::info;
+
+use crate::{
+    commands::install::unpack_extracted_bins,
+    constants::{FUELUP_RELEASE_DOWNLOAD_URL, GITHUB_API_REPOS_BASE_URL, RELEASES_LATEST},
+    download::{download_file_and_unpack, fuelup_bin_dir, get_latest_tag},
+};
+
+#[derive(Debug, Parser)]
+pub enum FuelupSubcommand {
+    /// Updates the fuelup tool.
+    Update,
+}
+
+#[derive(Debug, Parser)]
+struct UpdateCommand {}
+
+fn fuelup_bin_tarball_name(version: &str) -> Result<String> {
+    let architecture = match std::env::consts::ARCH {
+        "aarch64" => "aarch64",
+        "x86_64" => "x86_64",
+        unsupported_arch => bail!("Unsupported architecture: {}", unsupported_arch),
+    };
+
+    let vendor = match std::env::consts::OS {
+        "macos" => "apple",
+        _ => "unknown",
+    };
+
+    let os = match std::env::consts::OS {
+        "macos" => "darwin",
+        "linux" => "linux-gnu",
+        unsupported_os => bail!("Unsupported os: {}", unsupported_os),
+    };
+
+    println!("{:?}", version);
+
+    Ok(format!(
+        "fuelup-{}-{}-{}-{}.tar.gz",
+        // strip the 'v' from the version string to match the file name of the releases
+        &version[1..version.len()],
+        architecture,
+        vendor,
+        os
+    ))
+}
+
+pub fn self_update() -> Result<()> {
+    // get latest fuelup tag
+    //
+    // download to a tmp directory
+    //
+    // replace with current fuelup
+    //
+    let proc = std::process::Command::new("fuelup")
+        .arg("--version")
+        .output()
+        .expect("Could not run fuelup.");
+
+    let stdout = String::from_utf8_lossy(&proc.stdout);
+    let current_version = stdout.split_whitespace().nth(1).unwrap();
+
+    let fuelup_release_latest_tag = match get_latest_tag(&format!(
+        "{}{}/{}",
+        GITHUB_API_REPOS_BASE_URL, "fuelup", RELEASES_LATEST
+    )) {
+        Ok(t) => t,
+        Err(_) => bail!("Failed to fetch latest fuelup release tag from GitHub API"),
+    };
+    if &fuelup_release_latest_tag.split_at(1).1 != &current_version {
+        println!("fuelup unchanged - at latest version ({})", current_version);
+        return Ok(());
+    }
+
+    let fuelup_bin_tarball_name = fuelup_bin_tarball_name(&fuelup_release_latest_tag)?;
+
+    info!("Fetching fuelup {}", &fuelup_release_latest_tag);
+    download_file_and_unpack(
+        FUELUP_RELEASE_DOWNLOAD_URL,
+        &fuelup_release_latest_tag,
+        &fuelup_bin_tarball_name,
+    )?;
+
+    unpack_extracted_bins(&fuelup_bin_dir())?;
+
+    Ok(())
+}

--- a/src/commands/fuelup.rs
+++ b/src/commands/fuelup.rs
@@ -61,7 +61,7 @@ pub fn self_update() -> Result<()> {
         Err(_) => bail!("Failed to fetch latest fuelup release tag from GitHub API"),
     };
 
-    if &fuelup_release_latest_tag.split_at(1).1 == &current_version {
+    if fuelup_release_latest_tag.split_at(1).1 == current_version {
         info!("fuelup unchanged - at latest version ({})", current_version);
         return Ok(());
     }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use tracing::info;
 
 use crate::constants::{FUEL_CORE_RELEASE_DOWNLOAD_URL, SWAY_RELEASE_DOWNLOAD_URL};
-use crate::download::{download_file_and_unpack, fuelup_bin_dir};
+use crate::download::{download_file_and_unpack, fuelup_bin_dir, unpack_extracted_bins};
 use crate::{
     constants::{FUEL_CORE_REPO, GITHUB_API_REPOS_BASE_URL, RELEASES_LATEST, SWAY_REPO},
     download::{forc_bin_tarball_name, fuel_core_bin_tarball_name, get_latest_tag},
@@ -55,23 +55,7 @@ pub fn install() -> Result<()> {
         &fuel_core_bin_tarball_name,
     )?;
 
-    for entry in std::fs::read_dir(&fuelup_bin_dir)? {
-        let sub_path = entry?.path();
-
-        if sub_path.is_dir() {
-            for bin in std::fs::read_dir(&sub_path)? {
-                let bin_file = bin?;
-                info!(
-                    "Unpacking and moving {} to {}",
-                    &bin_file.file_name().to_string_lossy(),
-                    fuelup_bin_dir.display()
-                );
-                fs::copy(&bin_file.path(), fuelup_bin_dir.join(&bin_file.file_name()))?;
-            }
-
-            fs::remove_dir_all(sub_path)?;
-        }
-    }
+    unpack_extracted_bins(&fuelup_bin_dir)?;
 
     info!(
         "\n\nInstalled: forc {}, fuel-core {}",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod fuelup;
 pub mod install;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,5 +7,7 @@ pub const RELEASES_LATEST: &str = "releases/latest";
 pub const RELEASES_TAGS: &str = "releases/tags";
 
 pub const SWAY_RELEASE_DOWNLOAD_URL: &str = "https://github.com/FuelLabs/sway/releases/download";
+pub const FUELUP_RELEASE_DOWNLOAD_URL: &str =
+    "https://github.com/FuelLabs/fuelup/releases/download";
 pub const FUEL_CORE_RELEASE_DOWNLOAD_URL: &str =
     "https://github.com/FuelLabs/fuel-core/releases/download";

--- a/src/download.rs
+++ b/src/download.rs
@@ -133,3 +133,25 @@ pub fn download_file_and_unpack(
 
     Ok(())
 }
+
+pub fn unpack_extracted_bins(dir: &std::path::PathBuf) -> Result<()> {
+    for entry in std::fs::read_dir(&dir)? {
+        let sub_path = entry?.path();
+
+        if sub_path.is_dir() {
+            for bin in std::fs::read_dir(&sub_path)? {
+                let bin_file = bin?;
+                info!(
+                    "Unpacking and moving {} to {}",
+                    &bin_file.file_name().to_string_lossy(),
+                    dir.display()
+                );
+                fs::copy(&bin_file.path(), dir.join(&bin_file.file_name()))?;
+            }
+
+            fs::remove_dir_all(sub_path)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,24 @@
 use anyhow::Result;
 use clap::Parser;
+use fuelup::commands::install;
 
-use fuelup::commands::install::{install, InstallCommand};
+use fuelup::commands::fuelup::{self_update, FuelupSubcommand};
+use fuelup::commands::install::InstallCommand;
 
 #[derive(Debug, Parser)]
 #[clap(name = "fuelup", about = "Fuel Toolchain Manager", version)]
 struct Cli {
     #[clap(subcommand)]
-    command: Fuelup,
+    command: Commands,
 }
 
 #[derive(Debug, Parser)]
-enum Fuelup {
+enum Commands {
     /// Installs the latest Fuel toolchain.
     Install(InstallCommand),
+    /// Manage your fuelup installation.
+    #[clap(name = "self", subcommand)]
+    Fuelup(FuelupSubcommand),
 }
 
 fn main() -> Result<()> {
@@ -27,6 +32,9 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Fuelup::Install(_command) => install(),
+        Commands::Install(_command) => install::install(),
+        Commands::Fuelup(command) => match command {
+            FuelupSubcommand::Update => self_update(),
+        },
     }
 }


### PR DESCRIPTION
Allows users to run `fuelup self update` to download the latest `fuelup` into `.fuelup/bin`