### PR TITLE
show dates for `fuelup show` in nightly

### DIFF
--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -57,7 +57,7 @@ pub fn show() -> Result<()> {
 
     for component in [component::FORC, component::FUEL_CORE] {
         if let Some(c) = channel.as_ref() {
-            let version = &c.pkg[component].version.semver;
+            let version = &c.pkg[component].version;
             bold(|s| write!(s, "  {}", &component));
             println!(" : {}", version);
         } else {
@@ -95,7 +95,7 @@ pub fn show() -> Result<()> {
         if component == component::FORC {
             for plugin in SUPPORTED_PLUGINS {
                 if let Some(c) = channel.as_ref() {
-                    let version = &c.pkg[component].version.semver;
+                    let version = &c.pkg[component].version;
 
                     if plugin == &component::FORC_DEPLOY {
                         bold(|s| writeln!(s, "    - forc-client"));


### PR DESCRIPTION
Follow up to #167 

Fixs `fuelup show` not showing dates in nightly.

Example:

<img width="535" alt="Screenshot 2022-09-03 at 9 31 32 AM" src="https://user-images.githubusercontent.com/25565268/188250786-d27be98e-c4f0-4ba5-8a6a-e9db6fe4f019.png">
