### PR TITLE
forc client check

### DIFF
--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -165,6 +165,12 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
 
         if verbose && component == component::FORC {
             for plugin in SUPPORTED_PLUGINS {
+                if plugin == &component::FORC_DEPLOY {
+                    bold(|s| writeln!(s, "    - forc-client"));
+                }
+                if plugin == &component::FORC_RUN || plugin == &component::FORC_DEPLOY {
+                    print!("  ");
+                }
                 check_plugin(&toolchain, plugin, &latest_versions[component::FORC])?;
             }
         }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -1,9 +1,3 @@
-use std::cmp::Ordering::{Equal, Greater, Less};
-use std::collections::HashMap;
-use std::io::Write;
-use std::str::FromStr;
-use tracing::error;
-
 use crate::{
     channel::Channel,
     commands::check::CheckCommand,
@@ -15,7 +9,12 @@ use crate::{
 };
 use anyhow::Result;
 use semver::Version;
+use std::cmp::Ordering::{Equal, Greater, Less};
+use std::collections::HashMap;
+use std::io::Write;
+use std::str::FromStr;
 use termcolor::Color;
+use tracing::error;
 
 use crate::{component, download::DownloadCfg};
 


### PR DESCRIPTION
Closes #145 

Small update to `fuelup check --verbose` to correctly display `forc-run` and `forc-deploy` as the same package `forc-client`.