### PR TITLE
include `.github/workflows/scripts` dir in shfmt and shellcheck CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-  check-fuelup-init:
+  check-scripts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Run shellcheck and shfmt
+      - name: Run shellcheck and shfmt on all scripts
         uses: luizm/action-sh-checker@master
         env:
           SHELLCHECK_OPTS: -e SC3043 # exclude 'local' is undefined

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           SHFMT_OPTS: -i 4 -ci
         with:
           sh_checker_comment: false
-          sh_checker_exclude: "src .github"
+          sh_checker_exclude: "src"
       - name: Attempt to install fuelup through fuelup-init.sh
         run: ./fuelup-init.sh
 

--- a/.github/workflows/scripts/verify_tag.sh
+++ b/.github/workflows/scripts/verify_tag.sh
@@ -2,7 +2,7 @@
 set -e
 
 err() {
-    echo -e "\e[31m\e[1merror:\e[0m $*" 1>&2;
+    echo -e "\e[31m\e[1merror:\e[0m $*" 1>&2
 }
 
 status() {
@@ -24,12 +24,12 @@ if [ -z "$MANIFEST" ]; then
 fi
 
 # strip preceeding 'v' if it exists on tag
-REF=${REF/#v}
+REF=${REF/#v/}
 TOML_VERSION=$(dasel -f "$MANIFEST" -r toml 'package.version')
 
 if [ "$TOML_VERSION" != "$REF" ]; then
     err "Crate version $TOML_VERSION, doesn't match tag version $REF"
     exit 1
 else
-  status "Crate version matches tag $TOML_VERSION"
+    status "Crate version matches tag $TOML_VERSION"
 fi

--- a/.github/workflows/scripts/verify_tag.sh
+++ b/.github/workflows/scripts/verify_tag.sh
@@ -2,7 +2,7 @@
 set -e
 
 err() {
-    echo -e "\e[31m\e[1merror:\e[0m $@" 1>&2;
+    echo -e "\e[31m\e[1merror:\e[0m $*" 1>&2;
 }
 
 status() {
@@ -25,7 +25,7 @@ fi
 
 # strip preceeding 'v' if it exists on tag
 REF=${REF/#v}
-TOML_VERSION=$(cat $MANIFEST | dasel -r toml 'package.version')
+TOML_VERSION=$(dasel -f "$MANIFEST" -r toml 'package.version')
 
 if [ "$TOML_VERSION" != "$REF" ]; then
     err "Crate version $TOML_VERSION, doesn't match tag version $REF"


### PR DESCRIPTION
This includes both `index-versions.sh` and `verify-tags.sh` within the `/scripts` directory into `shellcheck` and `shfmt`, and fixes the issues with them.

**verify-tags.sh**
`SC2145`: https://www.shellcheck.net/wiki/SC2145
Also removed `cat $MANIFEST` since we can input `-f <FILE>`


