### PR TITLE
ensure dir exists when downloading components

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -16,7 +16,7 @@ use crate::constants::{
     GITHUB_API_REPOS_BASE_URL, RELEASES_LATEST, SWAY_RELEASE_DOWNLOAD_URL, SWAY_REPO,
 };
 use crate::file::hard_or_symlink_file;
-use crate::path::fuelup_bin_dir;
+use crate::path::fuelup_bin;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct LatestReleaseApiResponse {
@@ -238,8 +238,7 @@ pub fn download_file_and_unpack(download_cfg: &DownloadCfg, dst_dir_path: &Path)
 }
 
 pub fn link_to_fuelup(bins: Vec<PathBuf>) -> Result<()> {
-    let fuelup_bin_dir = fuelup_bin_dir();
-    let fuelup_bin_path = fuelup_bin_dir.join("fuelup");
+    let fuelup_bin_path = fuelup_bin();
     for path in bins {
         hard_or_symlink_file(&fuelup_bin_path, &path)?;
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,4 +1,7 @@
-use std::path::PathBuf;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use dirs;
 
@@ -12,6 +15,10 @@ pub fn fuelup_bin_dir() -> PathBuf {
     fuelup_dir().join("bin")
 }
 
+pub fn fuelup_bin() -> PathBuf {
+    fuelup_bin_dir().join("fuelup")
+}
+
 pub fn settings_file() -> PathBuf {
     fuelup_dir().join("settings.toml")
 }
@@ -22,4 +29,10 @@ pub fn toolchain_dir() -> PathBuf {
 
 pub fn toolchain_bin_dir(toolchain: &str) -> PathBuf {
     toolchain_dir().join(toolchain).join("bin")
+}
+
+pub fn ensure_dir_exists(path: &Path) {
+    if !path.is_dir() {
+        fs::create_dir_all(path).expect(&format!("Failed to create {}", path.display()));
+    }
 }


### PR DESCRIPTION
In some cases (especially when developing and running fuelup as `cargo run`), `fuelup` may not exist and thus the code doesn't know what to do with downloaded binaries (can't link since `fuelup` doesn't exist!) This is a small PR just to ensure that fuelup exists.