### PR TITLE
Fix `toolchain install` command

### DIFF
--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -30,7 +30,7 @@ pub fn install(command: InstallCommand) -> Result<()> {
                 "Failed to get latest channel {} - fetching versions using GitHub API",
                 e
             );
-            [component::FORC, component::FUEL_CORE, component::FORC_LSP]
+            [component::FORC, component::FUEL_CORE]
                 .iter()
                 .map(|c| {
                     DownloadCfg::new(


### PR DESCRIPTION
https://github.com/FuelLabs/fuelup/commit/54772294712f658255de44751e74e23aa51acc56

This was an unintended change that caused `toolchain install` to look for `forc-lsp` - not sure how I didn't catch this but seems like this was accidentally updated. 

Should be immediately followed up with a new patch release since this is an urgent bug fix.