### PR TITLE
Bump v0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Contains bugfixes and a change to `fuelup check` to more appropriate nest `forc-deploy` and `forc-run` under `forc-client`: 
- [x] #151 
- [x] #154 
- [x] #157 