### PR TITLE
add '^' to correctly match compatible files only while indexing versions

### DIFF
--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -122,7 +122,7 @@ jobs:
           path: versions
 
       # Here, we decide which versions to mark as compatible or incompatible.
-      # Compatible: the uploaded artifact starting with the name 'compatible*' and is at the top when sorted.
+      # Compatible: the uploaded artifact starting with the name 'compatible' and is at the top when sorted.
       # We only care about the latest version set that passed tests here.
       #
       # Incompatible: all the uploaded artifacts that has 'incompatible' in file names, followed by their versions.
@@ -132,7 +132,7 @@ jobs:
         id: prep-versions
         working-directory: versions
         run: |
-            COMPATIBLE_VERSIONS=$(ls -1 | grep "compatible*" | sort -rV | head -n 1)
+            COMPATIBLE_VERSIONS=$(ls -1 | grep "^compatible*" | sort -rV | head -n 1)
             echo "LATEST_COMPATIBLE_FORC=$(echo $COMPATIBLE_VERSIONS | cut -d '@' -f1 | cut -d '-' -f3-)" >> $GITHUB_ENV
             echo "LATEST_COMPATIBLE_FUEL_CORE=$(echo $COMPATIBLE_VERSIONS | cut -d '@' -f2 | cut -d '-' -f3)" >> $GITHUB_ENV
 


### PR DESCRIPTION
Current channel has published `fuel-core` at `0.9.6` despite failing tests, because of a missing `^` in the regex matching done that doesn't exclude the files marked as `incompatible`.

To confirm:

```console
$ touch incompatible
$ touch compatible
$ ls -1 | grep "compatible*"
compatible
incompatible
$ ls -1 | grep "^compatible*"
compatible
```

Also removed the `*` from the comment.