### PR TITLE
nightly support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,6 @@ checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "libc",
  "num_threads",
- "serde",
  "time-macros",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "libc",
  "num_threads",
+ "serde",
  "time-macros",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 tar = "0.4"
 tempfile = "3"
 termcolor = "1"
-time = { version = "0.3", features = ["macros", "parsing", "serde"] }
+time = { version = "0.3", features = ["macros", "parsing"] }
 toml_edit = { version = "0.13", features = ["serde", "easy"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ sha2 = "0.10"
 tar = "0.4"
 tempfile = "3"
 termcolor = "1"
-time = { version = "0.3", features = ["macros", "parsing"] }
+time = { version = "0.3", features = ["macros", "parsing", "serde"] }
 toml_edit = { version = "0.13", features = ["serde", "easy"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -37,8 +37,8 @@ pub struct Package {
     pub date: Option<Date_>,
 }
 
-#[derive(Debug)]
-struct Date_(Date);
+#[derive(Debug, Eq, PartialEq)]
+pub struct Date_(Date);
 
 struct DateVisitor;
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -5,10 +5,10 @@ use crate::{
     toolchain::{DistToolchainName, OfficialToolchainDescription},
 };
 use anyhow::{anyhow, bail, Context, Result};
-use core::fmt;
 use semver::Version;
 use serde::{Deserialize, Deserializer};
 use sha2::{Digest, Sha256};
+use std::fmt;
 use std::str::FromStr;
 use std::{collections::HashMap, path::PathBuf};
 use time::{macros::format_description, Date};

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -37,7 +37,7 @@ pub struct Package {
 
 #[derive(Debug)]
 pub struct PackageVersion {
-    pub core: Version,
+    pub semver: Version,
     pub date: Option<Date>,
 }
 
@@ -58,7 +58,7 @@ where
     };
 
     Ok(PackageVersion {
-        core: Version::parse(version).unwrap(),
+        semver: Version::parse(version).unwrap(),
         date: parsed_date,
     })
 }
@@ -125,12 +125,12 @@ mod tests {
         assert_eq!(channel.pkg.keys().len(), 2);
         assert!(channel.pkg.contains_key("forc"));
         assert_eq!(
-            channel.pkg["forc"].version.core,
+            channel.pkg["forc"].version.semver,
             Version::parse("0.17.0").unwrap()
         );
         assert!(channel.pkg.contains_key("fuel-core"));
         assert_eq!(
-            channel.pkg["fuel-core"].version.core,
+            channel.pkg["fuel-core"].version.semver,
             Version::parse("0.9.4").unwrap()
         );
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -78,7 +78,7 @@ impl Channel {
         {
             Ok(_) => {
                 let toml_path = dst_path.join(channel_file_name);
-                read_file(CHANNEL_LATEST_FILE_NAME, &toml_path)?
+                read_file(channel_file_name, &toml_path)?
             }
             Err(_) => bail!(
                 "Could not download {} to {}",

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -186,8 +186,8 @@ mod tests {
 
         assert_eq!(cfgs.len(), 2);
         assert_eq!(cfgs[0].name, "forc");
-        assert_eq!(cfgs[0].version, Version::parse("0.17.0").unwrap());
+        assert_eq!(cfgs[0].version.semver, Version::parse("0.17.0").unwrap());
         assert_eq!(cfgs[1].name, "fuel-core");
-        assert_eq!(cfgs[1].version, Version::parse("0.9.4").unwrap());
+        assert_eq!(cfgs[1].version.semver, Version::parse("0.9.4").unwrap());
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -37,7 +37,7 @@ pub struct Package {
     pub version: PackageVersion,
 }
 
-#[derive(Debug, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Clone)]
 pub struct PackageVersion {
     pub semver: Version,
     pub date: Option<Date>,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -5,9 +5,11 @@ use crate::{
     toolchain::{DistToolchainName, OfficialToolchainDescription},
 };
 use anyhow::{bail, Result};
+use semver::Version;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::{collections::HashMap, path::PathBuf};
+use time::Date;
 use toml_edit::de;
 
 pub const LATEST: &str = "latest";
@@ -29,7 +31,8 @@ pub struct Channel {
 #[derive(Debug, Deserialize)]
 pub struct Package {
     pub target: HashMap<String, HashedBinary>,
-    pub version: String,
+    pub version: Version,
+    pub date: Option<Date>,
 }
 
 impl Channel {
@@ -93,9 +96,15 @@ mod tests {
 
         assert_eq!(channel.pkg.keys().len(), 2);
         assert!(channel.pkg.contains_key("forc"));
-        assert_eq!(channel.pkg["forc"].version, "0.17.0");
+        assert_eq!(
+            channel.pkg["forc"].version,
+            Version::parse("0.17.0").unwrap()
+        );
         assert!(channel.pkg.contains_key("fuel-core"));
-        assert_eq!(channel.pkg["fuel-core"].version, "0.9.4");
+        assert_eq!(
+            channel.pkg["fuel-core"].version,
+            Version::parse("0.9.4").unwrap()
+        );
 
         let targets = &channel.pkg["forc"].target;
         assert_eq!(targets.len(), 4);

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -62,9 +62,11 @@ impl FromStr for PackageVersion {
         let semver = semver::Version::parse(semver_str).context("failed to parse semver")?;
         let date = match date_str {
             None => None,
-            Some(s) => Date::parse(s, format_description!("([year]-[month]-[day])"))
-                .context("specified date is invalid")
-                .ok(),
+            Some(s) => {
+                let date = Date::parse(s, format_description!("([year]-[month]-[day])"))
+                    .context("specified date is invalid")?;
+                Some(date)
+            }
         };
         Ok(PackageVersion { semver, date })
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -5,6 +5,7 @@ use crate::{
     toolchain::{DistToolchainName, OfficialToolchainDescription},
 };
 use anyhow::{anyhow, bail, Context, Result};
+use core::fmt;
 use semver::Version;
 use serde::{Deserialize, Deserializer};
 use sha2::{Digest, Sha256};
@@ -36,7 +37,7 @@ pub struct Package {
     pub version: PackageVersion,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PackageVersion {
     pub semver: Version,
     pub date: Option<Date>,
@@ -66,6 +67,14 @@ impl FromStr for PackageVersion {
                 .ok(),
         };
         Ok(PackageVersion { semver, date })
+    }
+}
+impl fmt::Display for PackageVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.date {
+            Some(d) => write!(f, "{} ({})", self.semver, d),
+            None => write!(f, "{}", self.semver),
+        }
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -10,6 +10,7 @@ use anyhow::{bail, Result};
 use semver::Version;
 use serde::{de::Visitor, Deserialize};
 use sha2::{Digest, Sha256};
+use std::fmt;
 use std::{collections::HashMap, path::PathBuf};
 use time::Date;
 use toml_edit::de;
@@ -39,6 +40,12 @@ pub struct Package {
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Date_(Date);
+
+impl fmt::Display for Date_ {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 struct DateVisitor;
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -37,7 +37,7 @@ pub struct Package {
     pub version: PackageVersion,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct PackageVersion {
     pub semver: Version,
     pub date: Option<Date>,

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -30,7 +30,9 @@ pub fn exec(command: DefaultCommand) -> Result<()> {
 
     if let Ok(description) = OfficialToolchainDescription::from_str(&toolchain) {
         new_default = Toolchain::from(&description.to_string())?;
-    } else if !new_default.exists() {
+    }
+
+    if !new_default.exists() {
         bail!("Toolchain with name '{}' does not exist", &new_default.name);
     };
 

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -28,7 +28,7 @@ pub fn exec(command: DefaultCommand) -> Result<()> {
 
     let mut new_default = Toolchain::from(&toolchain)?;
 
-    if let Ok(_) = OfficialToolchainDescription::from_str(&toolchain) {
+    if OfficialToolchainDescription::from_str(&toolchain).is_ok() {
         new_default = Toolchain::new(&toolchain)?;
     } else if !new_default.exists() {
         bail!("Toolchain with name '{}' does not exist", &new_default.name);

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -1,4 +1,6 @@
-use crate::toolchain::RESERVED_TOOLCHAIN_NAMES;
+use std::str::FromStr;
+
+use crate::toolchain::OfficialToolchainDescription;
 use anyhow::{bail, Result};
 use clap::Parser;
 use tracing::info;
@@ -26,10 +28,10 @@ pub fn exec(command: DefaultCommand) -> Result<()> {
 
     let mut new_default = Toolchain::from(&toolchain)?;
 
-    if RESERVED_TOOLCHAIN_NAMES.contains(&toolchain.as_str()) {
+    if let Ok(_) = OfficialToolchainDescription::from_str(&toolchain) {
         new_default = Toolchain::new(&toolchain)?;
-    } else if !new_default.path.exists() {
-        bail!("Toolchain with name '{}' does not exist", &new_default.name)
+    } else if !new_default.exists() {
+        bail!("Toolchain with name '{}' does not exist", &new_default.name);
     };
 
     let settings = SettingsFile::new(settings_file());

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -28,8 +28,8 @@ pub fn exec(command: DefaultCommand) -> Result<()> {
 
     let mut new_default = Toolchain::from(&toolchain)?;
 
-    if OfficialToolchainDescription::from_str(&toolchain).is_ok() {
-        new_default = Toolchain::new(&toolchain)?;
+    if let Ok(description) = OfficialToolchainDescription::from_str(&toolchain) {
+        new_default = Toolchain::from(&description.to_string())?;
     } else if !new_default.exists() {
         bail!("Toolchain with name '{}' does not exist", &new_default.name);
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use std::io;
 
-use crate::path::toolchain_dir;
+use crate::path::toolchains_dir;
 use crate::toolchain::RESERVED_TOOLCHAIN_NAMES;
 
 pub struct Config {
@@ -14,7 +14,7 @@ pub struct Config {
 impl Config {
     pub(crate) fn from_env() -> Result<Self> {
         Ok(Self {
-            toolchains_dir: toolchain_dir(),
+            toolchains_dir: toolchains_dir(),
         })
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,5 @@
+use time::{format_description::FormatItem, macros::format_description};
+
 pub const SWAY_REPO: &str = "sway";
 pub const FUEL_CORE_REPO: &str = "fuel-core";
 pub const FUELUP_REPO: &str = "fuelup";
@@ -15,3 +17,5 @@ pub const FUELUP_GH_PAGES: &str = "https://raw.githubusercontent.com/FuelLabs/fu
 
 pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-latest.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
+
+pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");

--- a/src/download.rs
+++ b/src/download.rs
@@ -98,7 +98,7 @@ pub fn tarball_name(name: &str, version: &PackageVersion, target: &TargetTriple)
     match name {
         component::FORC => {
             let postfix = if version.date.is_some() {
-                version_string.to_string() + "-" + &target.to_string()
+                version_string + "-" + &target.to_string()
             } else {
                 target.to_string()
             };

--- a/src/download.rs
+++ b/src/download.rs
@@ -90,16 +90,23 @@ impl DownloadCfg {
 }
 
 pub fn tarball_name(name: &str, version: &PackageVersion, target: &TargetTriple) -> Result<String> {
-    let version = if let Some(d) = date {
-        version.to_string() + "-" + &d.to_string()
+    let version_string = if let Some(date) = version.date {
+        version.semver.to_string() + "-" + &date.to_string()
     } else {
-        version.to_string()
+        version.semver.to_string()
     };
 
     match name {
-        component::FORC => Ok(format!("forc-binaries-{}.tar.gz", target)),
-        component::FUEL_CORE => Ok(format!("fuel-core-{}-{}.tar.gz", version, target)),
-        component::FUELUP => Ok(format!("fuelup-{}-{}.tar.gz", version, target)),
+        component::FORC => {
+            let postfix = if let Some(date) = version.date {
+                version.semver.to_string() + &target.to_string()
+            } else {
+                target.to_string()
+            };
+            Ok(format!("forc-binaries-{}.tar.gz", postfix))
+        }
+        component::FUEL_CORE => Ok(format!("fuel-core-{}-{}.tar.gz", version_string, target)),
+        component::FUELUP => Ok(format!("fuelup-{}-{}.tar.gz", version_string, target)),
         _ => bail!("Unrecognized component: {}", name),
     }
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{fs, thread};
 use tar::Archive;
+use time::Date;
 use tracing::warn;
 use tracing::{error, info};
 
@@ -35,14 +36,20 @@ struct LatestReleaseApiResponse {
 pub struct DownloadCfg {
     pub name: String,
     pub target: TargetTriple,
-    pub version: String,
+    pub version: Version,
+    pub date: Option<Date>,
     tarball_name: String,
     tarball_url: String,
     hash: Option<String>,
 }
 
 impl DownloadCfg {
-    pub fn new(name: &str, target: TargetTriple, version: Option<Version>) -> Result<Self> {
+    pub fn new(
+        name: &str,
+        target: TargetTriple,
+        version: Option<Version>,
+        date: Option<Date>,
+    ) -> Result<Self> {
         let version = match version {
             Some(version) => version,
             None => get_latest_tag(name).map_err(|e| {
@@ -62,7 +69,8 @@ impl DownloadCfg {
         Ok(Self {
             name: name.to_string(),
             target,
-            version: version.to_string(),
+            version,
+            date,
             tarball_name,
             tarball_url,
             hash: None,

--- a/src/download.rs
+++ b/src/download.rs
@@ -99,7 +99,7 @@ pub fn tarball_name(name: &str, version: &PackageVersion, target: &TargetTriple)
     match name {
         component::FORC => {
             let postfix = if let Some(date) = version.date {
-                version.semver.to_string() + &target.to_string()
+                version_string.to_string() + "-" + &target.to_string()
             } else {
                 target.to_string()
             };

--- a/src/download.rs
+++ b/src/download.rs
@@ -10,7 +10,6 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::{fs, thread};
 use tar::Archive;
-use time::Date;
 use tracing::warn;
 use tracing::{error, info};
 
@@ -98,7 +97,7 @@ pub fn tarball_name(name: &str, version: &PackageVersion, target: &TargetTriple)
 
     match name {
         component::FORC => {
-            let postfix = if let Some(date) = version.date {
+            let postfix = if version.date.is_some() {
                 version_string.to_string() + "-" + &target.to_string()
             } else {
                 target.to_string()

--- a/src/download.rs
+++ b/src/download.rs
@@ -79,14 +79,14 @@ impl DownloadCfg {
     pub fn from_package(name: &str, package: Package) -> Result<Self> {
         let target = TargetTriple::from_component(name)?;
         let tarball_name =
-            tarball_name(name, &package.version.core, package.version.date, &target)?;
+            tarball_name(name, &package.version.semver, package.version.date, &target)?;
         let tarball_url = package.target[&target.to_string()].url.clone();
         let hash = Some(package.target[&target.to_string()].hash.clone());
         Ok(Self {
             name: name.to_string(),
             target,
             date: package.version.date,
-            version: package.version.core,
+            version: package.version.semver,
             tarball_name,
             tarball_url,
             hash,

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -43,7 +43,6 @@ fn compare_and_print_versions(
             Version::parse(&target_version_string)?,
         ),
         DistToolchainName::Nightly => (
-            // 0.11.0-nightly
             Version::parse(current_version_string.split_once('-').unwrap_or_default().0)?,
             Version::parse(target_version_string.split_once('-').unwrap_or_default().0)?,
         ),

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -45,12 +45,12 @@ fn compare_and_print_versions(
     let mut current = current_version.to_string();
     let mut latest = latest_version.to_string();
 
-    if current_date.is_some() && latest_date.is_some() {
-        current.push_str(&current_date.unwrap().to_string());
-        latest.push_str(&latest_date.unwrap().to_string());
+    if let (Some(c), Some(l)) = (current_date, latest_date) {
+        current.push_str(&(" (".to_owned() + &c.to_string() + ")"));
+        latest.push_str(&(" (".to_owned() + &l.to_string() + ")"));
     }
 
-    match current_version.cmp(&latest_version) {
+    match current_version.cmp(latest_version) {
         Less => {
             colored_bold(Color::Yellow, |s| write!(s, "Update available"));
             println!(" : {} -> {}", current, latest);
@@ -159,7 +159,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
 
         if component_executable.is_file() {
             bold(|s| write!(s, "  {} - ", &component));
-            compare_and_print_versions(&version, date, &latest_version, latest_date)?;
+            compare_and_print_versions(version, date, latest_version, latest_date)?;
         } else {
             print!("  ");
             bold(|s| write!(s, "{}", &component));
@@ -179,9 +179,9 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                 check_plugin(
                     &plugin_executable,
                     plugin,
-                    &version,
+                    version,
                     date,
-                    &latest_version,
+                    latest_version,
                     latest_date,
                 )?;
             }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -29,13 +29,7 @@ fn collect_package_versions(channel: Channel) -> HashMap<String, PackageVersion>
     let mut latest_versions: HashMap<String, PackageVersion> = HashMap::new();
 
     for (name, package) in channel.pkg.into_iter() {
-        latest_versions.insert(
-            name,
-            PackageVersion {
-                semver: package.version.semver,
-                date: package.version.date,
-            },
-        );
+        latest_versions.insert(name, package.version.clone());
     }
 
     latest_versions

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -1,5 +1,5 @@
 use crate::{
-    channel::Channel,
+    channel::{Channel, PackageVersion},
     commands::check::CheckCommand,
     component::SUPPORTED_PLUGINS,
     config::Config,
@@ -21,68 +21,65 @@ use std::{
 };
 use tempfile::tempdir_in;
 use termcolor::Color;
-use time::Date;
 use tracing::error;
 
 use crate::{component, download::DownloadCfg};
 
-fn collect_versions_and_dates(channel: Channel) -> HashMap<String, (Version, Option<Date>)> {
-    let mut latest_versions: HashMap<String, (Version, Option<Date>)> = HashMap::new();
+fn collect_package_versions(channel: Channel) -> HashMap<String, PackageVersion> {
+    let mut latest_versions: HashMap<String, PackageVersion> = HashMap::new();
 
     for (name, package) in channel.pkg.into_iter() {
-        latest_versions.insert(name, (package.version.semver, package.version.date));
+        latest_versions.insert(
+            name,
+            PackageVersion {
+                semver: package.version.semver,
+                date: package.version.date,
+            },
+        );
     }
 
     latest_versions
 }
 
 fn compare_and_print_versions(
-    current_version: &Version,
-    current_date: Option<Date>,
-    latest_version: &Version,
-    latest_date: Option<Date>,
+    current_version: &PackageVersion,
+    latest_version: &PackageVersion,
 ) -> Result<()> {
-    let mut current = current_version.to_string();
-    let mut latest = latest_version.to_string();
-
-    if let (Some(c), Some(l)) = (current_date, latest_date) {
-        current.push_str(&(" (".to_owned() + &c.to_string() + ")"));
-        latest.push_str(&(" (".to_owned() + &l.to_string() + ")"));
-    }
-
     match current_version.cmp(latest_version) {
         Less => {
             colored_bold(Color::Yellow, |s| write!(s, "Update available"));
-            println!(" : {} -> {}", current, latest);
+            println!(" : {} -> {}", current_version, latest_version);
         }
         Equal => {
+            colored_bold(Color::Green, |s| write!(s, "Up to date"));
+            println!(" : {}", current_version);
             // dates always come in the format '(YYYY-MM-DD)'
-            if current_date.is_some() && latest_date.is_some() {
-                match current_date.cmp(&latest_date) {
-                    Less => {
-                        colored_bold(Color::Yellow, |s| write!(s, "Update available"));
-                        println!(" : {} -> {}", current, latest);
-                    }
-                    Equal => {
-                        colored_bold(Color::Green, |s| write!(s, "Up to date"));
-                        println!(" : {}", current);
-                    }
-                    Greater => {
-                        print!(" : {}", current);
-                        colored_bold(Color::Yellow, |s| write!(s, " (unstable)"));
-                        print!(" -> {}", latest);
-                        colored_bold(Color::Green, |s| writeln!(s, " (recommended)"));
-                    }
-                }
-            } else {
-                colored_bold(Color::Green, |s| write!(s, "Up to date"));
-                println!(" : {}", current_version);
-            }
+            //            if current_date.is_some() && latest_date.is_some() {
+            //                match current_date.cmp(&latest_date) {
+            //                    Less => {
+            //                        colored_bold(Color::Yellow, |s| write!(s, "Update available"));
+            //                        println!(" : {} -> {}", current_version, latest_version);
+            //                    }
+            //                    Equal => {
+            //                        colored_bold(Color::Green, |s| write!(s, "Up to date"));
+            //                        println!(" : {}", current_version);
+            //                    }
+            //                    Greater => {
+            //                        print!(" : {}", current_version);
+            //                        colored_bold(Color::Yellow, |s| write!(s, " (unstable)"));
+            //                        print!(" -> {}", latest_version);
+            //                        colored_bold(Color::Green, |s| writeln!(s, " (recommended)"));
+            //                    }
+            //                }
+            //            } else {
+            //                colored_bold(Color::Green, |s| write!(s, "Up to date"));
+            //                println!(" : {}", current_version);
+            //            }
         }
         Greater => {
-            print!(" : {}", current);
+            print!(" : {}", current_version);
             colored_bold(Color::Yellow, |s| write!(s, " (unstable)"));
-            print!(" -> {}", latest);
+            print!(" -> {}", latest_version);
             colored_bold(Color::Green, |s| writeln!(s, " (recommended)"));
         }
     }
@@ -92,16 +89,14 @@ fn compare_and_print_versions(
 fn check_plugin(
     plugin_executable: &Path,
     plugin: &str,
-    current_version: &Version,
-    current_date: Option<Date>,
-    latest_version: &Version,
-    latest_date: Option<Date>,
+    current_version: &PackageVersion,
+    latest_version: &PackageVersion,
 ) -> Result<()> {
     if plugin_executable.is_file() {
         print!("    - ");
         bold(|s| write!(s, "{}", plugin));
         print!(" - ");
-        compare_and_print_versions(current_version, current_date, latest_version, latest_date)?;
+        compare_and_print_versions(current_version, latest_version)?;
     } else {
         print!("  ");
         bold(|s| write!(s, "{}", &plugin));
@@ -119,7 +114,13 @@ fn check_fuelup() -> Result<()> {
         None,
     ) {
         bold(|s| write!(s, "{} - ", component::FUELUP));
-        compare_and_print_versions(&fuelup_version, None, &fuelup_download_cfg.version, None)?;
+        compare_and_print_versions(
+            &PackageVersion {
+                semver: fuelup_version,
+                date: None,
+            },
+            &fuelup_download_cfg.version,
+        )?;
     } else {
         error!("Failed to create DownloadCfg for component 'fuelup'; skipping check for 'fuelup'");
     }
@@ -133,7 +134,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     let tmp_dir = tempdir_in(&fuelup_dir)?;
 
     let dist_channel = Channel::from_dist_channel(&description, tmp_dir.into_path())?;
-    let latest_versions_and_dates = collect_versions_and_dates(dist_channel);
+    let latest_package_versions = collect_package_versions(dist_channel);
 
     let toolchain = Toolchain::new(toolchain)?;
 
@@ -148,17 +149,14 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     bold(|s| writeln!(s, "{}", &toolchain.name));
 
     for component in [component::FORC, component::FUEL_CORE] {
-        let version = &channel.pkg[component].version.semver;
-        let date = channel.pkg[component].version.date;
-
-        let latest_version = &latest_versions_and_dates[component].0;
-        let latest_date = latest_versions_and_dates[component].1;
+        let version = &channel.pkg[component].version;
+        let latest_version = &latest_package_versions[component];
 
         let component_executable = toolchain.bin_path.join(component);
 
         if component_executable.is_file() {
             bold(|s| write!(s, "  {} - ", &component));
-            compare_and_print_versions(version, date, latest_version, latest_date)?;
+            compare_and_print_versions(version, latest_version)?;
         } else {
             print!("  ");
             bold(|s| write!(s, "{}", &component));
@@ -175,14 +173,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                 }
 
                 let plugin_executable = toolchain.bin_path.join(&plugin);
-                check_plugin(
-                    &plugin_executable,
-                    plugin,
-                    version,
-                    date,
-                    latest_version,
-                    latest_date,
-                )?;
+                check_plugin(&plugin_executable, plugin, version, latest_version)?;
             }
         }
     }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -117,7 +117,6 @@ fn check_fuelup() -> Result<()> {
         component::FUELUP,
         TargetTriple::from_component(component::FUELUP)?,
         None,
-        None,
     ) {
         bold(|s| write!(s, "{} - ", component::FUELUP));
         compare_and_print_versions(&fuelup_version, None, &fuelup_download_cfg.version, None)?;

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -44,8 +44,8 @@ fn compare_and_print_versions(
         ),
         DistToolchainName::Nightly => (
             // 0.11.0-nightly
-            Version::parse(&current_version_string.split_once('-').unwrap_or_default().0)?,
-            Version::parse(&target_version_string.split_once('-').unwrap_or_default().0)?,
+            Version::parse(current_version_string.split_once('-').unwrap_or_default().0)?,
+            Version::parse(target_version_string.split_once('-').unwrap_or_default().0)?,
         ),
     };
     match current_version.cmp(&target_version) {

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -180,14 +180,14 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
         }
     };
 
-    let toolchain = Toolchain::from(toolchain)?;
+    let toolchain = Toolchain::new(toolchain)?;
 
     let channel_file_name = match description.name {
         DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
         DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,
     };
     let toml_path = toolchain.path.join(channel_file_name);
-    let toml = read_file(CHANNEL_LATEST_FILE_NAME, &toml_path)?;
+    let toml = read_file("channel", &toml_path)?;
     let channel = Channel::from_toml(&toml)?;
 
     bold(|s| writeln!(s, "{}", &toolchain.name));
@@ -236,7 +236,9 @@ pub fn check(command: CheckCommand) -> Result<()> {
     let cfg = Config::from_env()?;
 
     for toolchain in cfg.list_official_toolchains()? {
-        check_toolchain(&toolchain, verbose)?;
+        // TODO: remove once date/target are supported
+        let name = toolchain.split_once('-').unwrap_or_default().0;
+        check_toolchain(&name, verbose)?;
     }
 
     check_fuelup()?;

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -53,28 +53,6 @@ fn compare_and_print_versions(
         Equal => {
             colored_bold(Color::Green, |s| write!(s, "Up to date"));
             println!(" : {}", current_version);
-            // dates always come in the format '(YYYY-MM-DD)'
-            //            if current_date.is_some() && latest_date.is_some() {
-            //                match current_date.cmp(&latest_date) {
-            //                    Less => {
-            //                        colored_bold(Color::Yellow, |s| write!(s, "Update available"));
-            //                        println!(" : {} -> {}", current_version, latest_version);
-            //                    }
-            //                    Equal => {
-            //                        colored_bold(Color::Green, |s| write!(s, "Up to date"));
-            //                        println!(" : {}", current_version);
-            //                    }
-            //                    Greater => {
-            //                        print!(" : {}", current_version);
-            //                        colored_bold(Color::Yellow, |s| write!(s, " (unstable)"));
-            //                        print!(" -> {}", latest_version);
-            //                        colored_bold(Color::Green, |s| writeln!(s, " (recommended)"));
-            //                    }
-            //                }
-            //            } else {
-            //                colored_bold(Color::Green, |s| write!(s, "Up to date"));
-            //                println!(" : {}", current_version);
-            //            }
         }
         Greater => {
             print!(" : {}", current_version);

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -238,7 +238,7 @@ pub fn check(command: CheckCommand) -> Result<()> {
     for toolchain in cfg.list_official_toolchains()? {
         // TODO: remove once date/target are supported
         let name = toolchain.split_once('-').unwrap_or_default().0;
-        check_toolchain(&name, verbose)?;
+        check_toolchain(name, verbose)?;
     }
 
     check_fuelup()?;

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -157,8 +157,8 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
         Ok(c) => collect_versions(c),
         Err(e) => {
             error!(
-                "Failed to get latest channel {} - fetching versions using GitHub API",
-                e
+                "Failed to get '{}' channel: {} - fetching versions using GitHub API",
+                description.name, e
             );
             [component::FORC, component::FUEL_CORE, component::FUELUP]
                 .iter()

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -30,7 +30,7 @@ fn collect_versions_and_dates(channel: Channel) -> HashMap<String, (Version, Opt
     let mut latest_versions: HashMap<String, (Version, Option<Date>)> = HashMap::new();
 
     for (name, package) in channel.pkg.into_iter() {
-        latest_versions.insert(name, (package.version.core, package.version.date));
+        latest_versions.insert(name, (package.version.semver, package.version.date));
     }
 
     latest_versions
@@ -149,7 +149,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     bold(|s| writeln!(s, "{}", &toolchain.name));
 
     for component in [component::FORC, component::FUEL_CORE] {
-        let version = &channel.pkg[component].version.core;
+        let version = &channel.pkg[component].version.semver;
         let date = channel.pkg[component].version.date;
 
         let latest_version = &latest_versions_and_dates[component].0;

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -5,8 +5,8 @@ use semver::Version;
 use tracing::info;
 
 use crate::{
-    commands::component::AddCommand, download::DownloadCfg, target_triple::TargetTriple,
-    toolchain::Toolchain,
+    channel::PackageVersion, commands::component::AddCommand, download::DownloadCfg,
+    target_triple::TargetTriple, toolchain::Toolchain,
 };
 
 pub fn add(command: AddCommand) -> Result<()> {
@@ -32,7 +32,7 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
         );
     }
 
-    let (component, version): (&str, Option<Version>) =
+    let (component, version): (&str, Option<PackageVersion>) =
         match maybe_versioned_component.split_once('@') {
             Some(t) => {
                 let v = match Version::from_str(t.1) {
@@ -43,7 +43,13 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
                         e
                     ),
                 };
-                (t.0, Some(v))
+                (
+                    t.0,
+                    Some(PackageVersion {
+                        semver: v,
+                        date: None,
+                    }),
+                )
             }
             None => (&maybe_versioned_component, None),
         };

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -48,12 +48,8 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
             None => (&maybe_versioned_component, None),
         };
 
-    let download_cfg = DownloadCfg::new(
-        component,
-        TargetTriple::from_component(component)?,
-        version,
-        None,
-    )?;
+    let download_cfg =
+        DownloadCfg::new(component, TargetTriple::from_component(component)?, version)?;
     toolchain.add_component(download_cfg)?;
 
     Ok(())

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -15,9 +15,19 @@ pub fn add(command: AddCommand) -> Result<()> {
     } = command;
 
     let toolchain = Toolchain::from_settings()?;
+    if toolchain.is_official() {
+        bail!(
+            "Installing specific components is reserved for custom toolchains.
+You are currently using '{}'.
+
+You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
+            toolchain.name
+        )
+    };
+
     if toolchain.has_component(&maybe_versioned_component) {
         info!(
-            "{} already exists in toolchain '{}'; replacing existing version",
+            "{} already exists in toolchain '{}'; replacing existing version with `latest` version",
             &maybe_versioned_component, toolchain.name
         );
     }
@@ -25,15 +35,6 @@ pub fn add(command: AddCommand) -> Result<()> {
     let (component, version): (&str, Option<Version>) =
         match maybe_versioned_component.split_once('@') {
             Some(t) => {
-                if toolchain.is_official() {
-                    bail!(
-"Installing specific versions of components is reserved for custom toolchains.
-You are currently using '{}'.
-
-You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
-                    toolchain.name
-                )
-                };
                 let v = match Version::from_str(t.1) {
                     Ok(v) => v,
                     Err(e) => bail!(

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -48,8 +48,12 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
             None => (&maybe_versioned_component, None),
         };
 
-    let download_cfg =
-        DownloadCfg::new(component, TargetTriple::from_component(component)?, version)?;
+    let download_cfg = DownloadCfg::new(
+        component,
+        TargetTriple::from_component(component)?,
+        version,
+        None,
+    )?;
     toolchain.add_component(download_cfg)?;
 
     Ok(())

--- a/src/ops/fuelup_component/remove.rs
+++ b/src/ops/fuelup_component/remove.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 
 use crate::{commands::component::RemoveCommand, toolchain::Toolchain};
 
@@ -6,6 +6,17 @@ pub fn remove(command: RemoveCommand) -> Result<()> {
     let RemoveCommand { component } = command;
 
     let toolchain = Toolchain::from_settings()?;
+
+    if toolchain.is_official() {
+        bail!(
+            "Installing specific components is reserved for custom toolchains.
+You are currently using '{}'.
+
+You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
+            toolchain.name
+        )
+    };
+
     toolchain.remove_component(&component)?;
     Ok(())
 }

--- a/src/ops/fuelup_component/remove.rs
+++ b/src/ops/fuelup_component/remove.rs
@@ -9,7 +9,7 @@ pub fn remove(command: RemoveCommand) -> Result<()> {
 
     if toolchain.is_official() {
         bail!(
-            "Installing specific components is reserved for custom toolchains.
+            "Removing specific components is reserved for custom toolchains.
 You are currently using '{}'.
 
 You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -22,6 +22,7 @@ pub fn self_update() -> Result<()> {
         component::FUELUP,
         TargetTriple::from_component(component::FUELUP)?,
         None,
+        None,
     )?;
 
     let fuelup_bin = fuelup_bin();

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -22,7 +22,6 @@ pub fn self_update() -> Result<()> {
         component::FUELUP,
         TargetTriple::from_component(component::FUELUP)?,
         None,
-        None,
     )?;
 
     let fuelup_bin = fuelup_bin();

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -57,7 +57,7 @@ pub fn show() -> Result<()> {
 
     for component in [component::FORC, component::FUEL_CORE] {
         if let Some(c) = channel.as_ref() {
-            let version = &c.pkg[component].version.core;
+            let version = &c.pkg[component].version.semver;
             bold(|s| write!(s, "  {}", &component));
             println!(" : {}", version);
         } else {
@@ -95,7 +95,7 @@ pub fn show() -> Result<()> {
         if component == component::FORC {
             for plugin in SUPPORTED_PLUGINS {
                 if let Some(c) = channel.as_ref() {
-                    let version = &c.pkg[component].version.core;
+                    let version = &c.pkg[component].version.semver;
 
                     if plugin == &component::FORC_DEPLOY {
                         bold(|s| writeln!(s, "    - forc-client"));

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -37,7 +37,7 @@ pub fn show() -> Result<()> {
 
     println!("{} (default)", current_toolchain.name);
     for component in [component::FORC, component::FUEL_CORE] {
-        let component_executable = current_toolchain.path.join(component);
+        let component_executable = current_toolchain.bin_path.join(component);
 
         match std::process::Command::new(&component_executable)
             .arg("--version")
@@ -70,7 +70,7 @@ pub fn show() -> Result<()> {
 
         if component == component::FORC {
             for plugin in SUPPORTED_PLUGINS {
-                let plugin_executable = current_toolchain.path.join(&plugin);
+                let plugin_executable = current_toolchain.bin_path.join(&plugin);
                 if plugin == &component::FORC_DEPLOY {
                     bold(|s| writeln!(s, "    - forc-client"));
                 }

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -96,7 +96,14 @@ pub fn show() -> Result<()> {
             for plugin in SUPPORTED_PLUGINS {
                 if let Some(c) = channel.as_ref() {
                     let version = &c.pkg[component].version;
-                    bold(|s| write!(s, "    {}", &plugin));
+
+                    if plugin == &component::FORC_DEPLOY {
+                        bold(|s| writeln!(s, "    - forc-client"));
+                    }
+                    if plugin == &component::FORC_RUN || plugin == &component::FORC_DEPLOY {
+                        print!("  ");
+                    }
+                    bold(|s| write!(s, "    - {}", &plugin));
                     println!(" : {}", version);
                 } else {
                     let plugin_executable = active_toolchain.bin_path.join(&plugin);

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -57,7 +57,7 @@ pub fn show() -> Result<()> {
 
     for component in [component::FORC, component::FUEL_CORE] {
         if let Some(c) = channel.as_ref() {
-            let version = &c.pkg[component].version;
+            let version = &c.pkg[component].version.core;
             bold(|s| write!(s, "  {}", &component));
             println!(" : {}", version);
         } else {
@@ -95,7 +95,7 @@ pub fn show() -> Result<()> {
         if component == component::FORC {
             for plugin in SUPPORTED_PLUGINS {
                 if let Some(c) = channel.as_ref() {
-                    let version = &c.pkg[component].version;
+                    let version = &c.pkg[component].version.core;
 
                     if plugin == &component::FORC_DEPLOY {
                         bold(|s| writeln!(s, "    - forc-client"));

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -1,14 +1,18 @@
 use anyhow::Result;
 use semver::Version;
-use std::{io::Write, thread::current};
+use std::io::Write;
+use std::str::FromStr;
 
 use crate::{
+    channel::Channel,
     component::{self, SUPPORTED_PLUGINS},
     config::Config,
+    constants::{CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME},
+    file::read_file,
     fmt::{bold, print_header},
     path::fuelup_dir,
     target_triple::TargetTriple,
-    toolchain::Toolchain,
+    toolchain::{DistToolchainName, OfficialToolchainDescription, Toolchain},
 };
 
 pub fn show() -> Result<()> {
@@ -35,73 +39,100 @@ pub fn show() -> Result<()> {
     print_header("active toolchain");
 
     println!("{} (default)", active_toolchain.name);
-    for component in [component::FORC, component::FUEL_CORE] {
-        let component_executable = active_toolchain.bin_path.join(component);
 
-        match std::process::Command::new(&component_executable)
-            .arg("--version")
-            .output()
-        {
-            Ok(o) => {
-                let output = String::from_utf8_lossy(&o.stdout).into_owned();
-                match output.split_whitespace().nth(1) {
-                    Some(v) => {
-                        let version = Version::parse(v)?;
-                        bold(|s| write!(s, "  {}", &component));
-                        println!(" : {}", version);
+    let channel = if active_toolchain.is_official() {
+        let description = OfficialToolchainDescription::from_str(
+            active_toolchain.name.split_once('-').unwrap_or_default().0,
+        )?;
+        let channel_file_name = match description.name {
+            DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
+            DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,
+        };
+        let toml_path = active_toolchain.path.join(channel_file_name);
+        let toml = read_file("channel", &toml_path)?;
+        Some(Channel::from_toml(&toml)?)
+    } else {
+        None
+    };
+
+    for component in [component::FORC, component::FUEL_CORE] {
+        if let Some(c) = channel.as_ref() {
+            let version = &c.pkg[component].version;
+            bold(|s| write!(s, "  {}", &component));
+            println!(" : {}", version);
+        } else {
+            let component_executable = active_toolchain.bin_path.join(component);
+            match std::process::Command::new(&component_executable)
+                .arg("--version")
+                .output()
+            {
+                Ok(o) => {
+                    let output = String::from_utf8_lossy(&o.stdout).into_owned();
+                    match output.split_whitespace().nth(1) {
+                        Some(v) => {
+                            let version = Version::parse(v)?;
+                            bold(|s| write!(s, "  {}", &component));
+                            println!(" : {}", version);
+                        }
+                        None => {
+                            eprintln!("  {} - Error getting version string", component);
+                        }
+                    };
+                }
+                Err(e) => {
+                    print!("  ");
+                    bold(|s| write!(s, "{}", &component));
+                    print!(" - ");
+                    if component_executable.exists() {
+                        println!("execution error - {}", e);
+                    } else {
+                        println!("not found");
                     }
-                    None => {
-                        eprintln!("  {} - Error getting version string", component);
-                    }
-                };
-            }
-            Err(e) => {
-                print!("  ");
-                bold(|s| write!(s, "{}", &component));
-                print!(" - ");
-                if component_executable.exists() {
-                    println!("execution error - {}", e);
-                } else {
-                    println!("not found");
                 }
             }
         };
 
         if component == component::FORC {
             for plugin in SUPPORTED_PLUGINS {
-                let plugin_executable = active_toolchain.bin_path.join(&plugin);
-                if plugin == &component::FORC_DEPLOY {
-                    bold(|s| writeln!(s, "    - forc-client"));
-                }
-                if plugin == &component::FORC_RUN || plugin == &component::FORC_DEPLOY {
-                    print!("  ");
-                }
-                match std::process::Command::new(&plugin_executable)
-                    .arg("--version")
-                    .output()
-                {
-                    Ok(o) => {
-                        let output = String::from_utf8_lossy(&o.stdout).into_owned();
-                        match output.split_whitespace().nth(1) {
-                            Some(v) => {
-                                let version = Version::parse(v)?;
-                                print!("    - ");
-                                bold(|s| write!(s, "{}", plugin));
-                                println!(" : {}", version);
-                            }
-                            None => {
-                                eprintln!("    - {} - Error getting version string", plugin);
-                            }
-                        };
+                if let Some(c) = channel.as_ref() {
+                    let version = &c.pkg[component].version;
+                    bold(|s| write!(s, "    {}", &plugin));
+                    println!(" : {}", version);
+                } else {
+                    let plugin_executable = active_toolchain.bin_path.join(&plugin);
+                    if plugin == &component::FORC_DEPLOY {
+                        bold(|s| writeln!(s, "    - forc-client"));
                     }
-                    Err(e) => {
-                        print!("    - ");
-                        bold(|s| write!(s, "{}", plugin));
-                        print!(" - ");
-                        if plugin_executable.exists() {
-                            println!("execution error - {}", e);
-                        } else {
-                            println!("not found");
+                    if plugin == &component::FORC_RUN || plugin == &component::FORC_DEPLOY {
+                        print!("  ");
+                    }
+                    match std::process::Command::new(&plugin_executable)
+                        .arg("--version")
+                        .output()
+                    {
+                        Ok(o) => {
+                            let output = String::from_utf8_lossy(&o.stdout).into_owned();
+                            match output.split_whitespace().nth(1) {
+                                Some(v) => {
+                                    let version = Version::parse(v)?;
+                                    print!("    - ");
+                                    bold(|s| write!(s, "{}", plugin));
+                                    println!(" : {}", version);
+                                }
+                                None => {
+                                    eprintln!("    - {} - Error getting version string", plugin);
+                                }
+                            };
+                        }
+                        Err(e) => {
+                            print!("    - ");
+                            bold(|s| write!(s, "{}", plugin));
+                            print!(" - ");
+                            if plugin_executable.exists() {
+                                println!("execution error - {}", e);
+                            } else {
+                                println!("not found");
+                            }
                         }
                     }
                 }

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use semver::Version;
-use std::io::Write;
+use std::{io::Write, thread::current};
 
 use crate::{
     component::{self, SUPPORTED_PLUGINS},
@@ -21,10 +21,10 @@ pub fn show() -> Result<()> {
 
     print_header("installed toolchains");
     let cfg = Config::from_env()?;
-    let current_toolchain = Toolchain::from_settings()?;
+    let active_toolchain = Toolchain::from_settings()?;
 
     for toolchain in cfg.list_toolchains()? {
-        if toolchain == current_toolchain.name {
+        if toolchain == active_toolchain.name {
             println!("{} (default)", toolchain);
         } else {
             println!("{}", toolchain);
@@ -33,11 +33,10 @@ pub fn show() -> Result<()> {
 
     println!();
     print_header("active toolchain");
-    let current_toolchain = Toolchain::from_settings()?;
 
-    println!("{} (default)", current_toolchain.name);
+    println!("{} (default)", active_toolchain.name);
     for component in [component::FORC, component::FUEL_CORE] {
-        let component_executable = current_toolchain.bin_path.join(component);
+        let component_executable = active_toolchain.bin_path.join(component);
 
         match std::process::Command::new(&component_executable)
             .arg("--version")
@@ -70,7 +69,7 @@ pub fn show() -> Result<()> {
 
         if component == component::FORC {
             for plugin in SUPPORTED_PLUGINS {
-                let plugin_executable = current_toolchain.bin_path.join(&plugin);
+                let plugin_executable = active_toolchain.bin_path.join(&plugin);
                 if plugin == &component::FORC_DEPLOY {
                     bold(|s| writeln!(s, "    - forc-client"));
                 }

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -1,9 +1,7 @@
-use crate::component;
 use crate::constants::{CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME};
 use crate::download::DownloadCfg;
 use crate::path::{fuelup_dir, settings_file};
 use crate::settings::SettingsFile;
-use crate::target_triple::TargetTriple;
 use crate::toolchain::{DistToolchainName, OfficialToolchainDescription, Toolchain};
 use crate::{channel::Channel, commands::toolchain::InstallCommand};
 use anyhow::{bail, Result};

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -31,6 +31,7 @@ pub fn install(command: InstallCommand) -> Result<()> {
     let fuelup_dir = fuelup_dir();
     let tmp_dir = tempdir_in(&fuelup_dir)?;
     let tmp_dir_path = tmp_dir.into_path();
+
     let cfgs: Vec<DownloadCfg> =
         match Channel::from_dist_channel(&description, tmp_dir_path.clone()) {
             Ok(c) => c.build_download_configs(),

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -6,7 +6,7 @@ use crate::settings::SettingsFile;
 use crate::target_triple::TargetTriple;
 use crate::toolchain::{DistToolchainName, OfficialToolchainDescription, Toolchain};
 use crate::{channel::Channel, commands::toolchain::InstallCommand};
-use anyhow::Result;
+use anyhow::{bail, Result};
 use std::fmt::Write;
 use std::fs;
 use std::str::FromStr;
@@ -33,26 +33,10 @@ pub fn install(command: InstallCommand) -> Result<()> {
     let tmp_dir_path = tmp_dir.into_path();
 
     let cfgs: Vec<DownloadCfg> =
-        match Channel::from_dist_channel(&description, tmp_dir_path.clone()) {
-            Ok(c) => c.build_download_configs(),
-            Err(e) => {
-                error!(
-                    "Failed to get latest channel {} - fetching versions using GitHub API",
-                    e
-                );
-                [component::FORC, component::FUEL_CORE]
-                    .iter()
-                    .map(|c| {
-                        DownloadCfg::new(
-                            c,
-                            TargetTriple::from_component(c)
-                                .expect("Failed to create DownloadCfg from component"),
-                            None,
-                        )
-                        .unwrap()
-                    })
-                    .collect()
-            }
+        if let Ok(channel) = Channel::from_dist_channel(&description, tmp_dir_path.clone()) {
+            channel.build_download_configs()
+        } else {
+            bail!("Could not build download configs from channel")
         };
 
     info!(

--- a/src/ops/fuelup_toolchain/new.rs
+++ b/src/ops/fuelup_toolchain/new.rs
@@ -1,6 +1,6 @@
-use crate::path::{ensure_dir_exists, settings_file, toolchain_bin_dir};
+use crate::commands::toolchain::NewCommand;
+use crate::path::{ensure_dir_exists, settings_file, toolchain_bin_dir, toolchains_dir};
 use crate::settings::SettingsFile;
-use crate::{commands::toolchain::NewCommand, path::toolchain_dir};
 use anyhow::bail;
 use anyhow::Result;
 use std::fs;
@@ -10,10 +10,10 @@ use tracing::info;
 pub fn new(command: NewCommand) -> Result<()> {
     let NewCommand { name } = command;
 
-    let toolchain_dir = toolchain_dir();
+    let toolchains_dir = toolchains_dir();
 
-    let toolchain_exists = toolchain_dir.is_dir()
-        && fs::read_dir(&toolchain_dir)?
+    let toolchain_exists = toolchains_dir.is_dir()
+        && fs::read_dir(&toolchains_dir)?
             .filter_map(io::Result::ok)
             .filter(|e| e.path().is_dir())
             .map(|e| e.file_name().into_string().ok().unwrap_or_default())
@@ -34,7 +34,7 @@ pub fn new(command: NewCommand) -> Result<()> {
         })?;
     }
 
-    ensure_dir_exists(&toolchain_dir.join(toolchain_bin_dir))?;
+    ensure_dir_exists(&toolchains_dir.join(toolchain_bin_dir))?;
     info!("New toolchain initialized: {}", &name);
 
     Ok(())

--- a/src/ops/fuelup_toolchain/uninstall.rs
+++ b/src/ops/fuelup_toolchain/uninstall.rs
@@ -12,7 +12,6 @@ pub fn uninstall(command: UninstallCommand) -> Result<()> {
     let UninstallCommand { name } = command;
 
     let mut toolchain = Toolchain::from(&name)?;
-    println!("{:?}", toolchain);
 
     if toolchain.is_official() {
         let description = OfficialToolchainDescription::from_str(&name)?;

--- a/src/ops/fuelup_toolchain/uninstall.rs
+++ b/src/ops/fuelup_toolchain/uninstall.rs
@@ -1,20 +1,31 @@
+use std::str::FromStr;
+
 use anyhow::Result;
 use tracing::info;
 
-use crate::{commands::toolchain::UninstallCommand, toolchain::Toolchain};
+use crate::{
+    commands::toolchain::UninstallCommand,
+    toolchain::{OfficialToolchainDescription, Toolchain},
+};
 
 pub fn uninstall(command: UninstallCommand) -> Result<()> {
     let UninstallCommand { name } = command;
 
-    let toolchain = Toolchain::from(&name)?;
+    let mut toolchain = Toolchain::from(&name)?;
+    println!("{:?}", toolchain);
+
+    if toolchain.is_official() {
+        let description = OfficialToolchainDescription::from_str(&name)?;
+        toolchain = Toolchain::from(&description.to_string())?;
+    }
 
     if !toolchain.exists() {
-        info!("toolchain '{}' does not exist", &name);
+        info!("toolchain '{}' does not exist", &toolchain.name);
         return Ok(());
     }
 
     toolchain.uninstall_self()?;
-    info!("toolchain '{}' uninstalled", &name);
+    info!("toolchain '{}' uninstalled", &toolchain.name);
 
     Ok(())
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -24,12 +24,16 @@ pub fn settings_file() -> PathBuf {
     fuelup_dir().join("settings.toml")
 }
 
-pub fn toolchain_dir() -> PathBuf {
+pub fn toolchains_dir() -> PathBuf {
     fuelup_dir().join("toolchains")
 }
 
+pub fn toolchain_dir(toolchain: &str) -> PathBuf {
+    toolchains_dir().join(toolchain)
+}
+
 pub fn toolchain_bin_dir(toolchain: &str) -> PathBuf {
-    toolchain_dir().join(toolchain).join("bin")
+    toolchain_dir(toolchain).join("bin")
 }
 
 pub fn ensure_dir_exists(path: &Path) -> Result<()> {

--- a/src/proxy_cli.rs
+++ b/src/proxy_cli.rs
@@ -26,7 +26,7 @@ pub fn proxy_run(arg0: &str) -> Result<ExitCode> {
 }
 
 fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: Toolchain) -> io::Result<ExitCode> {
-    let bin_path = toolchain.path.join(proc_name);
+    let bin_path = toolchain.bin_path.join(proc_name);
     let mut cmd = Command::new(bin_path);
 
     cmd.args(args);

--- a/src/target_triple.rs
+++ b/src/target_triple.rs
@@ -2,7 +2,7 @@ use crate::component;
 use anyhow::{bail, Result};
 use std::fmt;
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub struct TargetTriple(String);
 
 impl fmt::Display for TargetTriple {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -153,7 +153,7 @@ impl Toolchain {
     }
 
     pub fn is_official(&self) -> bool {
-        OfficialToolchainDescription::from_str(&self.name).is_ok()
+        RESERVED_TOOLCHAIN_NAMES.contains(&self.name.split_once('-').unwrap_or_default().0)
     }
 
     pub fn exists(&self) -> bool {
@@ -268,10 +268,12 @@ mod tests {
 
     #[test]
     fn test_parse_nightly_date() -> Result<()> {
-        let desc = OfficialToolchainDescription::from_str(NIGHTLY_DATE)?;
-        assert_eq!(desc.name, DistToolchainName::from_str("nightly").unwrap());
-        assert_eq!(desc.date.unwrap().to_string(), DATE);
-        assert_eq!(desc.target, None);
+        assert!(OfficialToolchainDescription::from_str(NIGHTLY_DATE).is_err());
+
+        // TODO: uncomment once specifying date and target is supporting
+        //assert_eq!(desc.name, DistToolchainName::from_str("nightly").unwrap());
+        //assert_eq!(desc.date.unwrap().to_string(), DATE);
+        //assert_eq!(desc.target, None);
 
         Ok(())
     }
@@ -285,13 +287,14 @@ mod tests {
             TARGET_X86_LINUX,
         ] {
             let input = channel::NIGHTLY.to_owned() + "-" + DATE + "-" + target;
-            let desc = OfficialToolchainDescription::from_str(&input)?;
-            assert_eq!(
-                desc.name,
-                DistToolchainName::from_str(channel::NIGHTLY).unwrap()
-            );
-            assert_eq!(desc.date.unwrap().to_string(), DATE);
-            assert_eq!(desc.target.unwrap().to_string(), target);
+            assert!(OfficialToolchainDescription::from_str(&input).is_err());
+            // TODO: uncomment once specifying date and target is supporting
+            //   assert_eq!(
+            //       desc.name,
+            //       DistToolchainName::from_str(channel::NIGHTLY).unwrap()
+            //   );
+            //   assert_eq!(desc.date.unwrap().to_string(), DATE);
+            //   assert_eq!(desc.target.unwrap().to_string(), target);
         }
 
         Ok(())
@@ -307,10 +310,12 @@ mod tests {
         ] {
             for name in [channel::LATEST, channel::NIGHTLY] {
                 let toolchain = name.to_owned() + "-" + target;
-                let desc = OfficialToolchainDescription::from_str(&toolchain)?;
-                assert_eq!(desc.name, DistToolchainName::from_str(name).unwrap());
-                assert!(desc.date.is_none());
-                assert_eq!(desc.target.unwrap().to_string(), target);
+                assert!(OfficialToolchainDescription::from_str(&toolchain).is_err());
+
+                // TODO: uncomment once specifying date and target is supporting
+                // assert_eq!(desc.name, DistToolchainName::from_str(name).unwrap());
+                // assert!(desc.date.is_none());
+                // assert_eq!(desc.target.unwrap().to_string(), target);
             }
         }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -222,7 +222,7 @@ impl Toolchain {
 
     pub fn uninstall_self(&self) -> Result<()> {
         if self.exists() {
-            remove_dir_all(self.path.parent().unwrap())?
+            remove_dir_all(self.path.clone())?
         }
         Ok(())
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -24,7 +24,7 @@ pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::STABLE,
 ];
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum DistToolchainName {
     Latest,
     Nightly,
@@ -61,20 +61,18 @@ fn parse_metadata(metadata: String) -> Result<(Option<Date>, Option<TargetTriple
     let (first, second) = metadata.split_at(std::cmp::min(10, metadata.len()));
 
     match Date::parse(first, DATE_FORMAT) {
-        Ok(d) => {
-            match TargetTriple::new(second.trim_start_matches('-')) {
-                Ok(t) => return Ok((Some(d), Some(t))),
-                Err(_) => return Ok((Some(d), None)),
-            };
-        }
+        Ok(d) => match TargetTriple::new(second.trim_start_matches('-')) {
+            Ok(t) => Ok((Some(d), Some(t))),
+            Err(_) => Ok((Some(d), None)),
+        },
         Err(_) => {
             // try parse target, if date not ok
             match TargetTriple::new(&metadata) {
-                Ok(t) => return Ok((None, Some(t))),
+                Ok(t) => Ok((None, Some(t))),
                 Err(_) => bail!("Failed to parse date or target"),
-            };
+            }
         }
-    };
+    }
 }
 
 impl FromStr for OfficialToolchainDescription {
@@ -121,8 +119,8 @@ impl Toolchain {
     pub fn from(toolchain: &str) -> Result<Self> {
         Ok(Self {
             name: toolchain.to_string(),
-            path: toolchain_dir(&toolchain),
-            bin_path: toolchain_bin_dir(&toolchain),
+            path: toolchain_dir(toolchain),
+            bin_path: toolchain_bin_dir(toolchain),
         })
     }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -85,27 +85,25 @@ impl FromStr for OfficialToolchainDescription {
         let (name, metadata) = s.split_once('-').unwrap_or((s, ""));
 
         if metadata.is_empty() {
-            return Ok(Self {
+            Ok(Self {
                 name: DistToolchainName::from_str(name)?,
                 date: None,
                 target: None,
-            });
-        } else {
-            if let Ok((_, _)) = parse_metadata(metadata.to_string()) {
-                bail!(
-                    "You may not specify a date or target for official toolchain name '{}' yet.",
-                    name
-                );
+            })
+        } else if let Ok((_, _)) = parse_metadata(metadata.to_string()) {
+            bail!(
+                "You may not specify a date or target for official toolchain name '{}' yet.",
+                name
+            );
 
-                // TODO: uncomment once specifying date and target is supported
-                // Ok(Self {
-                //     name: DistToolchainName::from_str(name)?,
-                //     date,
-                //     target,
-                // })
-            } else {
-                bail!("Invalid official toolchain name '{}'", s);
-            }
+            // TODO: uncomment once specifying date and target is supported
+            // Ok(Self {
+            //     name: DistToolchainName::from_str(name)?,
+            //     date,
+            //     target,
+            // })
+        } else {
+            bail!("Invalid official toolchain name '{}'", s);
         }
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -65,13 +65,10 @@ fn parse_metadata(metadata: String) -> Result<(Option<Date>, Option<TargetTriple
             Ok(t) => Ok((Some(d), Some(t))),
             Err(_) => Ok((Some(d), None)),
         },
-        Err(_) => {
-            // try parse target, if date not ok
-            match TargetTriple::new(&metadata) {
-                Ok(t) => Ok((None, Some(t))),
-                Err(_) => bail!("Failed to parse date or target"),
-            }
-        }
+        Err(_) => match TargetTriple::new(&metadata) {
+            Ok(t) => Ok((None, Some(t))),
+            Err(_) => bail!("Failed to parse date or target"),
+        },
     }
 }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -72,6 +72,16 @@ fn parse_metadata(metadata: String) -> Result<(Option<Date>, Option<TargetTriple
     }
 }
 
+impl fmt::Display for OfficialToolchainDescription {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let target = TargetTriple::from_host().unwrap_or_default();
+        match self.date {
+            Some(d) => write!(f, "{}-{}-{}", self.name, d, target),
+            None => write!(f, "{}-{}", self.name, target),
+        }
+    }
+}
+
 impl FromStr for OfficialToolchainDescription {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self> {
@@ -148,7 +158,7 @@ impl Toolchain {
     }
 
     pub fn is_official(&self) -> bool {
-        RESERVED_TOOLCHAIN_NAMES.contains(&self.name.split_once('-').unwrap_or_default().0)
+        RESERVED_TOOLCHAIN_NAMES.contains(&self.name.split_once('-').unwrap_or((&self.name, "")).0)
     }
 
     pub fn exists(&self) -> bool {

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use fuelup::target_triple::TargetTriple;
+use fuelup::{channel, target_triple::TargetTriple};
 use std::{env, path::Path};
 
 mod testcfg;
@@ -34,7 +34,7 @@ fn fuelup_version() -> Result<()> {
 }
 
 #[test]
-fn fuelup_toolchain_install() -> Result<()> {
+fn fuelup_toolchain_install_latest() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
         cfg.fuelup(&["toolchain", "install", "latest"]);
 
@@ -54,6 +54,28 @@ fn fuelup_toolchain_install() -> Result<()> {
             assert!(output.stdout.contains("forc - Up to date"));
             // TODO: uncomment once new fuel-core is released and this works
             // assert!(stdout.contains("fuel-core - Up to date"));
+        }
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn fuelup_toolchain_install_nightly() -> Result<()> {
+    testcfg::setup(FuelupState::Empty, &|cfg| {
+        cfg.fuelup(&["toolchain", "install", "nightly"]);
+
+        for entry in cfg.toolchains_dir().read_dir().expect("Could not read dir") {
+            let toolchain_dir = entry.unwrap();
+            let expected_toolchain_name =
+                "nightly-".to_owned() + &TargetTriple::from_host().unwrap().to_string();
+            assert_eq!(
+                expected_toolchain_name,
+                toolchain_dir.file_name().to_str().unwrap()
+            );
+            assert!(toolchain_dir.file_type().unwrap().is_dir());
+
+            expect_files_exist(&toolchain_dir.path().join("bin"), ALL_BINS);
         }
     })?;
 
@@ -160,9 +182,11 @@ fn fuelup_toolchain_new() -> Result<()> {
 #[test]
 fn fuelup_toolchain_new_disallowed() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
-        let output = cfg.fuelup(&["toolchain", "new", "latest"]);
-        let expected_stderr = "error: Invalid value \"latest\" for '<NAME>': Cannot use official toolchain name 'latest' as a custom toolchain name\n\nFor more information try --help\n";
-        assert_eq!(output.stderr, expected_stderr);
+        for toolchain in [channel::LATEST, channel::NIGHTLY] {
+            let output = cfg.fuelup(&["toolchain", "new", toolchain]);
+            let expected_stderr = format!("error: Invalid value \"{toolchain}\" for '<NAME>': Cannot use official toolchain name '{toolchain}' as a custom toolchain name\n\nFor more information try --help\n");
+            assert_eq!(output.stderr, expected_stderr);
+        }
     })?;
 
     Ok(())

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -4,7 +4,7 @@ use std::{env, path::Path};
 
 mod testcfg;
 
-use testcfg::{FuelupState, ALL_BINS, FUEL_CORE_BIN};
+use testcfg::{FuelupState, ALL_BINS};
 
 use crate::testcfg::FORC_BINS;
 
@@ -252,7 +252,7 @@ fn fuelup_component_add() -> Result<()> {
 fn fuelup_component_add_disallowed() -> Result<()> {
     testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
         let output = cfg.fuelup(&["component", "add", "forc@0.19.1"]);
-        let expected_stdout = r#"Installing specific versions of components is reserved for custom toolchains.
+        let expected_stdout = r#"Installing specific components is reserved for custom toolchains.
 You are currently using 'latest-x86_64-apple-darwin'.
 
 You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
@@ -263,16 +263,20 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
     Ok(())
 }
 #[test]
-fn fuelup_component_remove() -> Result<()> {
+fn fuelup_component_remove_disallowed() -> Result<()> {
     testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
         let latest_toolchain_bin_dir = cfg.toolchain_bin_dir("latest-x86_64-apple-darwin");
 
         expect_files_exist(&latest_toolchain_bin_dir, ALL_BINS);
-        let _ = cfg.fuelup(&["component", "remove", "forc"]);
-        expect_files_exist(&latest_toolchain_bin_dir, FUEL_CORE_BIN);
+        let output = cfg.fuelup(&["component", "remove", "forc"]);
 
-        let _ = cfg.fuelup(&["component", "remove", "fuel-core"]);
-        expect_files_exist(&latest_toolchain_bin_dir, &[]);
+        let expected_stdout = r#"Removing specific components is reserved for custom toolchains.
+You are currently using 'latest-x86_64-apple-darwin'.
+
+You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
+"#;
+        assert_eq!(output.stdout, expected_stdout);
+        expect_files_exist(&latest_toolchain_bin_dir, ALL_BINS);
     })?;
 
     Ok(())

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -164,10 +164,13 @@ fn fuelup_default() -> Result<()> {
 }
 
 #[test]
-fn fuelup_default_latest() -> Result<()> {
+fn fuelup_default_uninstalled_toolchain() -> Result<()> {
     testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
-        let output = cfg.fuelup(&["default", "latest"]);
-        let expected_stdout = "default toolchain set to 'latest-x86_64-apple-darwin'\n";
+        let output = cfg.fuelup(&["default", "nightly"]);
+        let expected_stdout = format!(
+            "Toolchain with name 'nightly-{}' does not exist\n",
+            TargetTriple::from_host().unwrap()
+        );
 
         assert_eq!(output.stdout, expected_stdout);
     })?;

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -164,6 +164,18 @@ fn fuelup_default() -> Result<()> {
 }
 
 #[test]
+fn fuelup_default_latest() -> Result<()> {
+    testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
+        let output = cfg.fuelup(&["default", "latest"]);
+        let expected_stdout = "default toolchain set to 'latest-x86_64-apple-darwin'\n";
+
+        assert_eq!(output.stdout, expected_stdout);
+    })?;
+
+    Ok(())
+}
+
+#[test]
 fn fuelup_toolchain_new() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
         let output = cfg.fuelup(&["toolchain", "new", "my_toolchain"]);

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -260,7 +260,7 @@ fn fuelup_component_add_disallowed() -> Result<()> {
     testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
         let output = cfg.fuelup(&["component", "add", "forc@0.19.1"]);
         let expected_stdout = r#"Installing specific versions of components is reserved for custom toolchains.
-You are currently using 'latest'.
+You are currently using 'latest-x86_64-apple-darwin'.
 
 You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
 "#;

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -32,7 +32,6 @@ pub const FORC_BINS: &[&str] = &[
     "forc-lsp",
     "forc-run",
 ];
-pub const FUEL_CORE_BIN: &[&str] = &["fuel-core"];
 
 pub static ALL_BINS: &[&str] = &[
     "forc",


### PR DESCRIPTION
Closes #159


Allows for the command `fuelup toolchain install nightly` which sources the channel TOML from gh-pages ([example](https://github.com/FuelLabs/fuelup/blob/b0daef81746066a7c507e784eedad3f0bfc18484/channel-fuel-nightly.toml)) and downloads from the links there.

Note that this does not yet allow for specifying dates or targets, even though some of the infra code that allows for it is in this PR.

In order to support nightly, there were some refactoring that had to be done:
-  `Package` struct now takes version as a `String` instead of a `Version`. This is because nightly versions are semver versions postfixed with `-nightly` and the date at the back. `fuelup check` will use this date to check for updates.
- We used to download the channel TOMLs as temporary files, but this PR will install them into the toolchain directory i.e. `toolchains/<my-toolchain>/ `. Previously we executed the actual binaries to check versions but with nightlies the semver versions are the same if we check nightlies of the same `latest` release. We use the channels to compare versions instead.
- As mentioned, much of the infra code to support parsing of date and target when we install toolchains is in this PR to support specifying a specific nightly to install, but is left unused for now.
- Refactored some paths.

Example `fuelup check` 

![Screenshot 2022-09-01 at 12 08 24 AM](https://user-images.githubusercontent.com/25565268/187726398-329ea02d-e697-4471-8d85-3000df9492c7.png)

