### PR TITLE
Use current `latest` channel as `stable` channel instead

### DIFF
--- a/.github/workflows/index-versions-latest.yml
+++ b/.github/workflows/index-versions-latest.yml
@@ -10,13 +10,14 @@ env:
 
 jobs:
   index-versions:
-    name: Index versions and publish channel (latest)
+    name: Index and publish channel (latest)
     runs-on: ubuntu-latest
     steps:
       - name: checkout master
         uses: actions/checkout@v3
 
-      - name: Get latest versions and update channel if needed
+      - name: Compare latest versions with published channel
+        id: compare-latest-versions
         run: |
           curl -s "https://fuellabs.github.io/fuelup/channel-fuel-latest.toml" -L -o channel-fuel-latest.toml
           mkdir -p ${{ env.LATEST_CHANNEL_DIR }}
@@ -37,9 +38,11 @@ jobs:
             exit 0
           fi
 
+          echo "::set-output name=should_publish::true"
           ./.github/workflows/scripts/index-versions.sh $FORC_LATEST_VERSION $FUEL_CORE_LATEST_VERSION
           cp channel-fuel-latest.toml ${{ env.LATEST_CHANNEL_DIR }}
-      - name: Deploy latest
+      - name: Publish channel (latest)
+        if: ${{ always() && steps.compare-latest-versions.outputs.should_publish == 'true' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/index-versions-latest.yml
+++ b/.github/workflows/index-versions-latest.yml
@@ -1,10 +1,9 @@
 name: Index Versions (latest)
 
 on:
-  push
-  #schedule:
+  schedule:
     # Run at minute 0 and 30 every hour
-    # - cron: '0,30 * * * *'
+    - cron: '0,30 * * * *'
 env:
   LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/
 

--- a/.github/workflows/index-versions-latest.yml
+++ b/.github/workflows/index-versions-latest.yml
@@ -1,9 +1,9 @@
 name: Index Versions (latest)
 
 on:
-  schedule:
+  push
+  #schedule:
     # Run at minute 0 and 30 every hour
-    - push
     # - cron: '0,30 * * * *'
 env:
   LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/

--- a/.github/workflows/index-versions-latest.yml
+++ b/.github/workflows/index-versions-latest.yml
@@ -9,7 +9,8 @@ env:
   LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/
 
 jobs:
-  index-version-sets:
+  index-versions:
+    name: Index versions and publish channel (latest)
     runs-on: ubuntu-latest
     steps:
       - name: checkout master

--- a/.github/workflows/index-versions-latest.yml
+++ b/.github/workflows/index-versions-latest.yml
@@ -1,0 +1,47 @@
+name: Index Versions (latest)
+
+on:
+  schedule:
+    # Run at minute 0 and 30 every hour
+    - push
+    # - cron: '0,30 * * * *'
+env:
+  LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/
+
+jobs:
+  index-version-sets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout master
+        uses: actions/checkout@v3
+
+      - name: Get latest versions and update channel if needed
+        run: |
+          curl -s "https://fuellabs.github.io/fuelup/channel-fuel-latest.toml" -L -o channel-fuel-latest.toml
+          mkdir -p ${{ env.LATEST_CHANNEL_DIR }}
+
+          FORC_API_URL="https://api.github.com/repos/FuelLabs/sway/actions/runs?event=release&status=success"
+          FUEL_CORE_API_URL="https://api.github.com/repos/FuelLabs/fuel-core/actions/runs?event=release&status=success"
+
+          # Get latest versions from GitHub repo workflows API
+          FORC_LATEST_VERSION="$(curl -s ${FORC_API_URL} | grep "head_branch" | head -n 1 | cut -d "v" -f 2- | rev | cut -c 3- | rev)"
+          FUEL_CORE_LATEST_VERSION="$(curl -s ${FUEL_CORE_API_URL} | grep "head_branch" | head -n 1 | cut -d "v" -f 2- | rev | cut -c 3- | rev)"
+
+          # Get latest versions published within channel-fuel-latest.yml
+          FORC_CURRENT_VERSION="$(grep -s -A1 "\[pkg.forc\]" channel-fuel-latest.toml | grep "version" | cut -d "\"" -f 2- | rev | cut -c 2- | rev)"
+          FUEL_CORE_CURRENT_VERSION="$(grep -s -A1 "\[pkg.fuel-core\]" channel-fuel-latest.toml | grep "version" | cut -d "\"" -f 2- | rev | cut -c 2- | rev)"
+
+          if [ "${FORC_LATEST_VERSION}" = "${FORC_CURRENT_VERSION}" ] && [ "${FUEL_CORE_LATEST_VERSION}" = "${FUEL_CORE_CURRENT_VERSION}" ]; then
+            printf "No new forc and fuel-core versions; exiting\n"
+            exit 0
+          fi
+
+          ./.github/workflows/scripts/index-versions.sh $FORC_LATEST_VERSION $FUEL_CORE_LATEST_VERSION
+          cp channel-fuel-latest.toml ${{ env.LATEST_CHANNEL_DIR }}
+      - name: Deploy latest
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true
+          publish_dir: ${{ env.LATEST_CHANNEL_DIR }}
+          destination_dir: ./

