### PR TITLE
add missing 'v' to release link

### DIFF
--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -274,7 +274,7 @@ downloader() {
         if [ -n "$_err" ]; then
             echo "$_err" >&2
             if echo "$_err" | grep -q 404; then
-                err "fuelup ${_fuelup_version} was not found - either the release is not ready yet or the tag is invalid. You can check if the release is available here: https://github.com/FuelLabs/fuelup/releases/${_fuelup_version}"
+                err "fuelup ${_fuelup_version} was not found - either the release is not ready yet or the tag is invalid. You can check if the release is available here: https://github.com/FuelLabs/fuelup/releases/v${_fuelup_version}"
             fi
         fi
 


### PR DESCRIPTION
Missing 'v' when linking to the release page since `_fuelup_version` in the script does not contain 'v':

wrong link (old):
https://github.com/FuelLabs/fuelup/releases/0.2.1

new:
https://github.com/FuelLabs/fuelup/releases/v0.2.1

