### PR TITLE
Fix fuelup self update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4"
 termcolor = "1"
+tempfile = "3"
 toml = "0.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 ureq = "2.4"
-
-[dev-dependencies]
-tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4"
-termcolor = "1"
 tempfile = "3"
+termcolor = "1"
 toml = "0.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -24,8 +24,9 @@ pub fn self_update() -> Result<()> {
     let fuelup_backup = fuelup_bin_dir.join("fuelup-backup");
 
     let fuelup_new_dir = tempdir_in(&fuelup_bin_dir)?;
+    let fuelup_new_dir_path = fuelup_new_dir.path();
 
-    if let Err(e) = attempt_install_self(download_cfg, fuelup_new_dir.path()) {
+    if let Err(e) = attempt_install_self(download_cfg, fuelup_new_dir_path) {
         // Skip all other steps if downloading fails here.
         // We do not need to handle failure, since this downloads to a tempdir.
         bail!("Failed to install fuelup: {}", e);
@@ -38,10 +39,10 @@ pub fn self_update() -> Result<()> {
 
     info!(
         "Moving {} to {}",
-        fuelup_new_dir.path().join("fuelup").display(),
+        fuelup_new_dir_path.join("fuelup").display(),
         &fuelup_bin.display()
     );
-    if let Err(e) = fs::rename(fuelup_new_dir.path().join("fuelup"), &fuelup_bin) {
+    if let Err(e) = fs::rename(fuelup_new_dir_path.join("fuelup"), &fuelup_bin) {
         error!("Failed to replace the old fuelup: {}", e);
         error!("Restoring old fuelup");
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use std::{fs, path::Path};
 use tempfile::tempdir_in;
 use tracing::{error, info};

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -50,13 +50,13 @@ pub fn self_update() -> Result<()> {
         fuelup_new.display(),
         &fuelup_bin.display()
     );
-    if let Err(e) = fs::rename("wot", &fuelup_bin) {
+    if let Err(e) = fs::rename(&fuelup_new, &fuelup_bin) {
         error!(
             "Failed to replace old fuelup with new fuelup. Attempting to restore backup fuelup.",
         );
         // If we have failed to replace the old fuelup for whatever reason, we want the backup.
         // Although unlikely, should this last step fail, we will recommend to re-install fuelup using fuelup-init.
-        if let Err(e) = fs::rename(&"wot", &fuelup_bin) {
+        if let Err(e) = fs::rename(&fuelup_backup, &fuelup_bin) {
             bail!(
                 "Could not restore backup fuelup. {}
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -26,7 +26,7 @@ pub fn self_update() -> Result<()> {
     let fuelup_backup_dir = tempdir_in(&fuelup_bin_dir)?;
 
     if let Err(e) = attempt_install_self(download_cfg, fuelup_new_dir.path()) {
-        error!("Failed to install and replace fuelup. {}", e);
+        error!("Failed to install fuelup: {}", e);
     };
 
     let fuelup_backup = fuelup_backup_dir.path().join("fuelup-backup");
@@ -41,7 +41,9 @@ pub fn self_update() -> Result<()> {
         // If we have failed to replace the old fuelup for whatever reason, we want the backup.
         error!("Failed to replace the old fuelup: {}", e);
         if let Err(e) = fs::copy(&fuelup_backup, &fuelup_bin) {
-            error!("Could not restore backup fuelup: {}. You should re-install fuelup using the script: `curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh`", e);
+            error!("Could not restore backup fuelup: {}", e);
+            error!("You should re-install fuelup using the script:");
+            error!("`curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh`");
         }
     };
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -25,7 +25,7 @@ pub fn self_update() -> Result<()> {
     let fuelup_new_dir = tempdir_in(&fuelup_bin_dir)?;
     let fuelup_backup_dir = tempdir_in(&fuelup_bin_dir)?;
 
-    if let Err(e) = attempt_install_self(download_cfg, &fuelup_new_dir.path()) {
+    if let Err(e) = attempt_install_self(download_cfg, fuelup_new_dir.path()) {
         error!("Failed to install and replace fuelup. {}", e);
     };
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use std::{fs, path::Path};
 use tempfile::tempdir_in;
 use tracing::error;
@@ -26,7 +26,8 @@ pub fn self_update() -> Result<()> {
     let fuelup_backup_dir = tempdir_in(&fuelup_bin_dir)?;
 
     if let Err(e) = attempt_install_self(download_cfg, fuelup_new_dir.path()) {
-        error!("Failed to install fuelup: {}", e);
+        // Skip all other steps if downloading fails here.
+        bail!("Failed to install fuelup: {}", e);
     };
 
     let fuelup_backup = fuelup_backup_dir.path().join("fuelup-backup");

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -33,6 +33,7 @@ pub fn self_update() -> Result<()> {
     if fuelup_bin.exists() {
         // Make a backup of fuelup, fuelup-backup.
         fs::copy(&fuelup_bin, &fuelup_backup).expect("Could not make a fuelup-backup");
+        fs::remove_file(&fuelup_bin)?;
     };
 
     // Copy the new fuelup into the bin folder.

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -53,5 +53,8 @@ pub fn self_update() -> Result<()> {
         }
     };
 
+    // Remove backup at the end.
+    let _ = fs::remove_file(fuelup_backup);
+
     Ok(())
 }

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -42,7 +42,7 @@ pub fn self_update() -> Result<()> {
         error!("Failed to replace the old fuelup: {}", e);
         if let Err(e) = fs::copy(&fuelup_backup, &fuelup_bin) {
             error!("Could not restore backup fuelup: {}", e);
-            error!("You should re-install fuelup using the script:");
+            error!("You should re-install fuelup using fuelup-init:");
             error!("`curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh`");
         }
     };

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -52,8 +52,8 @@ pub fn self_update() -> Result<()> {
     );
     if let Err(e) = fs::rename(&fuelup_new, &fuelup_bin) {
         error!(
-            "Failed to replace old fuelup with new fuelup. Attempting to restore backup fuelup.",
-        );
+            "Failed to replace old fuelup with new fuelup: {}. Attempting to restore backup fuelup.",
+        e);
         // If we have failed to replace the old fuelup for whatever reason, we want the backup.
         // Although unlikely, should this last step fail, we will recommend to re-install fuelup using fuelup-init.
         if let Err(e) = fs::rename(&fuelup_backup, &fuelup_bin) {
@@ -66,8 +66,9 @@ You should re-install fuelup using fuelup-init:
             );
         }
 
-        error!("Old fuelup restored.");
-        bail!("Failed to replace old fuelup with new fuelup: {}", e);
+        bail!(
+            "Old fuelup restored because something went wrong replacing old fuelup with new fuelup.",
+        );
     };
 
     // Remove backup at the end.

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -27,6 +27,7 @@ pub fn self_update() -> Result<()> {
 
     if let Err(e) = attempt_install_self(download_cfg, fuelup_new_dir.path()) {
         // Skip all other steps if downloading fails here.
+        // We do not need to handle failure, since this downloads to a tempdir.
         bail!("Failed to install fuelup: {}", e);
     };
 
@@ -38,7 +39,6 @@ pub fn self_update() -> Result<()> {
         fs::remove_file(&fuelup_bin).expect("Failed to remove fuelup");
     };
 
-    // Copy the new fuelup into the bin folder.
     if let Err(e) = fs::copy(fuelup_new_dir.path().join("fuelup"), &fuelup_bin) {
         error!("Failed to replace the old fuelup: {}", e);
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -37,7 +37,7 @@ pub fn self_update() -> Result<()> {
     };
 
     info!(
-        "Copying {} to {}",
+        "Moving {} to {}",
         fuelup_new_dir.path().join("fuelup").display(),
         &fuelup_bin.display()
     );

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -54,7 +54,7 @@ pub fn self_update() -> Result<()> {
     };
 
     // Remove backup at the end.
-    let _ = fs::remove_file(fuelup_backup);
+    let _ = fs::remove_file(&fuelup_backup);
 
     Ok(())
 }

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -34,7 +34,14 @@ pub fn self_update() -> Result<()> {
 
     if fuelup_bin.exists() {
         // Make a backup of fuelup, fuelup-backup.
-        fs::rename(&fuelup_bin, &fuelup_backup).expect("Could not make a fuelup-backup");
+        if let Err(e) = fs::rename(&fuelup_bin, &fuelup_backup) {
+            bail!(
+                "Failed moving {} to {}: {}",
+                &fuelup_bin.display(),
+                &fuelup_backup.display(),
+                e
+            );
+        }
     };
 
     info!(

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -24,6 +24,7 @@ pub fn self_update() -> Result<()> {
     let fuelup_bin_dir = fuelup_bin_dir();
 
     let fuelup_new_dir = fuelup_bin_dir.join("fuelup-new");
+    fs::create_dir(&fuelup_new_dir)?;
     let fuelup_backup = fuelup_bin_dir.join("fuelup-backup");
     let fuelup_new = fuelup_new_dir.join("fuelup");
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -1,4 +1,5 @@
-use std::{env::temp_dir, fs, path::Path};
+use std::{fs, path::Path};
+use tempfile::tempdir;
 use tracing::error;
 
 use anyhow::Result;
@@ -19,7 +20,8 @@ pub fn attempt_install_self(download_cfg: DownloadCfg, dst: &Path) -> Result<()>
 pub fn self_update() -> Result<()> {
     let download_cfg = DownloadCfg::new(component::FUELUP, None)?;
     let fuelup_bin = fuelup_bin();
-    let fuelup_backup = temp_dir().join("fuelup-backup");
+    let temp_dir = tempdir()?;
+    let fuelup_backup = temp_dir.path().join("fuelup-backup");
 
     if fuelup_bin.exists() {
         // Make a backup of fuelup.
@@ -36,10 +38,6 @@ pub fn self_update() -> Result<()> {
             fs::copy(&fuelup_backup, &fuelup_bin).expect("Could not restore fuelup-backup");
         }
     };
-
-    if fuelup_backup.exists() {
-        fs::remove_file(&fuelup_backup).expect("Could not remove fuelup backup");
-    }
 
     Ok(())
 }

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -41,7 +41,7 @@ pub fn self_update() -> Result<()> {
         fuelup_new_dir.path().join("fuelup").display(),
         &fuelup_bin.display()
     );
-    if let Err(e) = fs::copy(fuelup_new_dir.path().join("fuelup"), &fuelup_bin) {
+    if let Err(e) = fs::rename(fuelup_new_dir.path().join("fuelup"), &fuelup_bin) {
         error!("Failed to replace the old fuelup: {}", e);
 
         // If we have failed to replace the old fuelup for whatever reason, we want the backup.

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -43,13 +43,15 @@ pub fn self_update() -> Result<()> {
     );
     if let Err(e) = fs::rename(fuelup_new_dir.path().join("fuelup"), &fuelup_bin) {
         error!("Failed to replace the old fuelup: {}", e);
+        error!("Restoring old fuelup");
 
         // If we have failed to replace the old fuelup for whatever reason, we want the backup.
-        // Should this last step fail, we will recommend to re-install fuelup using fuelup-init.
+        // Although unlikely, should this last step fail, we will recommend to re-install fuelup using fuelup-init.
         if let Err(e) = fs::rename(&fuelup_backup, &fuelup_bin) {
             error!("Could not restore backup fuelup: {}", e);
             error!("You should re-install fuelup using fuelup-init:");
             error!("`curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh`");
+            std::process::exit(1);
         }
     };
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use std::{fs, path::Path};
 use tempfile::tempdir_in;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::{
     component,
@@ -39,6 +39,11 @@ pub fn self_update() -> Result<()> {
         fs::remove_file(&fuelup_bin).expect("Failed to remove fuelup");
     };
 
+    info!(
+        "Copying {} to {}",
+        fuelup_new_dir.path().join("fuelup").display(),
+        &fuelup_bin.display()
+    );
     if let Err(e) = fs::copy(fuelup_new_dir.path().join("fuelup"), &fuelup_bin) {
         error!("Failed to replace the old fuelup: {}", e);
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -33,22 +33,22 @@ pub fn self_update() -> Result<()> {
     if fuelup_bin.exists() {
         // Make a backup of fuelup, fuelup-backup.
         fs::copy(&fuelup_bin, &fuelup_backup).expect("Could not make a fuelup-backup");
+        // On Linux, we have to unlink/remove the original bin first.
         fs::remove_file(&fuelup_bin).expect("Failed to remove fuelup");
     };
 
     // Copy the new fuelup into the bin folder.
     if let Err(e) = fs::copy(fuelup_new_dir.path().join("fuelup"), &fuelup_bin) {
-        // If we have failed to replace the old fuelup for whatever reason, we want the backup.
         error!("Failed to replace the old fuelup: {}", e);
+
+        // If we have failed to replace the old fuelup for whatever reason, we want the backup.
+        // Should this last step fail, we will recommend to re-install fuelup using fuelup-init.
         if let Err(e) = fs::copy(&fuelup_backup, &fuelup_bin) {
             error!("Could not restore backup fuelup: {}", e);
             error!("You should re-install fuelup using fuelup-init:");
             error!("`curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh`");
         }
     };
-
-    // Finally remove backup and the folder.
-    let _ = fs::remove_file(&fuelup_backup);
 
     Ok(())
 }

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -1,17 +1,37 @@
+use std::{env::temp_dir, fs, path::Path};
+use tracing::error;
+
 use anyhow::Result;
 
 use crate::{
     component,
     download::{download_file_and_unpack, unpack_bins, DownloadCfg},
-    path::fuelup_bin_dir,
+    path::{fuelup_bin, fuelup_bin_dir},
 };
+
+pub fn attempt_install_self(download_cfg: DownloadCfg, dst: &Path) -> Result<()> {
+    download_file_and_unpack(&download_cfg, dst)?;
+    unpack_bins(dst, dst)?;
+
+    Ok(())
+}
 
 pub fn self_update() -> Result<()> {
     let download_cfg = DownloadCfg::new(component::FUELUP, None)?;
-    let fuelup_bin_dir = fuelup_bin_dir();
+    let fuelup_bin = fuelup_bin();
+    let fuelup_backup = temp_dir().join("fuelup-backup");
 
-    download_file_and_unpack(&download_cfg, &fuelup_bin_dir)?;
-    unpack_bins(&fuelup_bin_dir, &fuelup_bin_dir)?;
+    if fuelup_bin.exists() {
+        // Make a backup of fuelup, in case downloading fails. If download fails below, we use the backup.
+        fs::copy(&fuelup_bin, &fuelup_backup).expect("Could not make a fuelup backup");
+        // We cannot copy new fuelup over the old; we must unlink it first.
+        fs::remove_file(&fuelup_bin).expect("Could not remove fuelup");
+    };
+
+    if let Err(e) = attempt_install_self(download_cfg, &fuelup_bin_dir()) {
+        error!("Failed to install and replace fuelup - {}.", e);
+        fs::copy(fuelup_backup, fuelup_bin)?;
+    };
 
     Ok(())
 }

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -1,8 +1,7 @@
+use anyhow::Result;
 use std::{fs, path::Path};
 use tempfile::tempdir_in;
 use tracing::error;
-
-use anyhow::Result;
 
 use crate::{
     component,
@@ -24,23 +23,30 @@ pub fn self_update() -> Result<()> {
     let fuelup_bin_dir = fuelup_bin_dir();
 
     let fuelup_new_dir = tempdir_in(&fuelup_bin_dir)?;
+    let fuelup_backup_dir = tempdir_in(&fuelup_bin_dir)?;
 
     if let Err(e) = attempt_install_self(download_cfg, &fuelup_new_dir.path()) {
         error!("Failed to install and replace fuelup. {}", e);
     };
 
-    let fuelup_backup = fuelup_bin_dir.join("fuelup-backup");
+    let fuelup_backup = fuelup_backup_dir.path().join("fuelup-backup");
     if fuelup_bin.exists() {
         // Make a backup of fuelup, fuelup-backup.
         fs::copy(&fuelup_bin, &fuelup_backup).expect("Could not make a fuelup-backup");
-        fs::remove_file(&fuelup_bin)?;
+        fs::remove_file(&fuelup_bin).expect("Failed to remove fuelup");
     };
 
     // Copy the new fuelup into the bin folder.
-    fs::copy(fuelup_new_dir.path().join("fuelup"), &fuelup_bin)?;
+    if let Err(e) = fs::copy(fuelup_new_dir.path().join("fuelup"), &fuelup_bin) {
+        // If we have failed to replace the old fuelup for whatever reason, we want the backup.
+        error!("Failed to replace the old fuelup: {}", e);
+        if let Err(e) = fs::copy(&fuelup_backup, &fuelup_bin) {
+            error!("Could not restore backup fuelup: {}. You should re-install fuelup using the script: `curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh`", e);
+        }
+    };
 
     // Finally remove backup and the folder.
-    fs::remove_file(&fuelup_backup)?;
+    let _ = fs::remove_file(&fuelup_backup);
 
     Ok(())
 }

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -25,6 +25,7 @@ pub fn self_update() -> Result<()> {
 
     let fuelup_new_dir = tempdir_in(&fuelup_bin_dir)?;
     let fuelup_new_dir_path = fuelup_new_dir.path();
+    let fuelup_new = fuelup_new_dir_path.join(component::FUELUP);
 
     if let Err(e) = attempt_install_self(download_cfg, fuelup_new_dir_path) {
         // Skip all other steps if downloading fails here.
@@ -46,10 +47,10 @@ pub fn self_update() -> Result<()> {
 
     info!(
         "Moving {} to {}",
-        fuelup_new_dir_path.join("fuelup").display(),
+        fuelup_new.display(),
         &fuelup_bin.display()
     );
-    if let Err(e) = fs::rename(fuelup_new_dir_path.join("fuelup"), &fuelup_bin) {
+    if let Err(e) = fs::rename(fuelup_new, &fuelup_bin) {
         error!("Failed to replace the old fuelup: {}", e);
         error!("Restoring old fuelup");
 


### PR DESCRIPTION
Fixes #96

`fuelup` should remove itself (unlink) before trying to download a new version. ~We will temporarily copy this as a backup in case download fails - in which case we copy the temp `fuelup` back.~

Updated with @mitchmindtree 's suggestion:

1. Create a tempdir `fuelup_new_dir` and fetch new fuelup to this dir. At this point, if download fails, do nothing else so old fuelup remains.
2. Upon success, if old fuelup already exists, rename old fuelup to `fuelup-backup`.
3. Finally, copy the new fuelup within `fuelup_new_dir` into the `bin` directory.
4. If the above step somehow fails, rename `fuelup-backup` back into the `fuelup`. If this also somehow fails, we recommend to reinstall via the `fuelup-init` script.
5. We do not need to clean up the download since we're using [`tempdir`](https://docs.rs/tempfile/3.3.0/tempfile/fn.tempdir.html) which cleans itself up once we exit the scope.