### PR TITLE
Separate CI step that checks fuelup-init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
   try-run-fuelup-init:
     needs: cancel-previous-runs
+    if: github.event_name != 'release' || github.event.action != 'published'
     name: Try fuelup installation with fuelup-init
     strategy:
       matrix:
@@ -47,7 +48,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Attempt to install fuelup through fuelup-init.sh
-        if: github.event_name != 'release' || github.event.action != 'published'
         run: ./fuelup-init.sh
 
   cargo-clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           access_token: ${{ github.token }}
 
   check-scripts:
+    needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -35,6 +36,7 @@ jobs:
           sh_checker_exclude: "src"
 
   try-run-fuelup-init:
+    needs: cancel-previous-runs
     name: Try fuelup installation with fuelup-init
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,19 @@ jobs:
         with:
           sh_checker_comment: false
           sh_checker_exclude: "src"
+
+  try-run-fuelup-init:
+    name: Try fuelup installation with fuelup-init
+    strategy:
+      matrix:
+        job:
+          - os: ubuntu-latest
+          - os: macos-latest
+    runs-on: ${{ matrix.job.os }}
+    steps:
+      - uses: actions/checkout@v3
       - name: Attempt to install fuelup through fuelup-init.sh
-        if: github.event_name != 'release' && github.event.action != 'published'
+        if: github.event_name != 'release' || github.event.action != 'published'
         run: ./fuelup-init.sh
 
   cargo-clippy:
@@ -253,18 +264,18 @@ jobs:
           asset_content_type: application/gzipa
 
   post-release-checks:
-    name: Try fuelup install with fuelup-init
+    name: Do post-release checks
+    needs: [cancel-previous-runs, build-release]
+    if: github.event_name == 'release' && github.event.action == 'published'
     strategy:
       matrix:
         job:
           - os: ubuntu-latest
           - os: macos-latest
     runs-on: ${{ matrix.job.os }}
-    if: github.event_name == 'release' && github.event.action == 'published'
-    needs: [cancel-previous-runs, build-release]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Run fuelup-init
+      - name: Try fuelup installation with fuelup-init
         run: ./fuelup-init.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
         with:
           sh_checker_comment: false
           sh_checker_exclude: "src"
-      - name: Attempt fuelup installation through fuelup-init
-        if: github.event_name != 'release'
+      - name: Attempt to install fuelup through fuelup-init.sh
+        if: github.event_name != 'release' && github.event.action != 'published'
         run: ./fuelup-init.sh
 
   cargo-clippy:
@@ -252,19 +252,19 @@ jobs:
           asset_name: ${{ env.ZIP_FILE_NAME }}
           asset_content_type: application/gzipa
 
-  check-fuelup-init-post-release:
-    name: Try installing fuelup via fuelup-init post-release
-    needs: build-release
-    runs-on: ${{ matrix.job.os }}
+  post-release-checks:
+    name: Try fuelup install with fuelup-init
     strategy:
       matrix:
         job:
           - os: ubuntu-latest
           - os: macos-latest
+    runs-on: ${{ matrix.job.os }}
+    if: github.event_name == 'release' && github.event.action == 'published'
+    needs: [cancel-previous-runs, build-release]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Use fuelup-init
-        run: |
-          ./fuelup-init.sh
+      - name: Run fuelup-init
+        run: ./fuelup-init.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,18 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
-  check-fuelup-init:
+  check-scripts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Run shellcheck and shfmt
+      - name: Run shellcheck and shfmt on all scripts
         uses: luizm/action-sh-checker@master
         env:
           SHELLCHECK_OPTS: -e SC3043 # exclude 'local' is undefined
           SHFMT_OPTS: -i 4 -ci
         with:
           sh_checker_comment: false
-          sh_checker_exclude: "src .github"
+          sh_checker_exclude: "src"
       - name: Attempt to install fuelup through fuelup-init.sh
         run: ./fuelup-init.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,5 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-
       - name: Try fuelup installation with fuelup-init
         run: ./fuelup-init.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
         with:
           sh_checker_comment: false
           sh_checker_exclude: "src"
-      - name: Attempt to install fuelup through fuelup-init.sh
+      - name: Attempt fuelup installation through fuelup-init
+        if: github.event_name != 'release'
         run: ./fuelup-init.sh
 
   cargo-clippy:
@@ -250,3 +251,20 @@ jobs:
           asset_path: ./${{ env.ZIP_FILE_NAME }}
           asset_name: ${{ env.ZIP_FILE_NAME }}
           asset_content_type: application/gzipa
+
+  check-fuelup-init-post-release:
+    name: Try installing fuelup via fuelup-init post-release
+    needs: build-release
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      matrix:
+        job:
+          - os: ubuntu-latest
+          - os: macos-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Use fuelup-init
+        run: |
+          ./fuelup-init.sh

--- a/.github/workflows/scripts/verify_tag.sh
+++ b/.github/workflows/scripts/verify_tag.sh
@@ -2,7 +2,7 @@
 set -e
 
 err() {
-    echo -e "\e[31m\e[1merror:\e[0m $@" 1>&2;
+    echo -e "\e[31m\e[1merror:\e[0m $*" 1>&2
 }
 
 status() {
@@ -24,12 +24,12 @@ if [ -z "$MANIFEST" ]; then
 fi
 
 # strip preceeding 'v' if it exists on tag
-REF=${REF/#v}
-TOML_VERSION=$(cat $MANIFEST | dasel -r toml 'package.version')
+REF=${REF/#v/}
+TOML_VERSION=$(dasel -f "$MANIFEST" -r toml 'package.version')
 
 if [ "$TOML_VERSION" != "$REF" ]; then
     err "Crate version $TOML_VERSION, doesn't match tag version $REF"
     exit 1
 else
-  status "Crate version matches tag $TOML_VERSION"
+    status "Crate version matches tag $TOML_VERSION"
 fi


### PR DESCRIPTION
Fixes #88 

The step that runs `fuelup-init` to check for installation of fuelup should be run at all times, but handled differently:

1) During normal CI checks: it's ok to run it directly within `check-scripts`.
2) During releases: `fuelup-init` has to wait for releases to finish building before attempting to download the `fuelup` binary.

Note that this does not prevent releases from being uploaded if there's an error with installing fuelup-init, but only notifies.