--- a/.github/workflows/index-versions-stable.yml
+++ b/.github/workflows/index-versions-stable.yml
@@ -5,11 +5,11 @@ on:
     # Run at minute 0 and 30 every hour
     - cron: '0,30 * * * *'
 env:
-  LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/
+  LATEST_CHANNEL_DIR: ./channel-fuel-stable.toml.d/
 
 jobs:
   # compare-versions: This job runs the compare-version script which collects
-  # latest versions released after the versions found in channel-fuel-latest.toml,
+  # latest versions released after the versions found in channel-fuel-stable.toml,
   # filters out incompatible versions and uses the leftover as inputs to
   # test-toolchain-compatibility job to run integration tests.
   compare-versions:
@@ -49,7 +49,7 @@ jobs:
 
             # Read the output of compare-versions line-by-line
             # for the versions newer than what is published within
-            # channel-fuel-latest.toml
+            # channel-fuel-stable.toml
             while read line
             do
               if [ -d gh-pages/incompatible-versions ] && [ -e gh-pages/incompatible-versions/$line ]; then

--- a/.github/workflows/index-versions-stable.yml
+++ b/.github/workflows/index-versions-stable.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     # Run at minute 0 and 30 every hour
     - cron: '0,30 * * * *'
-env:
-  LATEST_CHANNEL_DIR: ./channel-fuel-stable.toml.d/
 
 jobs:
   # compare-versions: This job runs the compare-version script which collects

--- a/.github/workflows/index-versions-stable.yml
+++ b/.github/workflows/index-versions-stable.yml
@@ -1,4 +1,4 @@
-name: Check Versions
+name: Check Versions (stable)
 
 on:
   schedule:

--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -110,7 +110,7 @@ jobs:
   # index-versions: This job will process the artifacts above if testing is not skipped and upload
   # incompatible versions and/or publish a new channel-fuel-latest.toml to gh-pages.
   index-versions:
