### PR TITLE
fix script location

### DIFF
--- a/.github/workflows/index-versions.yml
+++ b/.github/workflows/index-versions.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           curl -s "https://fuellabs.github.io/fuelup/channel-fuel-latest.toml" -L -o channel-fuel-latest.toml
           mkdir -p ${{ env.LATEST_CHANNEL_DIR }}
-          ./.github/workflows/index-versions.sh
+          ./.github/workflows/scripts/index-versions.sh
           cp channel-fuel-latest.toml ${{ env.LATEST_CHANNEL_DIR }}
 
       - name: Deploy latest


### PR DESCRIPTION
The script within this repo and my personal repo lived in a different place - as a result the CI for `fuelup` is failing because I didn't amend it prior to making PR #75 