### PR TITLE
fix integration tests

### DIFF
--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -54,9 +54,7 @@ fn fuelup_toolchain_install() -> Result<()> {
 
             let output = cfg.fuelup(&["check"]);
             assert!(output.stdout.contains("forc - Up to date"));
-            // TODO: uncomment once new fuel-core is released and this works
-            // assert!(stdout.contains("fuel-core - Up to date"));
-            assert!(output.stdout.contains("fuelup - Up to date"));
+            assert!(output.stdout.contains("fuel-core - Up to date"));
         }
     })?;
 
@@ -67,9 +65,7 @@ fn fuelup_toolchain_install() -> Result<()> {
 fn fuelup_check() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
         let output = cfg.fuelup(&["check"]);
-        let expected_stdout = format!("fuelup - Up to date : {}\n", clap::crate_version!());
-
-        assert_eq!(output.stdout, expected_stdout);
+        assert!(output.status.success());
     })?;
 
     Ok(())

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -54,7 +54,8 @@ fn fuelup_toolchain_install() -> Result<()> {
 
             let output = cfg.fuelup(&["check"]);
             assert!(output.stdout.contains("forc - Up to date"));
-            assert!(output.stdout.contains("fuel-core - Up to date"));
+            // TODO: uncomment once new fuel-core is released and this works
+            // assert!(stdout.contains("fuel-core - Up to date"));
         }
     })?;
 

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -1,5 +1,9 @@
 use anyhow::Result;
-use std::{env, fs, path::PathBuf, process::Command};
+use std::{
+    env, fs,
+    path::PathBuf,
+    process::{Command, ExitStatus},
+};
 use tempfile::tempdir_in;
 
 pub enum FuelupState {
@@ -17,6 +21,7 @@ pub struct TestCfg {
 pub struct TestOutput {
     pub stdout: String,
     pub stderr: String,
+    pub status: ExitStatus,
 }
 
 impl TestCfg {
@@ -49,7 +54,11 @@ impl TestCfg {
             .expect("Failed to execute command");
         let stdout = String::from_utf8(output.stdout).unwrap();
         let stderr = String::from_utf8(output.stderr).unwrap();
-        TestOutput { stdout, stderr }
+        TestOutput {
+            stdout,
+            stderr,
+            status: output.status,
+        }
     }
 }
 


### PR DESCRIPTION
Some inconsistencies in the tests due to bumping the version of `fuelup` that wasn't considered before.

1) we assert `success()` status in the `fuelup_check` now instead of the exact version string.
2) remove the `fuelup` version string check from the toolchain installation test.