### PR TITLE
install std and core libs on installing `forc`

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Context, Result};
 use std::fmt;
 use std::fs::{remove_dir_all, remove_file};
 use std::path::PathBuf;
+use std::process::Command;
 use std::str::FromStr;
 use time::Date;
 use tracing::info;
@@ -11,7 +12,8 @@ use crate::constants::DATE_FORMAT;
 use crate::download::{download_file_and_unpack, link_to_fuelup, unpack_bins, DownloadCfg};
 use crate::ops::fuelup_self::self_update;
 use crate::path::{
-    ensure_dir_exists, fuelup_bin, fuelup_bin_dir, settings_file, toolchain_bin_dir, toolchain_dir,
+    ensure_dir_exists, fuelup_bin, fuelup_bin_dir, fuelup_dir, settings_file, toolchain_bin_dir,
+    toolchain_dir,
 };
 use crate::settings::SettingsFile;
 use crate::target_triple::TargetTriple;
@@ -200,6 +202,24 @@ impl Toolchain {
 
         if let Ok(downloaded) = unpack_bins(&self.bin_path, &fuelup_bin_dir) {
             link_to_fuelup(downloaded)?;
+
+            // Little hack here to download core and std lib upon installing `forc`
+            if download_cfg.name == component::FORC {
+                let forc_bin_path = self.bin_path.join(component::FORC);
+                let temp_project = tempfile::Builder::new()
+                    .prefix("temp-project")
+                    .tempdir_in(fuelup_dir())?;
+                let temp_project_path = temp_project.path().to_str().unwrap();
+                if Command::new(&forc_bin_path)
+                    .args(["init", "--path", temp_project_path])
+                    .status()
+                    .is_ok()
+                {
+                    Command::new(forc_bin_path)
+                        .args(["check", "--path", temp_project_path])
+                        .output()?;
+                };
+            }
         };
 
         Ok(download_cfg)

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
 use time::Date;
-use tracing::info;
+use tracing::{error, info};
 
 use crate::component::SUPPORTED_PLUGINS;
 use crate::constants::DATE_FORMAT;
@@ -216,12 +216,23 @@ impl Toolchain {
                     .status()
                     .is_ok()
                 {
-                    Command::new(forc_bin_path)
+                    info!("Fetching core forc dependencies");
+                    if Command::new(forc_bin_path)
                         .args(["check", "--path", temp_project_path])
-                        .output()?;
+                        .stdout(std::process::Stdio::null())
+                        .status()
+                        .is_err()
+                    {
+                        error!("Failed to fetch core forc dependencies");
+                    };
                 };
             }
         };
+
+        info!(
+            "Installed {} v{} for toolchain '{}'",
+            download_cfg.name, download_cfg.version, self.name
+        );
 
         Ok(download_cfg)
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -212,6 +212,7 @@ impl Toolchain {
                 let temp_project_path = temp_project.path().to_str().unwrap();
                 if Command::new(&forc_bin_path)
                     .args(["init", "--path", temp_project_path])
+                    .stdout(std::process::Stdio::null())
                     .status()
                     .is_ok()
                 {


### PR DESCRIPTION
closes #7 

This PR ensures that if we install `forc`, `fuelup` creates a temporary project within `.fuelup` using `tempfile` crate, executes `forc init --path` and `forc check --path` on it.

Note that this also executes the `forc` that is within the toolchain, so the right version is fetched.

To test:
1. rm -rf ~/.forc
2. checkout this branch
3. execute `cargo run component add forc`
4. Check that ~/.forc exists
5. Repeat step 1 again and execute `cargo run toolchain install latest`, check step 4 again