### PR TITLE
Check `toolchain_dir.is_dir()` before attempting to read dir

### DIFF
--- a/src/ops/fuelup_toolchain/new.rs
+++ b/src/ops/fuelup_toolchain/new.rs
@@ -12,11 +12,12 @@ pub fn new(command: NewCommand) -> Result<()> {
 
     let toolchain_dir = toolchain_dir();
 
-    let toolchain_exists = fs::read_dir(&toolchain_dir)?
-        .filter_map(io::Result::ok)
-        .filter(|e| e.path().is_dir())
-        .map(|e| e.file_name().into_string().ok().unwrap_or_default())
-        .any(|x| x == name);
+    let toolchain_exists = toolchain_dir.is_dir()
+        && fs::read_dir(&toolchain_dir)?
+            .filter_map(io::Result::ok)
+            .filter(|e| e.path().is_dir())
+            .map(|e| e.file_name().into_string().ok().unwrap_or_default())
+            .any(|x| x == name);
 
     if toolchain_exists {
         bail!("Toolchain with name '{}' already exists", &name)


### PR DESCRIPTION
Previously `fuelup toolchain new` was trying to do `fs::read_dir()` to check for duplicate toolchains before attempting to create a new one within `/toolchains`. This led to the CI [failing](https://github.com/FuelLabs/sway-applications/runs/7917369437?check_suite_focus=true#step:8:29) if the toolchains directory did not exist to begin with (which is the case for GitHub runners).