### PR TITLE
components toml

### DIFF
--- a/components.toml
+++ b/components.toml
@@ -5,7 +5,6 @@ executables = ["forc"]
 repository_url = "https://github.com/FuelLabs/sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 
-# This might be distributed together with `forc` above, but we should have a separate entry still.
 [component.forc-fmt]
 name = "forc-fmt"
 tarball_prefix = "forc-binaries"

--- a/components.toml
+++ b/components.toml
@@ -1,0 +1,46 @@
+[component.forc]
+name = "forc"
+tarball_prefix = "forc-binaries"
+executables = ["forc"]
+repository_url = "https://github.com/FuelLabs/sway"
+targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+
+# This might be distributed together with `forc` above, but we should have a separate entry still.
+[component.forc-fmt]
+name = "forc-fmt"
+tarball_prefix = "forc-binaries"
+is_plugin = true
+executables = ["forc-fmt"]
+repository_url = "https://github.com/FuelLabs/sway"
+targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+
+[component.forc-lsp]
+name = "forc-lsp"
+tarball_prefix = "forc-binaries"
+is_plugin = true
+executables = ["forc-lsp"]
+repository_url = "https://github.com/FuelLabs/sway"
+targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+
+[component.forc-explore]
+name = "forc-explore"
+tarball_prefix = "forc-binaries"
+is_plugin = true
+executables = ["forc-explore"]
+repository_url = "https://github.com/FuelLabs/sway"
+targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+
+[component.forc-client]
+name = "forc-client"
+tarball_prefix = "forc-binaries"
+is_plugin = true
+executables = ["forc-deploy", "forc-run"]
+repository_url = "https://github.com/FuelLabs/sway"
+targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+
+[component.fuel-core]
+name = "fuel-core"
+tarball_prefix = "fuel-core"
+executables = ["fuel-core"]
+repository_url = "https://github.com/FuelLabs/fuel-core"
+targets = [ "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin" ]

