### PR TITLE
compare-versions: handle 404 error vs other unexpected errors differently

### DIFF
--- a/scripts/compare-versions/src/main.rs
+++ b/scripts/compare-versions/src/main.rs
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
         }
         Err(e) => {
             bail!(
-                "Unexpected error trying to fetch channel {} - retrying at the next scheduled time",
+                "Unexpected error trying to fetch channel: {} - retrying at the next scheduled time",
                 e
             );
         }

--- a/scripts/compare-versions/src/main.rs
+++ b/scripts/compare-versions/src/main.rs
@@ -151,8 +151,11 @@ fn main() -> Result<()> {
             print_selected_versions(&[latest_sway_version], &[latest_fuel_core_version]);
             std::process::exit(0);
         }
-        Err(_) => {
-            bail!("Unexpected error trying to fetch channel - retrying at the next scheduled time");
+        Err(e) => {
+            bail!(
+                "Unexpected error trying to fetch channel {} - retrying at the next scheduled time",
+                e
+            );
         }
     };
 


### PR DESCRIPTION
We should only re-generate the channel toml if we encounter a `404` error. If we encounter some other forms of error, we should retry at the next scheduled run of the CI check.