### PR TITLE
add always() condition to workflow

### DIFF
--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -112,7 +112,7 @@ jobs:
   index-versions:
     name: Index versions compatibilities
     needs: test-toolchain-compatibility
-    if: needs.test-toolchain-compatibility.result != 'skipped'
+    if: ${{ always() && needs.test-toolchain-compatibility.result != 'skipped' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
`index-versions` job requires both `always()` and the skip check to run, otherwise it is always skipped despite tests successfully running. (as seen in the [actions page](https://github.com/FuelLabs/fuelup/actions))