-    name: Index versions compatibilities
+    name: Index versions and publish channel (stable)
     needs: test-toolchain-compatibility
     if: ${{ always() && needs.test-toolchain-compatibility.result != 'skipped' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   INCOMPATIBLE_DIR: ./incompatible-versions
-  LATEST_CHANNEL_DIR: ./channel-fuel-stable.toml.d/
+  STABLE_CHANNEL_DIR: ./channel-fuel-stable.toml.d/
 
 jobs:
   test-toolchain-compatibility:
@@ -147,16 +147,16 @@ jobs:
         if: ${{ env.LATEST_COMPATIBLE_FORC && env.LATEST_COMPATIBLE_FUEL_CORE }}
         run: |
             touch channel-fuel-stable.toml
-            mkdir -p ${{ env.LATEST_CHANNEL_DIR }}
+            mkdir -p ${{ env.STABLE_CHANNEL_DIR }}
             ./.github/workflows/scripts/index-versions.sh ${{ env.LATEST_COMPATIBLE_FORC }} ${{ env.LATEST_COMPATIBLE_FUEL_CORE }}
-            cp channel-fuel-stable.toml ${{ env.LATEST_CHANNEL_DIR }}
+            cp channel-fuel-stable.toml ${{ env.STABLE_CHANNEL_DIR }}
 
       - name: Publish channel (stable)
         if: ${{ env.LATEST_COMPATIBLE_FORC && env.LATEST_COMPATIBLE_FUEL_CORE }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.LATEST_CHANNEL_DIR }}
+          publish_dir: ${{ env.STABLE_CHANNEL_DIR }}
           keep_files: true
           destination_dir: ./
 

--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   INCOMPATIBLE_DIR: ./incompatible-versions
-  LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/
+  LATEST_CHANNEL_DIR: ./channel-fuel-stable.toml.d/
 
 jobs:
   test-toolchain-compatibility:
@@ -108,7 +108,7 @@ jobs:
           path: compatible-forc-${{ matrix.job.forc-version }}@fuel-core-${{ matrix.job.fuel-core-version }}
 
   # index-versions: This job will process the artifacts above if testing is not skipped and upload
-  # incompatible versions and/or publish a new channel-fuel-latest.toml to gh-pages.
+  # incompatible versions and/or publish a new channel-fuel-stable.toml to gh-pages.
   index-versions:
     name: Index versions and publish channel (stable)
     needs: test-toolchain-compatibility
@@ -146,12 +146,12 @@ jobs:
       - name: Prepare channel with compatible versions
         if: ${{ env.LATEST_COMPATIBLE_FORC && env.LATEST_COMPATIBLE_FUEL_CORE }}
         run: |
-            touch channel-fuel-latest.toml
+            touch channel-fuel-stable.toml
             mkdir -p ${{ env.LATEST_CHANNEL_DIR }}
             ./.github/workflows/scripts/index-versions.sh ${{ env.LATEST_COMPATIBLE_FORC }} ${{ env.LATEST_COMPATIBLE_FUEL_CORE }}
-            cp channel-fuel-latest.toml ${{ env.LATEST_CHANNEL_DIR }}
+            cp channel-fuel-stable.toml ${{ env.LATEST_CHANNEL_DIR }}
 
-      - name: Deploy latest channel
+      - name: Publish channel (stable)
         if: ${{ env.LATEST_COMPATIBLE_FORC && env.LATEST_COMPATIBLE_FUEL_CORE }}
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/CHANNELS.md
+++ b/CHANNELS.md
@@ -1,19 +1,31 @@
 # Channels
 
-`fuelup` adopts a simplified version of `rustup` [channels](https://rust-lang.github.io/rustup/concepts/channels.html). Currently, only the `latest` channel will be published and serve as a source of distribution of Fuel toolchain binaries.
+`fuelup` adopts a simplified version of `rustup` [channels](https://rust-lang.github.io/rustup/concepts/channels.html). Currently, `latest` and `stable` channels are published and serve as sources of distribution of Fuel toolchain binaries.
 
-The `latest` channel is updated by a scheduled GitHub workflow that **runs every 30 minutes** and checks for new, compatible releases of `forc` and `fuel-core`.
+Official channels are updated by scheduled GitHub workflows that **runs every 30 minutes**.
 
 ### `latest`
 
-The `latest` channel is `fuelup`'s default channel. It provides access to the latest compatible, published releases of `forc` and `fuel-core`.
+The `latest` channel is `fuelup`'s default channel. It serves as a source of distribution of the latest published releases of `forc` and `fuel-core`.
 
-When installing the `latest` channel, fuelup will refer to the `channel-fuel-latest.toml` file within this repository to determine the set of `forc` and `fuel-core` versions to retrieve. The versions in this file are updated by a scheduled GitHub workflow that runs once every 30 minutes and performs the following steps:
+When installing the `latest` channel, fuelup will refer to the `channel-fuel-latest.toml` file within this repository to determine the set of `forc` and `fuel-core` versions to retrieve.
+
+The `latest` toolchain is not tested for compatibility and may contain bugs considering our fast pace of development. If you encounter bugs while using it, please file an issue either within the [sway repository](https://github.com/FuelLabs/sway), or the [fuel-core repository](https://github.com/FuelLabs/fuel-core).
+
+### `stable`
+
+The `stable` channel provides access to the latest published AND compatible releases of `forc` and `fuel-core`.
+
+__Compatible__ means that integration tests have been run for both the `forc` and `fuel-core` distributed through this channel.
+
+When installing the `stable` channel, fuelup will refer to the `channel-fuel-stable.toml` file within this repository to determine the set of `forc` and `fuel-core` versions to retrieve. The scheduled workflow `index-versions-stable.yml` performs the following steps:
 
 1. Checks for newly published versions of forc and fuel-core.
 2. Tests compatibility of new versions against a set of integration tests.
 3. Selects the latest set of versions that successfully pass the tests.
-4. Publishes the selected versions to the channel-fuel-latest.toml manifest.
+4. Publishes the selected versions to the channel-fuel-stable.toml manifest.
+
+This means that unlike the `latest` channel, the `stable` toolchain has been tested for compatibility and should contain minimal breaking bugs. However, this also means that this toolchain may lack cutting edge updates you can find in the `latest` toolchain.
 
 ### `nightly`
 
@@ -21,7 +33,7 @@ This is a WIP - we aim to support `nightly` channel soon.
 
 ## Developer Guide
 
-### Understanding the `latest` workflow
+### Understanding `index-versions-stable.yml`
 
 _Note: Reading the information below is only really necessary if you wish to contribute to the workflows or want a deeper understanding on how channels are updated_
 

--- a/CHANNELS.md
+++ b/CHANNELS.md
@@ -33,11 +33,11 @@ This is a WIP - we aim to support `nightly` channel soon.
 
 ## Developer Guide
 
-### Understanding `index-versions-stable.yml`
+### Understanding `index-versions-stable.yml` and `test-toolchain-compatibility.yml`
 
 _Note: Reading the information below is only really necessary if you wish to contribute to the workflows or want a deeper understanding on how channels are updated_
 
-The entrypoint of the scheduled workflow is within `index-versions.yml`. We run the Rust script `compare-versions` to collect versions of `forc` and `fuel-core` to be tested. These versions are filtered for incompatible versions prior to being used as a JSON string input to `test-toolchain-compatibility.yml`, where the testing occurs.
+The entrypoint of the scheduled workflow is within `index-versions-stable.yml`. We run the Rust script `compare-versions` to collect versions of `forc` and `fuel-core` to be tested. These versions are filtered for incompatible versions prior to being used as a JSON string input to `test-toolchain-compatibility.yml`, where the testing occurs.
 
 In `test-toolchain-compatibility.yml`, The versions JSON string input is used to init a matrix using the [fromJSON](https://docs.github.com/en/actions/learn-github-actions/expressions#fromjson) expression. We checkout the Sway repo at the given `forc` version and pull the `fuel-core` Docker image at the given `fuel-core` version and run integration tests found in the [Sway CI](https://github.com/FuelLabs/sway/blob/3bd8eaf4a0f11a3009c9421100cc06c2e897b6c2/.github/workflows/ci.yml#L229-L270) for them.
 


### PR DESCRIPTION
Closes #116 

My observation of the needs of both internal and external devs seem to suggest that it might be better to always provide the latest binaries regardless of whether they passed tests.

It also makes sense to name the releases that passed integration tests as _compatible_ and therefore _stable_, since they have basically passed all known success and failure tests. Until we have a better definition of what constitutes a _stable_ toolchain, I propose we use this definition in the meantime.

The recent PR that defines the `latest` toolchain #95 will be used as the `stable` toolchain instead while the `latest` toolchain will always provide the `latest` binaries, regardless of whether they passed integration tests.

To accomplish this,

- I brought back parts of the old [index-versions.sh](https://github.com/FuelLabs/fuelup/blob/2c98e0669a0ee4284ac83b701c92dd4694aca88f/.github/workflows/scripts/index-versions.sh) that indexes latest versions indiscriminately as a separate `index-versions-latest.yml` workflow to publish the `latest` channel. This also runs every 30 minutes.
- I made necessary changes to the existing workflow(s) that publishes the `latest` channel, to publish the `stable` channel instead. This is done through changes to names of jobs, files, etc. within the YAML configuration files.
- Updated docs (CHANNELS.md). This should eventually be within an mdbook.