### PR TITLE
update README with updated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Installation is simple: all you need is `fuelup-init.sh`, which downloads the co
 curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
 ```
 
-This will install `forc`, `forc-fmt`, `forc-explore`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`. Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so.
+This will install `forc`, `forc-fmt`, `forc-explore`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`. Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh -s -- --no-modify-path
+```
 
 For `bash`/`zsh`, in `~/.bashrc` or `~/.zshrc` respectively:
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Currently, this script supports Linux/macOS systems only. For other systems, ple
 Installation is simple: all you need is `fuelup-init.sh`, which downloads the core Fuel binaries needed to get you started on development.
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh -s install
+curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
 ```
 
-This will install `forc`, `forc-fmt`, `forc-explore`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. You will have to add `~/.fuelup/bin` to your `PATH`.
+This will install `forc`, `forc-fmt`, `forc-explore`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`. Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` by default:
 
 For `bash`/`zsh`, in `~/.bashrc` or `~/.zshrc` respectively:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation is simple: all you need is `fuelup-init.sh`, which downloads the co
 curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
 ```
 
-This will install `forc`, `forc-fmt`, `forc-explore`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`. Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` by default:
+This will install `forc`, `forc-fmt`, `forc-explore`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`. Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so.
 
 For `bash`/`zsh`, in `~/.bashrc` or `~/.zshrc` respectively:
 


### PR DESCRIPTION
- remove `install` as an arg since we call it by default within `fuelup-init` now.
- also added instruction for `--no-modify-path`