### PR TITLE
better handling of 'fuelup check' downgrade behaviour

### DIFF
--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -92,7 +92,7 @@ fn check_fuelup() -> Result<()> {
     ) {
         bold(|s| write!(s, "{} - ", component::FUELUP));
         compare_versions(
-            &Version::parse(&FUELUP_VERSION)?,
+            &Version::parse(FUELUP_VERSION)?,
             &fuelup_download_cfg.version,
         );
     } else {

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering::{Equal, Greater, Less};
 use std::collections::HashMap;
 use std::io::Write;
 use std::str::FromStr;
@@ -27,6 +28,25 @@ fn collect_versions(channel: Channel) -> HashMap<String, Version> {
     latest_versions
 }
 
+fn compare_versions(current_version: &Version, target_version: &Version) {
+    match current_version.cmp(target_version) {
+        Less => {
+            colored_bold(Color::Yellow, |s| write!(s, "Update available"));
+            println!(" : {} -> {}", current_version, target_version);
+        }
+        Equal => {
+            colored_bold(Color::Green, |s| write!(s, "Up to date"));
+            println!(" : {}", current_version);
+        }
+        Greater => {
+            print!(" : {}", current_version);
+            colored_bold(Color::Yellow, |s| write!(s, " (unstable)"));
+            print!(" -> {}", target_version);
+            colored_bold(Color::Green, |s| writeln!(s, " (recommended)"));
+        }
+    }
+}
+
 fn check_plugin(toolchain: &Toolchain, plugin: &str, latest_version: &Version) -> Result<()> {
     let plugin_executable = toolchain.path.join(&plugin);
     match std::process::Command::new(&plugin_executable)
@@ -41,13 +61,7 @@ fn check_plugin(toolchain: &Toolchain, plugin: &str, latest_version: &Version) -
                     print!("    - ");
                     bold(|s| write!(s, "{}", plugin));
                     print!(" - ");
-                    if &version == latest_version {
-                        colored_bold(Color::Green, |s| write!(s, "Up to date"));
-                        println!(" : {}", version);
-                    } else {
-                        colored_bold(Color::Yellow, |s| write!(s, "Update available"));
-                        println!(" : {} -> {}", version, latest_version);
-                    }
+                    compare_versions(&version, latest_version);
                 }
                 None => {
                     eprintln!("    - {} - Error getting version string", plugin);
@@ -77,13 +91,10 @@ fn check_fuelup() -> Result<()> {
         None,
     ) {
         bold(|s| write!(s, "{} - ", component::FUELUP));
-        if FUELUP_VERSION == fuelup_download_cfg.version.to_string() {
-            colored_bold(Color::Green, |s| write!(s, "Up to date"));
-            println!(" : {}", FUELUP_VERSION);
-        } else {
-            colored_bold(Color::Yellow, |s| write!(s, "Update available"));
-            println!(" : {} -> {}", FUELUP_VERSION, fuelup_download_cfg.version);
-        };
+        compare_versions(
+            &Version::parse(&FUELUP_VERSION)?,
+            &fuelup_download_cfg.version,
+        );
     } else {
         error!("Failed to create DownloadCfg for component 'fuelup'; skipping check for 'fuelup'");
     }
@@ -128,13 +139,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                     Some(v) => {
                         let version = Version::parse(v)?;
                         bold(|s| write!(s, "  {} - ", &component));
-                        if version == latest_versions[component] {
-                            colored_bold(Color::Green, |s| write!(s, "Up to date"));
-                            println!(" : {}", version);
-                        } else {
-                            colored_bold(Color::Yellow, |s| write!(s, "Update available"));
-                            println!(" : {} -> {}", version, latest_versions[component]);
-                        }
+                        compare_versions(&version, &latest_versions[component]);
                     }
                     None => {
                         eprintln!("  {} - Error getting version string", component);

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -28,7 +28,7 @@ fn collect_versions(channel: Channel) -> HashMap<String, Version> {
     latest_versions
 }
 
-fn compare_versions(current_version: &Version, target_version: &Version) {
+fn compare_and_print_versions(current_version: &Version, target_version: &Version) {
     match current_version.cmp(target_version) {
         Less => {
             colored_bold(Color::Yellow, |s| write!(s, "Update available"));
@@ -61,7 +61,7 @@ fn check_plugin(toolchain: &Toolchain, plugin: &str, latest_version: &Version) -
                     print!("    - ");
                     bold(|s| write!(s, "{}", plugin));
                     print!(" - ");
-                    compare_versions(&version, latest_version);
+                    compare_and_print_versions(&version, latest_version);
                 }
                 None => {
                     eprintln!("    - {} - Error getting version string", plugin);
@@ -91,7 +91,7 @@ fn check_fuelup() -> Result<()> {
         None,
     ) {
         bold(|s| write!(s, "{} - ", component::FUELUP));
-        compare_versions(
+        compare_and_print_versions(
             &Version::parse(FUELUP_VERSION)?,
             &fuelup_download_cfg.version,
         );
@@ -139,7 +139,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                     Some(v) => {
                         let version = Version::parse(v)?;
                         bold(|s| write!(s, "  {} - ", &component));
-                        compare_versions(&version, &latest_versions[component]);
+                        compare_and_print_versions(&version, &latest_versions[component]);
                     }
                     None => {
                         eprintln!("  {} - Error getting version string", component);


### PR DESCRIPTION
Fixes #150 

Previously `fuelup check` assumes that you would never be able to download a version greater than what's published on a channel. In the upgrade from `fuelup v0.2` to `fuelup v0.3`, there were some users that upgraded `fuel-core` to `v0.10.1`, while the channel still has `v0.9.8` published (due to failing compatibility tests). This resulted in `fuelup check` showing that there's an update available from the more recent version to the older version.

This PR handles the above issue by:

1) Explicitly telling the user that the newer version is 'unstable', and the older version is 'recommended', though this is an edge case that won't happen unless the user manually moved a newer binary into the toolchain (since `fuelup check` only checks official toolchains).

2) There's also some QoL changes by extracting the common code that prints the version information and using `Ordering` for a cleaner look instead.

Example:

![Ordering](https://user-images.githubusercontent.com/25565268/185736308-d3b48045-76af-444b-80a4-90e2fcd44980.png)

