### PR TITLE
fix proxy_cli interaction; deprecate SUPPORTED_COMPONENTS

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -7,13 +7,4 @@ pub const FORC_LSP: &str = "forc-lsp";
 pub const FORC_DEPLOY: &str = "forc-run";
 pub const FORC_RUN: &str = "forc-deploy";
 
-pub const SUPPORTED_COMPONENTS: &[&str] = &[
-    FORC,
-    FUEL_CORE,
-    FORC_FMT,
-    FORC_LSP,
-    FORC_EXPLORE,
-    FORC_DEPLOY,
-    FORC_RUN,
-];
 pub const SUPPORTED_PLUGINS: &[&str] = &[FORC_FMT, FORC_LSP, FORC_EXPLORE, FORC_DEPLOY, FORC_RUN];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use fuelup::component;
 use fuelup::{fuelup_cli, proxy_cli};
 use std::panic;
@@ -14,22 +14,18 @@ fn run() -> Result<()> {
         .and_then(std::ffi::OsStr::to_str)
         .map(String::from);
 
+    println!("proc_name: {:?}", process_name);
+
     match process_name.as_deref() {
         Some(component::FUELUP) => {
             if let Err(e) = fuelup_cli::fuelup_cli() {
                 error!("{}", e);
             }
         }
-        Some(n) if component::SUPPORTED_COMPONENTS.contains(&n) => {
+        Some(n) => {
             if let Err(e) = proxy_cli::proxy_run(n) {
                 error!("{}", e);
             }
-        }
-        Some(n) => {
-            bail!(
-                "fuelup invoked with unexpected command or component {:?}",
-                n
-            )
         }
         None => panic!("fuelup does not understand this command"),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,6 @@ fn run() -> Result<()> {
         .and_then(std::ffi::OsStr::to_str)
         .map(String::from);
 
-    println!("proc_name: {:?}", process_name);
-
     match process_name.as_deref() {
         Some(component::FUELUP) => {
             if let Err(e) = fuelup_cli::fuelup_cli() {

--- a/src/proxy_cli.rs
+++ b/src/proxy_cli.rs
@@ -4,7 +4,6 @@ use std::os::unix::prelude::CommandExt;
 use std::process::{Command, ExitCode, Stdio};
 use std::{env, io};
 
-use crate::component;
 use crate::toolchain::Toolchain;
 
 /// Runs forc or fuel-core in proxy mode
@@ -12,16 +11,7 @@ pub fn proxy_run(arg0: &str) -> Result<ExitCode> {
     let cmd_args: Vec<_> = env::args_os().skip(1).collect();
     let toolchain = Toolchain::from_settings()?;
 
-    if !cmd_args.is_empty()
-        && component::SUPPORTED_PLUGINS
-            .contains(&cmd_args[0].to_str().expect("Failed to parse cmd args"))
-    {
-        let plugin = &format!("{}-{}", arg0, &cmd_args[0].to_string_lossy());
-        direct_proxy(plugin, &cmd_args[1..], toolchain)?;
-    } else {
-        direct_proxy(arg0, &cmd_args, toolchain)?;
-    }
-
+    direct_proxy(arg0, &cmd_args, toolchain)?;
     Ok(ExitCode::SUCCESS)
 }
 

--- a/src/proxy_cli.rs
+++ b/src/proxy_cli.rs
@@ -4,6 +4,7 @@ use std::os::unix::prelude::CommandExt;
 use std::process::{Command, ExitCode, Stdio};
 use std::{env, io};
 
+use crate::component::SUPPORTED_PLUGINS;
 use crate::toolchain::Toolchain;
 
 /// Runs forc or fuel-core in proxy mode
@@ -11,11 +12,18 @@ pub fn proxy_run(arg0: &str) -> Result<ExitCode> {
     let cmd_args: Vec<_> = env::args_os().skip(1).collect();
     let toolchain = Toolchain::from_settings()?;
 
-    direct_proxy(arg0, &cmd_args, toolchain)?;
+    if !cmd_args.is_empty() {
+        let plugin = format!("{}-{}", arg0, &cmd_args[0].to_string_lossy());
+        if SUPPORTED_PLUGINS.contains(&plugin.as_str()) {
+            direct_proxy(&plugin, &cmd_args[1..], &toolchain)?;
+        }
+    }
+
+    direct_proxy(arg0, &cmd_args, &toolchain)?;
     Ok(ExitCode::SUCCESS)
 }
 
-fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: Toolchain) -> io::Result<ExitCode> {
+fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: &Toolchain) -> io::Result<ExitCode> {
     let bin_path = toolchain.bin_path.join(proc_name);
     let mut cmd = Command::new(bin_path);
 


### PR DESCRIPTION
I relooked at some code in anticipation of #163 and #162 and found some incorrect and perhaps redundant code here. 

- The if branch within `proxy_cli.rs` was never called. `component::SUPPORTED_PLUGINS.contains(&cmd_args[0].to_str())` always evaluated to false, since the `cmd_args` was not processed to form a plugin prior to the condition check
- Calling `forc deploy`, for example, used to call `forc` first. before evaluating to `forc-deploy` - so things actually still worked, but both binaries were being called.


Technically, calling `direct_proxy` is good enough since plugins automatically resolve to their intended path eg. calling `forc deploy` will evaluate `forc` with `deploy` as an arg but `fuelup` knows to call `forc-deploy`. I maintained the condition check since it seems more correct for fuelup to be able to directly call the plugin, instead of depending on calling its parent first eg `forc` -> `forc-deploy`


- Also deprecated `SUPPORTED_COMPONENTS`  and removed its usage in `main.rs` for 2 reasons: 

1) `fuelup` would already be aware of bins in the context of the official components/plugins ecosystem. e.g. calling `forc hello` would result in `Error: no such subcommand: 'hello'`, since it's invoked in the context of `forc`. Hence there is no real reason for this check. Same for any other binary that's already linked to `fuelup` in the installation step.
2) we _might_ be supporting external plugins with the above issue in mind and in that case we shouldn't limit what can be ran by fuelup to a slice of consts.
This PR fixes the 'if' check and disallows the double calling.
