### PR TITLE
correctly pass args to fuelup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           sh_checker_comment: false
           sh_checker_exclude: "src .github"
-      - uses: actions/checkout@v3
-        name: Attempt to install fuelup through fuelup-init.sh
+      - name: Attempt to install fuelup through fuelup-init.sh
         run: ./fuelup-init.sh
 
   cargo-clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           sh_checker_comment: false
           sh_checker_exclude: "src .github"
+      - uses: actions/checkout@v3
+        name: Attempt to install fuelup through fuelup-init.sh
+        run: ./fuelup-init.sh
 
   cargo-clippy:
     needs: cancel-previous-runs

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -115,7 +115,7 @@ main() {
         exit 1
     fi
 
-    ignore "$FUELUP_DIR/bin/fuelup" "toolchain install latest"
+    ignore "$FUELUP_DIR/bin/fuelup" "toolchain" "install" "latest"
 
     local _retval=$?
 


### PR DESCRIPTION
Fixes https://github.com/FuelLabs/action-fuel-toolchain/pull/30

Args to the executable have to be separated instead of being passed as a single, whitespace-separated string.