### PR TITLE
add `--skip-toolchain installation` to `fuelup-init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not m
 curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh -s -- --no-modify-path
 ```
 
+If you just want `fuelup` without automatically installing the `latest` toolchain:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh -s -- --skip-toolchain-installation
+```
+
 In future, `fuelup` will also let you switch between toolchains, allowing for a smooth developer experience while allowing you to have more flexibility, along with other features.
 
 ## Usage

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -58,7 +58,7 @@ main() {
             --no-modify-path)
                 prompt_modify=no
                 ;;
-	    --skip-toolchain-installation)
+            --skip-toolchain-installation)
                 skip_toolchain_installation=yes
                 ;;
             *)

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -50,11 +50,16 @@ main() {
 
     # always prompt PATH modification, unless --no-modify-path provided
     local prompt_modify=yes
+    # always install latest toolchain (for convenience), unless --skip-toolchain-installation provided
+    local skip_toolchain_installation=no
 
     for arg in "$@"; do
         case "$arg" in
             --no-modify-path)
                 prompt_modify=no
+                ;;
+	    --skip-toolchain-installation)
+                skip_toolchain_installation=yes
                 ;;
             *)
                 OPTIND=1
@@ -121,7 +126,9 @@ main() {
         exit 1
     fi
 
-    ignore "$FUELUP_DIR/bin/fuelup" "toolchain" "install" "latest"
+    if [ "$skip_toolchain_installation" = "no" ]; then
+        ignore "$FUELUP_DIR/bin/fuelup" "toolchain" "install" "latest"
+    fi
 
     local _retval=$?
 


### PR DESCRIPTION
_Reopened because of messed up commit tree in #135_

Small update to fuelup-init to support https://github.com/FuelLabs/action-fuel-toolchain/pull/67

Since within the action we may not always want the latest toolchain, the `--skip-toolchain-installation` option allows the action to install fuelup without installing the latest toolchain. For the convenience of general users, the default behavior should still be to install the latest toolchain.