### PR TITLE
port usage of toml-rs to toml-edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +122,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +159,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "fastrand"
@@ -201,7 +223,7 @@ dependencies = [
  "tar",
  "tempfile",
  "termcolor",
- "toml",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -270,6 +292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kstring"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -319,6 +359,12 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniz_oxide"
@@ -651,11 +697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
-name = "toml"
-version = "0.5.9"
+name = "toml_edit"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "744e9ed5b352340aa47ce033716991b5589e23781acb97cad37d4ea70560f55b"
 dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+ "kstring",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = "1.0"
 tar = "0.4"
 tempfile = "3"
 termcolor = "1"
-toml = "0.5"
+toml_edit = { version = "0.13", features = ["serde", "easy"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 ureq = "2.4"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -77,7 +77,7 @@ fn take_value(table: &mut Table, key: &str) -> Result<Value> {
 
 fn get_opt_string(table: &mut Table, key: &str) -> Result<Option<String>> {
     if let Ok(v) = take_value(table, key) {
-        if let Some(s) = v.as_str() {
+        if let Value::String(s) = v {
             Ok(Some(s.to_string()))
         } else {
             bail!("Expected string, got {}", key)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,7 @@
 use std::{cell::RefCell, path::PathBuf};
+use toml_edit::{value, Document, Table, Value};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 
 use crate::file;
 
@@ -65,18 +66,21 @@ pub struct Settings {
     pub default_toolchain: Option<String>,
 }
 
-fn take_value(table: &mut toml::value::Table, key: &str, path: &str) -> Result<toml::Value> {
-    table
-        .remove(key)
-        .ok_or_else(|| anyhow!(format!("missing key: '{}'", path.to_owned() + key)))
+fn take_value(table: &mut Table, key: &str) -> Result<Value> {
+    if let Some(i) = table.remove(key) {
+        i.into_value()
+            .or_else(|_| bail!("Item is None for key: '{}'", key))
+    } else {
+        bail!("missing key: '{}'", key)
+    }
 }
 
-fn get_opt_string(table: &mut toml::value::Table, key: &str, path: &str) -> Result<Option<String>> {
-    if let Ok(v) = take_value(table, key, path) {
-        if let toml::Value::String(s) = v {
-            Ok(Some(s))
+fn get_opt_string(table: &mut Table, key: &str) -> Result<Option<String>> {
+    if let Ok(v) = take_value(table, key) {
+        if let Some(s) = v.as_str() {
+            Ok(Some(s.to_string()))
         } else {
-            bail!("Expected string, got {}", path.to_owned() + key)
+            bail!("Expected string, got {}", key)
         }
     } else {
         Ok(None)
@@ -84,28 +88,29 @@ fn get_opt_string(table: &mut toml::value::Table, key: &str, path: &str) -> Resu
 }
 
 impl Settings {
-    pub(crate) fn from_toml(mut table: toml::value::Table, path: &str) -> Result<Self> {
+    pub(crate) fn from_toml(mut document: Document) -> Result<Self> {
         Ok(Self {
-            default_toolchain: get_opt_string(&mut table, "default_toolchain", path)?,
+            default_toolchain: get_opt_string(document.as_table_mut(), "default_toolchain")?,
         })
     }
 
-    pub(crate) fn parse(data: &str) -> Result<Self> {
-        let value = toml::from_str(data)?;
-        Self::from_toml(value, "")
+    pub(crate) fn parse(toml: &str) -> Result<Self> {
+        let document = toml.parse::<Document>().expect("Invalid doc");
+        Self::from_toml(document)
     }
 
     pub(crate) fn stringify(self) -> String {
-        toml::Value::Table(self.into_toml()).to_string()
+        self.into_toml().to_string()
     }
 
-    pub(crate) fn into_toml(self) -> toml::value::Table {
-        let mut result = toml::value::Table::new();
+    pub(crate) fn into_toml(self) -> Table {
+        let mut table = Table::new();
 
         if let Some(v) = self.default_toolchain {
-            result.insert("default_toolchain".to_owned(), toml::Value::String(v));
+            table["default_toolchain"] = value(v);
         }
 
-        result
+        table.fmt();
+        table
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -95,7 +95,7 @@ impl Settings {
     }
 
     pub(crate) fn parse(toml: &str) -> Result<Self> {
-        let document = toml.parse::<Document>().expect("Invalid doc");
+        let document = toml.parse::<Document>().expect("Invalid toml document");
         Self::from_toml(document)
     }
 


### PR DESCRIPTION
QoL PR to port usage of `toml-rs` to `toml_edit` for a few reasons:

- `toml-rs` is [no longer being maintained](https://github.com/alexcrichton/toml-rs/issues/460)
- `toml-rs` is only compliant with v0.5 of TOML, `toml_edit` is up to date with v1.0.
- `toml_edit` is format preserving and has a nicer API for editing toml (which we will need for future features here anyway)