--- a/src/component.rs
+++ b/src/component.rs
@@ -104,8 +104,10 @@ impl Components {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const TOML: &str = r#"
+    use crate::component;
+    #[test]
+    fn test_toml() -> Result<()> {
+        const TOML: &str = r#"
 [component.forc-fmt]
 name = "forc-fmt"
 is_plugin = true
@@ -115,8 +117,6 @@ repository_url = "https://github.com/FuelLabs/sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 "#;
 
-    #[test]
-    fn test_toml() -> Result<()> {
         let components = Components::from_toml(TOML)?;
 
         assert_eq!(components.component["forc-fmt"].name, "forc-fmt");
@@ -141,7 +141,14 @@ targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
     #[test]
     fn test_collect_exclude_plugins() -> Result<()> {
         let components = Components::collect_exclude_plugins()?;
-        println!("{:?}", components);
+        assert_eq!(components.len(), 2);
+        assert_eq!(
+            components
+                .iter()
+                .map(|c| c.name.clone())
+                .collect::<Vec<String>>(),
+            [component::FORC, component::FUEL_CORE]
+        );
         Ok(())
     }
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -44,18 +44,20 @@ impl Components {
     }
 
     pub fn collect_exclude_plugins() -> Result<Vec<Component>> {
-        let toml = Self::from_toml(COMPONENTS_TOML)?;
+        let components = Self::from_toml(COMPONENTS_TOML)?;
 
-        let mut main_components: Vec<Component> = toml
+        let mut main_components: Vec<Component> = components
             .component
             .keys()
             .filter(|&c| {
-                toml.component
+                components
+                    .component
                     .get(c)
                     .map_or(false, |p| !p.is_plugin.unwrap_or_default())
             })
             .map(|c| {
-                toml.component
+                components
+                    .component
                     .get(c)
                     .cloned()
                     .expect(&format!("Failed to get component '{}' from toml", c))

--- a/src/component.rs
+++ b/src/component.rs
@@ -1,3 +1,9 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use serde::Deserialize;
+use toml_edit::de;
+
 pub const FORC: &str = "forc";
 pub const FUEL_CORE: &str = "fuel-core";
 pub const FUELUP: &str = "fuelup";
@@ -8,3 +14,98 @@ pub const FORC_DEPLOY: &str = "forc-run";
 pub const FORC_RUN: &str = "forc-deploy";
 
 pub const SUPPORTED_PLUGINS: &[&str] = &[FORC_FMT, FORC_LSP, FORC_EXPLORE, FORC_DEPLOY, FORC_RUN];
+
+const COMPONENTS_TOML: &'static str = include_str!("../components.toml");
+
+#[derive(Debug, Deserialize)]
+pub struct Components {
+    pub component: HashMap<String, Component>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Component {
+    pub name: String,
+    pub is_plugin: Option<bool>,
+    pub tarball_prefix: String,
+    pub executables: Vec<String>,
+    pub repository_url: String,
+    pub targets: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct Plugin {
+    pub name: String,
+    pub executables: Vec<String>,
+}
+
+impl Plugin {
+    pub fn is_main_executable(&self) -> bool {
+        self.executables.len() == 1 && self.name == self.executables[0]
+    }
+}
+
+impl Components {
+    pub fn from_toml(toml: &str) -> Result<Self> {
+        let components: Components = de::from_str(toml)?;
+        Ok(components)
+    }
+
+    pub fn collect_plugins() -> Result<Vec<Plugin>> {
+        let components = Self::from_toml(COMPONENTS_TOML)?;
+
+        let plugins = components
+            .component
+            .keys()
+            .filter(|&c| {
+                components
+                    .component
+                    .get(c)
+                    .map_or(false, |p| p.is_plugin.unwrap_or_default())
+            })
+            .map(|p| {
+                let plugin = components.component.get(p).expect("Failed to get p");
+                Plugin {
+                    name: plugin.name.clone(),
+                    executables: plugin.executables.clone(),
+                }
+            })
+            .collect();
+
+        Ok(plugins)
+    }
+
+    pub fn collect_plugin_executables() -> Result<Vec<String>> {
+        let plugins = Self::collect_plugins()?;
+        let mut executables = vec![];
+
+        for plugin in plugins.iter() {
+            executables.extend(plugin.executables.clone().into_iter())
+        }
+
+        Ok(executables)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOML: &str = r#"
+[forc-fmt]
+name = "forc-fmt"
+tarball_prefix = "forc-binaries"
+executables = ["forc-fmt"]
+repository_url = "https://github.com/FuelLabs/sway"
+targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+"#;
+
+    #[test]
+    fn test_toml() {
+        assert!(Components::from_toml(TOML).is_ok());
+    }
+
+    #[test]
+    fn test_collect_plugins() {
+        assert!(Components::collect_plugins().is_ok());
+    }
+}

--- a/src/component.rs
+++ b/src/component.rs
@@ -58,7 +58,7 @@ impl Components {
                 toml.component
                     .get(c)
                     .cloned()
-                    .expect("Failed to get component")
+                    .expect(&format!("Failed to get component '{}' from toml", c))
             })
             .collect();
 
@@ -80,7 +80,10 @@ impl Components {
                     .map_or(false, |p| p.is_plugin.unwrap_or_default())
             })
             .map(|p| {
-                let plugin = components.component.get(p).expect("Failed to get p");
+                let plugin = components
+                    .component
+                    .get(p)
+                    .expect(&format!("Failed to get plugin '{}' from toml", p));
                 Plugin {
                     name: plugin.name.clone(),
                     executables: plugin.executables.clone(),

--- a/src/component.rs
+++ b/src/component.rs
@@ -49,7 +49,12 @@ impl Components {
         let mut main_components: Vec<Component> = components
             .component
             .keys()
-            .map(|c| components.component.get(c).unwrap())
+            .map(|c| {
+                components
+                    .component
+                    .get(c)
+                    .expect("Failed to parse components.toml")
+            })
             .filter_map(|c| c.is_plugin.is_none().then(|| c.clone()))
             .collect();
 
@@ -64,7 +69,12 @@ impl Components {
         let mut plugins: Vec<Plugin> = components
             .component
             .keys()
-            .map(|c| components.component.get(c).unwrap())
+            .map(|c| {
+                components
+                    .component
+                    .get(c)
+                    .expect("Failed to parse components.toml")
+            })
             .filter(|&c| c.is_plugin.unwrap_or_default())
             .map(|p| Plugin {
                 name: p.name.clone(),

--- a/src/component.rs
+++ b/src/component.rs
@@ -7,13 +7,4 @@ pub const FORC_LSP: &str = "forc-lsp";
 pub const FORC_DEPLOY: &str = "forc-run";
 pub const FORC_RUN: &str = "forc-deploy";
 
-pub const SUPPORTED_COMPONENTS: &[&str] = &[
-    FORC,
-    FUEL_CORE,
-    FORC_FMT,
-    FORC_LSP,
-    FORC_EXPLORE,
-    FORC_DEPLOY,
-    FORC_RUN,
-];
 pub const SUPPORTED_PLUGINS: &[&str] = &[FORC_FMT, FORC_LSP, FORC_EXPLORE, FORC_DEPLOY, FORC_RUN];

--- a/src/component.rs
+++ b/src/component.rs
@@ -46,7 +46,7 @@ impl Components {
     pub fn collect_exclude_plugins() -> Result<Vec<Component>> {
         let toml = Self::from_toml(COMPONENTS_TOML)?;
 
-        let not_plugins = toml
+        let mut main_components: Vec<Component> = toml
             .component
             .keys()
             .filter(|&c| {
@@ -62,7 +62,9 @@ impl Components {
             })
             .collect();
 
-        Ok(not_plugins)
+        main_components.sort_by(|a, b| a.name.cmp(&b.name));
+
+        Ok(main_components)
     }
 
     pub fn collect_plugins() -> Result<Vec<Plugin>> {
@@ -140,15 +142,15 @@ targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 
     #[test]
     fn test_collect_exclude_plugins() -> Result<()> {
-        let components = Components::collect_exclude_plugins()?;
+        let components = Components::collect_exclude_plugins().unwrap();
+        let actual = components
+            .iter()
+            .map(|c| c.name.clone())
+            .collect::<Vec<String>>();
+        let mut expected = [component::FORC, component::FUEL_CORE];
+        expected.sort();
         assert_eq!(components.len(), 2);
-        assert_eq!(
-            components
-                .iter()
-                .map(|c| c.name.clone())
-                .collect::<Vec<String>>(),
-            [component::FORC, component::FUEL_CORE]
-        );
+        assert_eq!(actual, expected);
         Ok(())
     }
 

--- a/src/component.rs
+++ b/src/component.rs
@@ -62,7 +62,7 @@ impl Components {
             })
             .collect();
 
-        main_components.sort_by(|a, b| a.name.cmp(&b.name));
+        main_components.sort_by_key(|c| c.name.clone());
 
         Ok(main_components)
     }
@@ -70,7 +70,7 @@ impl Components {
     pub fn collect_plugins() -> Result<Vec<Plugin>> {
         let components = Self::from_toml(COMPONENTS_TOML)?;
 
-        let plugins = components
+        let mut plugins: Vec<Plugin> = components
             .component
             .keys()
             .filter(|&c| {
@@ -87,6 +87,7 @@ impl Components {
                 }
             })
             .collect();
+        plugins.sort_by_key(|p| p.name.clone());
 
         Ok(plugins)
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -49,19 +49,8 @@ impl Components {
         let mut main_components: Vec<Component> = components
             .component
             .keys()
-            .filter(|&c| {
-                components
-                    .component
-                    .get(c)
-                    .map_or(false, |p| !p.is_plugin.unwrap_or_default())
-            })
-            .map(|c| {
-                components
-                    .component
-                    .get(c)
-                    .cloned()
-                    .unwrap_or_else(|| panic!("Failed to get component '{}' from toml", c))
-            })
+            .map(|c| components.component.get(c).unwrap())
+            .filter_map(|c| c.is_plugin.is_none().then(|| c.clone()))
             .collect();
 
         main_components.sort_by_key(|c| c.name.clone());
@@ -75,21 +64,11 @@ impl Components {
         let mut plugins: Vec<Plugin> = components
             .component
             .keys()
-            .filter(|&c| {
-                components
-                    .component
-                    .get(c)
-                    .map_or(false, |p| p.is_plugin.unwrap_or_default())
-            })
-            .map(|p| {
-                let plugin = components
-                    .component
-                    .get(p)
-                    .unwrap_or_else(|| panic!("Failed to get plugin '{}' from toml", p));
-                Plugin {
-                    name: plugin.name.clone(),
-                    executables: plugin.executables.clone(),
-                }
+            .map(|c| components.component.get(c).unwrap())
+            .filter(|&c| c.is_plugin.unwrap_or_default())
+            .map(|p| Plugin {
+                name: p.name.clone(),
+                executables: p.executables.clone(),
             })
             .collect();
         plugins.sort_by_key(|p| p.name.clone());

--- a/src/component.rs
+++ b/src/component.rs
@@ -60,7 +60,7 @@ impl Components {
                     .component
                     .get(c)
                     .cloned()
-                    .expect(&format!("Failed to get component '{}' from toml", c))
+                    .unwrap_or_else(|| panic!("Failed to get component '{}' from toml", c))
             })
             .collect();
 
@@ -85,7 +85,7 @@ impl Components {
                 let plugin = components
                     .component
                     .get(p)
-                    .expect(&format!("Failed to get plugin '{}' from toml", p));
+                    .unwrap_or_else(|| panic!("Failed to get plugin '{}' from toml", p));
                 Plugin {
                     name: plugin.name.clone(),
                     executables: plugin.executables.clone(),

--- a/src/component.rs
+++ b/src/component.rs
@@ -91,8 +91,9 @@ mod tests {
     use super::*;
 
     const TOML: &str = r#"
-[forc-fmt]
+[component.forc-fmt]
 name = "forc-fmt"
+is_plugin = true
 tarball_prefix = "forc-binaries"
 executables = ["forc-fmt"]
 repository_url = "https://github.com/FuelLabs/sway"
@@ -100,12 +101,35 @@ targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 "#;
 
     #[test]
-    fn test_toml() {
-        assert!(Components::from_toml(TOML).is_ok());
+    fn test_toml() -> Result<()> {
+        let components = Components::from_toml(TOML)?;
+
+        assert_eq!(components.component["forc-fmt"].name, "forc-fmt");
+        assert_eq!(components.component["forc-fmt"].is_plugin, Some(true));
+        assert_eq!(
+            components.component["forc-fmt"].tarball_prefix,
+            "forc-binaries"
+        );
+        assert_eq!(components.component["forc-fmt"].executables, ["forc-fmt"]);
+        assert_eq!(
+            components.component["forc-fmt"].repository_url,
+            "https://github.com/FuelLabs/sway"
+        );
+        assert_eq!(
+            components.component["forc-fmt"].targets,
+            ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+        );
+
+        Ok(())
     }
 
     #[test]
     fn test_collect_plugins() {
         assert!(Components::collect_plugins().is_ok());
+    }
+
+    #[test]
+    fn test_collect_plugin_executables() {
+        assert!(Components::collect_plugin_executables().is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::Result;
 use fuelup::component;
 use fuelup::{fuelup_cli, proxy_cli};
 use std::panic;
@@ -20,16 +20,10 @@ fn run() -> Result<()> {
                 error!("{}", e);
             }
         }
-        Some(n) if component::SUPPORTED_COMPONENTS.contains(&n) => {
+        Some(n) => {
             if let Err(e) = proxy_cli::proxy_run(n) {
                 error!("{}", e);
             }
-        }
-        Some(n) => {
-            bail!(
-                "fuelup invoked with unexpected command or component {:?}",
-                n
-            )
         }
         None => panic!("fuelup does not understand this command"),
     }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -1,6 +1,7 @@
 use crate::{
     channel::{Channel, PackageVersion},
     commands::check::CheckCommand,
+    component::Components,
     config::Config,
     constants::{CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME},
     file::read_file,
@@ -119,22 +120,22 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
 
     bold(|s| writeln!(s, "{}", &toolchain.name));
 
-    for component in [component::FORC, component::FUEL_CORE] {
-        let version = &channel.pkg[component].version;
-        let latest_version = &latest_package_versions[component];
+    for component in Components::collect_exclude_plugins()? {
+        let version = &channel.pkg[&component.name].version;
+        let latest_version = &latest_package_versions[&component.name];
 
-        let component_executable = toolchain.bin_path.join(component);
+        let component_executable = toolchain.bin_path.join(&component.name);
 
         if component_executable.is_file() {
-            bold(|s| write!(s, "  {} - ", &component));
+            bold(|s| write!(s, "  {} - ", &component.name));
             compare_and_print_versions(version, latest_version)?;
         } else {
             print!("  ");
-            bold(|s| write!(s, "{}", &component));
+            bold(|s| write!(s, "{}", &component.name));
             println!(" - not installed");
         }
 
-        if verbose && component == component::FORC {
+        if verbose && component.name == component::FORC {
             for plugin in component::Components::collect_plugins()? {
                 if !plugin.is_main_executable() {
                     bold(|s| writeln!(s, "    - {}", plugin.name));

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -112,18 +112,16 @@ pub fn show() -> Result<()> {
                     } else {
                         println!(" : {}", version);
                     }
-                } else {
-                    if !plugin.is_main_executable() {
-                        bold(|s| writeln!(s, "  - {}", &plugin.name));
-                        for executable in plugin.executables.iter() {
-                            print!("  ");
-                            let plugin_executable = active_toolchain.bin_path.join(&executable);
-                            exec_show_version(&executable, plugin_executable.as_path())?;
-                        }
-                    } else {
-                        let plugin_executable = active_toolchain.bin_path.join(&plugin.name);
-                        exec_show_version(&plugin.name, plugin_executable.as_path())?;
+                } else if !plugin.is_main_executable() {
+                    bold(|s| writeln!(s, "  - {}", &plugin.name));
+                    for executable in plugin.executables.iter() {
+                        print!("  ");
+                        let plugin_executable = active_toolchain.bin_path.join(&executable);
+                        exec_show_version(executable, plugin_executable.as_path())?;
                     }
+                } else {
+                    let plugin_executable = active_toolchain.bin_path.join(&plugin.name);
+                    exec_show_version(&plugin.name, plugin_executable.as_path())?;
                 }
             }
         }

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 
 fn exec_show_version(component: &str, component_executable: &Path) -> Result<()> {
-    bold(|s| write!(s, "  - {}", &component));
     match std::process::Command::new(component_executable)
         .arg("--version")
         .output()
@@ -88,9 +87,9 @@ pub fn show() -> Result<()> {
     };
 
     for component in Components::collect_exclude_plugins()? {
+        bold(|s| write!(s, "  {}", &component.name));
         if let Some(c) = channel.as_ref() {
             let version = &c.pkg[&component.name].version;
-            bold(|s| write!(s, "  {}", &component.name));
             println!(" : {}", version);
         } else {
             let component_executable = active_toolchain.bin_path.join(&component.name);
@@ -99,23 +98,23 @@ pub fn show() -> Result<()> {
 
         if component.name == component::FORC {
             for plugin in Components::collect_plugins()? {
+                bold(|s| write!(s, "    - {}", &plugin.name));
                 if let Some(c) = channel.as_ref() {
-                    bold(|s| write!(s, "  - {}", &plugin.name));
                     let version = &c.pkg[&component.name].version;
 
                     if !plugin.is_main_executable() {
                         println!();
                         for executable in plugin.executables.iter() {
-                            bold(|s| write!(s, "     - {}", &executable));
+                            bold(|s| write!(s, "      - {}", &executable));
                             println!(" : {}", version);
                         }
                     } else {
                         println!(" : {}", version);
                     }
                 } else if !plugin.is_main_executable() {
-                    bold(|s| writeln!(s, "  - {}", &plugin.name));
+                    println!();
                     for executable in plugin.executables.iter() {
-                        print!("  ");
+                        bold(|s| write!(s, "      - {}", &executable));
                         let plugin_executable = active_toolchain.bin_path.join(&executable);
                         exec_show_version(executable, plugin_executable.as_path())?;
                     }

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -87,21 +87,21 @@ pub fn show() -> Result<()> {
         None
     };
 
-    for component in [component::FORC, component::FUEL_CORE] {
+    for component in Components::collect_exclude_plugins()? {
         if let Some(c) = channel.as_ref() {
-            let version = &c.pkg[component].version;
-            bold(|s| write!(s, "  {}", &component));
+            let version = &c.pkg[&component.name].version;
+            bold(|s| write!(s, "  {}", &component.name));
             println!(" : {}", version);
         } else {
-            let component_executable = active_toolchain.bin_path.join(component);
-            exec_show_version(component, component_executable.as_path())?;
+            let component_executable = active_toolchain.bin_path.join(&component.name);
+            exec_show_version(&component.name, component_executable.as_path())?;
         };
 
-        if component == component::FORC {
+        if component.name == component::FORC {
             for plugin in Components::collect_plugins()? {
                 if let Some(c) = channel.as_ref() {
-                    let version = &c.pkg[component].version;
                     bold(|s| write!(s, "  - {}", &plugin.name));
+                    let version = &c.pkg[&component.name].version;
 
                     if !plugin.is_main_executable() {
                         println!();

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
 use semver::Version;
-use std::io::Write;
 use std::str::FromStr;
+use std::{io::Write, path::Path};
 
+use crate::component::Components;
 use crate::{
     channel::Channel,
-    component::{self, SUPPORTED_PLUGINS},
+    component,
     config::Config,
     constants::{CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME},
     file::read_file,
@@ -14,6 +15,37 @@ use crate::{
     target_triple::TargetTriple,
     toolchain::{DistToolchainName, OfficialToolchainDescription, Toolchain},
 };
+
+fn exec_show_version(component: &str, component_executable: &Path) -> Result<()> {
+    bold(|s| write!(s, "  - {}", &component));
+    match std::process::Command::new(component_executable)
+        .arg("--version")
+        .output()
+    {
+        Ok(o) => {
+            let output = String::from_utf8_lossy(&o.stdout).into_owned();
+            match output.split_whitespace().nth(1) {
+                Some(v) => {
+                    let version = Version::parse(v)?;
+                    println!(" : {}", version);
+                }
+                None => {
+                    eprintln!("  {} - Error getting version string", component);
+                }
+            };
+        }
+        Err(e) => {
+            print!(" - ");
+            if component_executable.exists() {
+                println!("execution error - {}", e);
+            } else {
+                println!("not found");
+            }
+        }
+    }
+
+    Ok(())
+}
 
 pub fn show() -> Result<()> {
     bold(|s| write!(s, "Default host: "));
@@ -62,85 +94,35 @@ pub fn show() -> Result<()> {
             println!(" : {}", version);
         } else {
             let component_executable = active_toolchain.bin_path.join(component);
-            match std::process::Command::new(&component_executable)
-                .arg("--version")
-                .output()
-            {
-                Ok(o) => {
-                    let output = String::from_utf8_lossy(&o.stdout).into_owned();
-                    match output.split_whitespace().nth(1) {
-                        Some(v) => {
-                            let version = Version::parse(v)?;
-                            bold(|s| write!(s, "  {}", &component));
-                            println!(" : {}", version);
-                        }
-                        None => {
-                            eprintln!("  {} - Error getting version string", component);
-                        }
-                    };
-                }
-                Err(e) => {
-                    print!("  ");
-                    bold(|s| write!(s, "{}", &component));
-                    print!(" - ");
-                    if component_executable.exists() {
-                        println!("execution error - {}", e);
-                    } else {
-                        println!("not found");
-                    }
-                }
-            }
+            exec_show_version(component, component_executable.as_path())?;
         };
 
         if component == component::FORC {
-            for plugin in SUPPORTED_PLUGINS {
+            for plugin in Components::collect_plugins()? {
                 if let Some(c) = channel.as_ref() {
                     let version = &c.pkg[component].version;
+                    bold(|s| write!(s, "  - {}", &plugin.name));
 
-                    if plugin == &component::FORC_DEPLOY {
-                        bold(|s| writeln!(s, "    - forc-client"));
+                    if !plugin.is_main_executable() {
+                        println!();
+                        for executable in plugin.executables.iter() {
+                            bold(|s| write!(s, "     - {}", &executable));
+                            println!(" : {}", version);
+                        }
+                    } else {
+                        println!(" : {}", version);
                     }
-                    if plugin == &component::FORC_RUN || plugin == &component::FORC_DEPLOY {
-                        print!("  ");
-                    }
-                    bold(|s| write!(s, "    - {}", &plugin));
-                    println!(" : {}", version);
                 } else {
-                    let plugin_executable = active_toolchain.bin_path.join(&plugin);
-                    if plugin == &component::FORC_DEPLOY {
-                        bold(|s| writeln!(s, "    - forc-client"));
-                    }
-                    if plugin == &component::FORC_RUN || plugin == &component::FORC_DEPLOY {
-                        print!("  ");
-                    }
-                    match std::process::Command::new(&plugin_executable)
-                        .arg("--version")
-                        .output()
-                    {
-                        Ok(o) => {
-                            let output = String::from_utf8_lossy(&o.stdout).into_owned();
-                            match output.split_whitespace().nth(1) {
-                                Some(v) => {
-                                    let version = Version::parse(v)?;
-                                    print!("    - ");
-                                    bold(|s| write!(s, "{}", plugin));
-                                    println!(" : {}", version);
-                                }
-                                None => {
-                                    eprintln!("    - {} - Error getting version string", plugin);
-                                }
-                            };
+                    if !plugin.is_main_executable() {
+                        bold(|s| writeln!(s, "  - {}", &plugin.name));
+                        for executable in plugin.executables.iter() {
+                            print!("  ");
+                            let plugin_executable = active_toolchain.bin_path.join(&executable);
+                            exec_show_version(&executable, plugin_executable.as_path())?;
                         }
-                        Err(e) => {
-                            print!("    - ");
-                            bold(|s| write!(s, "{}", plugin));
-                            print!(" - ");
-                            if plugin_executable.exists() {
-                                println!("execution error - {}", e);
-                            } else {
-                                println!("not found");
-                            }
-                        }
+                    } else {
+                        let plugin_executable = active_toolchain.bin_path.join(&plugin.name);
+                        exec_show_version(&plugin.name, plugin_executable.as_path())?;
                     }
                 }
             }

--- a/src/proxy_cli.rs
+++ b/src/proxy_cli.rs
@@ -4,7 +4,7 @@ use std::os::unix::prelude::CommandExt;
 use std::process::{Command, ExitCode, Stdio};
 use std::{env, io};
 
-use crate::component::SUPPORTED_PLUGINS;
+use crate::component::Components;
 use crate::toolchain::Toolchain;
 
 /// Runs forc or fuel-core in proxy mode
@@ -14,7 +14,7 @@ pub fn proxy_run(arg0: &str) -> Result<ExitCode> {
 
     if !cmd_args.is_empty() {
         let plugin = format!("{}-{}", arg0, &cmd_args[0].to_string_lossy());
-        if SUPPORTED_PLUGINS.contains(&plugin.as_str()) {
+        if Components::collect_plugin_executables()?.contains(&plugin) {
             direct_proxy(&plugin, &cmd_args[1..], &toolchain)?;
         }
     }

--- a/src/proxy_cli.rs
+++ b/src/proxy_cli.rs
@@ -4,7 +4,7 @@ use std::os::unix::prelude::CommandExt;
 use std::process::{Command, ExitCode, Stdio};
 use std::{env, io};
 
-use crate::component;
+use crate::component::SUPPORTED_PLUGINS;
 use crate::toolchain::Toolchain;
 
 /// Runs forc or fuel-core in proxy mode
@@ -12,20 +12,18 @@ pub fn proxy_run(arg0: &str) -> Result<ExitCode> {
     let cmd_args: Vec<_> = env::args_os().skip(1).collect();
     let toolchain = Toolchain::from_settings()?;
 
-    if !cmd_args.is_empty()
-        && component::SUPPORTED_PLUGINS
-            .contains(&cmd_args[0].to_str().expect("Failed to parse cmd args"))
-    {
-        let plugin = &format!("{}-{}", arg0, &cmd_args[0].to_string_lossy());
-        direct_proxy(plugin, &cmd_args[1..], toolchain)?;
-    } else {
-        direct_proxy(arg0, &cmd_args, toolchain)?;
+    if !cmd_args.is_empty() {
+        let plugin = format!("{}-{}", arg0, &cmd_args[0].to_string_lossy());
+        if SUPPORTED_PLUGINS.contains(&plugin.as_str()) {
+            direct_proxy(&plugin, &cmd_args[1..], &toolchain)?;
+        }
     }
 
+    direct_proxy(arg0, &cmd_args, &toolchain)?;
     Ok(ExitCode::SUCCESS)
 }
 
-fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: Toolchain) -> io::Result<ExitCode> {
+fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: &Toolchain) -> io::Result<ExitCode> {
     let bin_path = toolchain.bin_path.join(proc_name);
     let mut cmd = Command::new(bin_path);
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use time::Date;
 use tracing::info;
 
-use crate::component::SUPPORTED_PLUGINS;
+use crate::component::Components;
 use crate::constants::DATE_FORMAT;
 use crate::download::{download_file_and_unpack, link_to_fuelup, unpack_bins, DownloadCfg};
 use crate::ops::fuelup_self::self_update;
@@ -213,9 +213,9 @@ impl Toolchain {
                 .with_context(|| format!("failed to remove component '{}'", component))?;
             // If component to remove is 'forc', silently remove forc plugins
             if component == component::FORC {
-                for component in SUPPORTED_PLUGINS {
-                    let component_path = self.bin_path.join(component);
-                    remove_file(component_path)
+                for plugin in Components::collect_plugin_executables()? {
+                    let plugin_path = self.bin_path.join(plugin);
+                    remove_file(plugin_path)
                         .with_context(|| format!("failed to remove component '{}'", component))?;
                 }
             }

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -111,12 +111,12 @@ active toolchain
 ----------------
 my_toolchain (default)
   forc - not found
+    - forc-client
+      - forc-deploy - not found
+      - forc-run - not found
+    - forc-explore - not found
     - forc-fmt - not found
     - forc-lsp - not found
-    - forc-explore - not found
-    - forc-client
-      - forc-run - not found
-      - forc-deploy - not found
   fuel-core - not found
 "#;
         assert!(stdout.contains(expected_stdout));


### PR DESCRIPTION
~_WIP_~

closes #163 

- Adds `Component` and a `Plugin` abstractions to be able to read supported components and plugins from `components.toml` (which will be shared between `fuelup` usage and the CI).
- For now, this PR will only address the `fuelup` side of things - another PR will address the CI side
- In future, any components that have to be added and distributed by fuelup will have to be configured within `components.toml`. By relying on reading this TOML, fuelup will automatically know which component/plugin is supported and be able to download it.

This PR should also partially address #162 - the hope is to be able to specify a new component or plugin in this TOML and have `fuelup` and the CI automatically detect them.