### PR TITLE
curl fuelup-version instead of github api

### DIFF
--- a/.github/workflows/gh-pages-meta.yml
+++ b/.github/workflows/gh-pages-meta.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Get latest tag and copy into fuelup-version
         run: |
           mkdir -p ${{ env.FUELUP_VERSION_DIR }}
-          echo ${GITHUB_REF#refs/tags/} >> fuelup-version
+          FUELUP_VERSION="${GITHUB_REF#refs/tags/}"
+          # trim v from tag prefix
+          FUELUP_VERSION="${FUELUP_VERSION#v}"
+          echo $FUELUP_VERSION >> fuelup-version
           cp fuelup-version ${{ env.FUELUP_VERSION_DIR }}
 
       - name: Deploy latest fuelup version

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -24,7 +24,8 @@ main() {
     mkdir -p "$FUELUP_DIR/bin"
 
     local _fuelup_version
-    _fuelup_version="$(curl -s https://api.github.com/repos/FuelLabs/fuelup/releases/latest | grep "tag_name" | cut -d "\"" -f4 | cut -c 2-)"
+    _published_fuelup_version_url="https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/fuelup-version"
+    _fuelup_version="$(curl -s $_published_fuelup_version_url)"
     local _fuelup_url="https://github.com/FuelLabs/fuelup/releases/download/v${_fuelup_version}/fuelup-${_fuelup_version}-${_arch}.tar.gz"
 
     local _dir

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -27,8 +27,8 @@ main() {
     _published_fuelup_version_url="https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/fuelup-version"
     _fuelup_version="$(curl -s $_published_fuelup_version_url)"
     if echo "$_fuelup_version" | grep -q -E '404|400'; then
-	warn "fuelup-version was not found on fuelup gh-pages (https://github.com/FuelLabs/fuelup/tree/gh-pages); falling back to using GitHub API."
-	_fuelup_version="$(curl -s https://api.github.com/repos/FuelLabs/fuelup/releases/latest | grep "tag_name" | cut -d "\"" -f4 | cut -c 2-)"
+        warn "fuelup-version was not found on fuelup gh-pages (https://github.com/FuelLabs/fuelup/tree/gh-pages); falling back to using GitHub API."
+        _fuelup_version="$(curl -s https://api.github.com/repos/FuelLabs/fuelup/releases/latest | grep "tag_name" | cut -d "\"" -f4 | cut -c 2-)"
     fi
 
     local _fuelup_url="https://github.com/FuelLabs/fuelup/releases/download/v${_fuelup_version}/fuelup-${_fuelup_version}-${_arch}.tar.gz"

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -26,6 +26,11 @@ main() {
     local _fuelup_version
     _published_fuelup_version_url="https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/fuelup-version"
     _fuelup_version="$(curl -s $_published_fuelup_version_url)"
+    if echo "$_fuelup_version" | grep -q -E '404|400'; then
+	warn "fuelup-version was not found on fuelup gh-pages (https://github.com/FuelLabs/fuelup/tree/gh-pages); falling back to using GitHub API."
+	_fuelup_version="$(curl -s https://api.github.com/repos/FuelLabs/fuelup/releases/latest | grep "tag_name" | cut -d "\"" -f4 | cut -c 2-)"
+    fi
+
     local _fuelup_url="https://github.com/FuelLabs/fuelup/releases/download/v${_fuelup_version}/fuelup-${_fuelup_version}-${_arch}.tar.gz"
 
     local _dir


### PR DESCRIPTION
Closes #102
Related #58, #43 

Reduces dependence on GitHub API by querying the published `fuelup-version` instead of querying the latest tag endpoint of GitHub API, since we [publish the version](https://github.com/FuelLabs/fuelup/blob/gh-pages/fuelup-version) already. We still fallback to querying the api endpoint in case curl-ing `fuelup-version` fails.

We also trim the 'v' from the published version within the workflow so that it works nicely with our script.

Note that this change means installing via `fuelup-init` on **master** will break until a new version is published. This should not affect `fuelup-init` that is published onto gh-pages though (which means it should be fine for general public)