### PR TITLE
deprecate package version

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -95,12 +95,12 @@ mod tests {
         assert_eq!(channel.pkg.keys().len(), 2);
         assert!(channel.pkg.contains_key("forc"));
         assert_eq!(
-            channel.pkg["forc"].version.semver,
+            channel.pkg["forc"].version,
             Version::parse("0.17.0").unwrap()
         );
         assert!(channel.pkg.contains_key("fuel-core"));
         assert_eq!(
-            channel.pkg["fuel-core"].version.semver,
+            channel.pkg["fuel-core"].version,
             Version::parse("0.9.4").unwrap()
         );
 
@@ -141,8 +141,8 @@ mod tests {
 
         assert_eq!(cfgs.len(), 2);
         assert_eq!(cfgs[0].name, "forc");
-        assert_eq!(cfgs[0].version.semver, Version::parse("0.17.0").unwrap());
+        assert_eq!(cfgs[0].version, Version::parse("0.17.0").unwrap());
         assert_eq!(cfgs[1].name, "fuel-core");
-        assert_eq!(cfgs[1].version.semver, Version::parse("0.9.4").unwrap());
+        assert_eq!(cfgs[1].version, Version::parse("0.9.4").unwrap());
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -4,14 +4,11 @@ use crate::{
     file::read_file,
     toolchain::{DistToolchainName, OfficialToolchainDescription},
 };
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Result};
 use semver::Version;
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use std::fmt;
-use std::str::FromStr;
 use std::{collections::HashMap, path::PathBuf};
-use time::{macros::format_description, Date};
 use toml_edit::de;
 
 pub const LATEST: &str = "latest";
@@ -33,51 +30,7 @@ pub struct Channel {
 #[derive(Debug, Deserialize)]
 pub struct Package {
     pub target: HashMap<String, HashedBinary>,
-    #[serde(deserialize_with = "package_version_from_str")]
-    pub version: PackageVersion,
-}
-
-#[derive(Debug, PartialEq, Eq, Ord, PartialOrd, Clone)]
-pub struct PackageVersion {
-    pub semver: Version,
-    pub date: Option<Date>,
-}
-
-fn package_version_from_str<'de, D>(deserializer: D) -> Result<PackageVersion, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    s.parse().map_err(serde::de::Error::custom)
-}
-
-impl FromStr for PackageVersion {
-    type Err = anyhow::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut elems = s.split(' ');
-        let semver_str = elems
-            .next()
-            .ok_or_else(|| anyhow!("package version string is empty"))?;
-        let date_str = elems.next();
-        let semver = semver::Version::parse(semver_str).context("failed to parse semver")?;
-        let date = match date_str {
-            None => None,
-            Some(s) => {
-                let date = Date::parse(s, format_description!("([year]-[month]-[day])"))
-                    .context("specified date is invalid")?;
-                Some(date)
-            }
-        };
-        Ok(PackageVersion { semver, date })
-    }
-}
-impl fmt::Display for PackageVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.date {
-            Some(d) => write!(f, "{} ({})", self.semver, d),
-            None => write!(f, "{}", self.semver),
-        }
-    }
+    pub version: Version,
 }
 
 impl Channel {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -140,12 +140,12 @@ mod tests {
         assert_eq!(channel.pkg.keys().len(), 2);
         assert!(channel.pkg.contains_key("forc"));
         assert_eq!(
-            channel.pkg["forc"].version.semver,
+            channel.pkg["forc"].version,
             Version::parse("0.24.3+nightly.20220915.0b69f4d4").unwrap()
         );
         assert!(channel.pkg.contains_key("fuel-core"));
         assert_eq!(
-            channel.pkg["fuel-core"].version.semver,
+            channel.pkg["fuel-core"].version,
             Version::parse("0.10.1+nightly.20220915.bd5901f").unwrap()
         );
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -87,7 +87,7 @@ impl DownloadCfg {
 
 pub fn tarball_name(name: &str, version: &Version, target: &TargetTriple) -> Result<String> {
     match name {
-        component::FORC => Ok(format!("forc-binaries-{}.tar.gz", version)),
+        component::FORC => Ok(format!("forc-binaries-{}.tar.gz", target)),
         component::FUEL_CORE => Ok(format!("fuel-core-{}-{}.tar.gz", version, target)),
         component::FUELUP => Ok(format!("fuelup-{}-{}.tar.gz", version, target)),
         _ => bail!("Unrecognized component: {}", name),

--- a/src/download.rs
+++ b/src/download.rs
@@ -15,7 +15,6 @@ use tracing::warn;
 use tracing::{error, info};
 
 use crate::channel::Package;
-use crate::channel::PackageVersion;
 use crate::component;
 use crate::constants::{
     FUELUP_RELEASE_DOWNLOAD_URL, FUELUP_REPO, FUEL_CORE_RELEASE_DOWNLOAD_URL, FUEL_CORE_REPO,
@@ -36,22 +35,19 @@ struct LatestReleaseApiResponse {
 pub struct DownloadCfg {
     pub name: String,
     pub target: TargetTriple,
-    pub version: PackageVersion,
+    pub version: Version,
     tarball_name: String,
     tarball_url: String,
     hash: Option<String>,
 }
 
 impl DownloadCfg {
-    pub fn new(name: &str, target: TargetTriple, version: Option<PackageVersion>) -> Result<Self> {
+    pub fn new(name: &str, target: TargetTriple, version: Option<Version>) -> Result<Self> {
         let version = match version {
             Some(version) => version,
-            None => PackageVersion {
-                semver: get_latest_tag(name).map_err(|e| {
-                    anyhow!("Error getting latest tag for component: {:?}: {}", name, e)
-                })?,
-                date: None,
-            },
+            None => get_latest_tag(name).map_err(|e| {
+                anyhow!("Error getting latest tag for component: {:?}: {}", name, e)
+            })?,
         };
 
         let release_url = match name {
@@ -61,7 +57,7 @@ impl DownloadCfg {
             _ => bail!("Unrecognized component: {}", name),
         };
         let tarball_name = tarball_name(name, &version, &target)?;
-        let tarball_url = format!("{}/v{}/{}", &release_url, &version.semver, &tarball_name);
+        let tarball_url = format!("{}/v{}/{}", &release_url, &version, &tarball_name);
 
         Ok(Self {
             name: name.to_string(),
@@ -89,24 +85,11 @@ impl DownloadCfg {
     }
 }
 
-pub fn tarball_name(name: &str, version: &PackageVersion, target: &TargetTriple) -> Result<String> {
-    let version_string = if let Some(date) = version.date {
-        version.semver.to_string() + "-" + &date.to_string()
-    } else {
-        version.semver.to_string()
-    };
-
+pub fn tarball_name(name: &str, version: &Version, target: &TargetTriple) -> Result<String> {
     match name {
-        component::FORC => {
-            let postfix = if version.date.is_some() {
-                version_string + "-" + &target.to_string()
-            } else {
-                target.to_string()
-            };
-            Ok(format!("forc-binaries-{}.tar.gz", postfix))
-        }
-        component::FUEL_CORE => Ok(format!("fuel-core-{}-{}.tar.gz", version_string, target)),
-        component::FUELUP => Ok(format!("fuelup-{}-{}.tar.gz", version_string, target)),
+        component::FORC => Ok(format!("forc-binaries-{}.tar.gz", version)),
+        component::FUEL_CORE => Ok(format!("fuel-core-{}-{}.tar.gz", version, target)),
+        component::FUELUP => Ok(format!("fuelup-{}-{}.tar.gz", version, target)),
         _ => bail!("Unrecognized component: {}", name),
     }
 }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -66,10 +66,10 @@ fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version
                     print!("    - ");
                     bold(|s| write!(s, "{}", plugin));
                     print!(" - ");
-                    compare_and_print_versions(&version, latest_version);
+                    compare_and_print_versions(&version, latest_version)?;
                 }
                 None => {
-                    eprintln!("    - {} - Error getting version string", plugin);
+                    error!("    - {} - Error getting version string", plugin);
                 }
             };
         }
@@ -118,6 +118,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
 
     for component in Components::collect_exclude_plugins()? {
         let component_executable = toolchain.bin_path.join(&component.name);
+        let latest_version = &latest_package_versions[&component.name];
         match Command::new(&component_executable)
             .arg("--version")
             .output()
@@ -128,7 +129,8 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                 match output.split_whitespace().nth(1) {
                     Some(v) => {
                         let version = Version::parse(v)?;
-                        info!("{} : {}", &component.name, version);
+                        bold(|s| write!(s, "  {} - ", &component.name));
+                        compare_and_print_versions(&version, latest_version)?;
                     }
                     None => {
                         error!("  {} - Error getting version string", &component.name);

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -19,7 +19,7 @@ use std::{
 use std::{collections::HashMap, process::Command};
 use tempfile::tempdir_in;
 use termcolor::Color;
-use tracing::error;
+use tracing::{error, info};
 
 use crate::{component, download::DownloadCfg};
 
@@ -53,21 +53,36 @@ fn compare_and_print_versions(current_version: &Version, latest_version: &Versio
     Ok(())
 }
 
-fn check_plugin(
-    plugin_executable: &Path,
-    plugin: &str,
-    current_version: &Version,
-    latest_version: &Version,
-) -> Result<()> {
-    if plugin_executable.is_file() {
-        print!("    - ");
-        bold(|s| write!(s, "{}", plugin));
-        print!(" - ");
-        compare_and_print_versions(current_version, latest_version)?;
-    } else {
-        print!("  ");
-        bold(|s| write!(s, "{}", &plugin));
-        println!(" - not installed");
+fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version) -> Result<()> {
+    match std::process::Command::new(&plugin_executable)
+        .arg("--version")
+        .output()
+    {
+        Ok(o) => {
+            let output = String::from_utf8_lossy(&o.stdout).into_owned();
+            match output.split_whitespace().nth(1) {
+                Some(v) => {
+                    let version = Version::parse(v)?;
+                    print!("    - ");
+                    bold(|s| write!(s, "{}", plugin));
+                    print!(" - ");
+                    compare_and_print_versions(&version, latest_version);
+                }
+                None => {
+                    eprintln!("    - {} - Error getting version string", plugin);
+                }
+            };
+        }
+        Err(e) => {
+            print!("    - ");
+            bold(|s| write!(s, "{}", plugin));
+            print!(" - ");
+            if plugin_executable.exists() {
+                println!("execution error - {}", e);
+            } else {
+                println!("not found");
+            }
+        }
     }
     Ok(())
 }
@@ -103,27 +118,26 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
 
     for component in Components::collect_exclude_plugins()? {
         let component_executable = toolchain.bin_path.join(&component.name);
-        let version = match Command::new(&component_executable)
+        match Command::new(&component_executable)
             .arg("--version")
             .output()
         {
             Ok(o) => {
                 let output = String::from_utf8_lossy(&o.stdout).into_owned();
-                println!("{:?}", o);
-                Version::parse(&output)?
+
+                match output.split_whitespace().nth(1) {
+                    Some(v) => {
+                        let version = Version::parse(v)?;
+                        info!("{} : {}", &component.name, version);
+                    }
+                    None => {
+                        error!("  {} - Error getting version string", &component.name);
+                    }
+                }
             }
             Err(_) => bail!(""),
         };
         let latest_version = &latest_package_versions[&component.name];
-
-        if component_executable.is_file() {
-            bold(|s| write!(s, "  {} - ", &component.name));
-            compare_and_print_versions(&version, latest_version)?;
-        } else {
-            print!("  ");
-            bold(|s| write!(s, "{}", &component.name));
-            println!(" - not installed");
-        }
 
         if verbose && component.name == component::FORC {
             for plugin in component::Components::collect_plugins()? {
@@ -135,11 +149,13 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                     let plugin_executable = toolchain.bin_path.join(executable);
 
                     let mut plugin_name = &plugin.name;
+
                     if !plugin.is_main_executable() {
                         print!("  ");
                         plugin_name = &plugin.executables[index];
                     }
-                    check_plugin(&plugin_executable, plugin_name, &version, latest_version)?;
+
+                    check_plugin(&plugin_executable, plugin_name, latest_version)?;
                 }
             }
         }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -1,44 +1,39 @@
 use crate::{
-    channel::{Channel, PackageVersion},
+    channel::Channel,
     commands::check::CheckCommand,
     component::Components,
     config::Config,
-    constants::{CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME},
-    file::read_file,
     fmt::{bold, colored_bold},
     path::fuelup_dir,
     target_triple::TargetTriple,
-    toolchain::{DistToolchainName, OfficialToolchainDescription, Toolchain},
+    toolchain::{OfficialToolchainDescription, Toolchain},
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use semver::Version;
-use std::collections::HashMap;
 use std::io::Write;
 use std::str::FromStr;
 use std::{
     cmp::Ordering::{Equal, Greater, Less},
     path::Path,
 };
+use std::{collections::HashMap, process::Command};
 use tempfile::tempdir_in;
 use termcolor::Color;
 use tracing::error;
 
 use crate::{component, download::DownloadCfg};
 
-fn collect_package_versions(channel: Channel) -> HashMap<String, PackageVersion> {
-    let mut latest_versions: HashMap<String, PackageVersion> = HashMap::new();
+fn collect_package_versions(channel: Channel) -> HashMap<String, Version> {
+    let mut latest_versions: HashMap<String, Version> = HashMap::new();
 
     for (name, package) in channel.pkg.into_iter() {
-        latest_versions.insert(name, package.version.clone());
+        latest_versions.insert(name, package.version);
     }
 
     latest_versions
 }
 
-fn compare_and_print_versions(
-    current_version: &PackageVersion,
-    latest_version: &PackageVersion,
-) -> Result<()> {
+fn compare_and_print_versions(current_version: &Version, latest_version: &Version) -> Result<()> {
     match current_version.cmp(latest_version) {
         Less => {
             colored_bold(Color::Yellow, |s| write!(s, "Update available"));
@@ -61,8 +56,8 @@ fn compare_and_print_versions(
 fn check_plugin(
     plugin_executable: &Path,
     plugin: &str,
-    current_version: &PackageVersion,
-    latest_version: &PackageVersion,
+    current_version: &Version,
+    latest_version: &Version,
 ) -> Result<()> {
     if plugin_executable.is_file() {
         print!("    - ");
@@ -86,13 +81,7 @@ fn check_fuelup() -> Result<()> {
         None,
     ) {
         bold(|s| write!(s, "{} - ", component::FUELUP));
-        compare_and_print_versions(
-            &PackageVersion {
-                semver: fuelup_version,
-                date: None,
-            },
-            &fuelup_download_cfg.version,
-        )?;
+        compare_and_print_versions(&fuelup_version, &fuelup_download_cfg.version)?;
     } else {
         error!("Failed to create DownloadCfg for component 'fuelup'; skipping check for 'fuelup'");
     }
@@ -110,25 +99,26 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
 
     let toolchain = Toolchain::new(toolchain)?;
 
-    let channel_file_name = match description.name {
-        DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
-        DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,
-    };
-    let toml_path = toolchain.path.join(channel_file_name);
-    let toml = read_file("channel", &toml_path)?;
-    let channel = Channel::from_toml(&toml)?;
-
     bold(|s| writeln!(s, "{}", &toolchain.name));
 
     for component in Components::collect_exclude_plugins()? {
-        let version = &channel.pkg[&component.name].version;
-        let latest_version = &latest_package_versions[&component.name];
-
         let component_executable = toolchain.bin_path.join(&component.name);
+        let version = match Command::new(&component_executable)
+            .arg("--version")
+            .output()
+        {
+            Ok(o) => {
+                let output = String::from_utf8_lossy(&o.stdout).into_owned();
+                println!("{:?}", o);
+                Version::parse(&output)?
+            }
+            Err(_) => bail!(""),
+        };
+        let latest_version = &latest_package_versions[&component.name];
 
         if component_executable.is_file() {
             bold(|s| write!(s, "  {} - ", &component.name));
-            compare_and_print_versions(version, latest_version)?;
+            compare_and_print_versions(&version, latest_version)?;
         } else {
             print!("  ");
             bold(|s| write!(s, "{}", &component.name));
@@ -149,7 +139,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                         print!("  ");
                         plugin_name = &plugin.executables[index];
                     }
-                    check_plugin(&plugin_executable, plugin_name, version, latest_version)?;
+                    check_plugin(&plugin_executable, plugin_name, &version, latest_version)?;
                 }
             }
         }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -19,7 +19,7 @@ use std::{
 use std::{collections::HashMap, process::Command};
 use tempfile::tempdir_in;
 use termcolor::Color;
-use tracing::{error, info};
+use tracing::error;
 
 use crate::{component, download::DownloadCfg};
 

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -5,8 +5,8 @@ use semver::Version;
 use tracing::info;
 
 use crate::{
-    channel::PackageVersion, commands::component::AddCommand, download::DownloadCfg,
-    target_triple::TargetTriple, toolchain::Toolchain,
+    commands::component::AddCommand, download::DownloadCfg, target_triple::TargetTriple,
+    toolchain::Toolchain,
 };
 
 pub fn add(command: AddCommand) -> Result<()> {
@@ -32,24 +32,18 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
         );
     }
 
-    let (component, version): (&str, Option<PackageVersion>) =
+    let (component, version): (&str, Option<Version>) =
         match maybe_versioned_component.split_once('@') {
             Some(t) => {
                 let v = match Version::from_str(t.1) {
-                    Ok(v) => v,
+                    Ok(v) => Some(v),
                     Err(e) => bail!(
                         "Invalid version input '{}' while adding component: {}",
                         t.1,
                         e
                     ),
                 };
-                (
-                    t.0,
-                    Some(PackageVersion {
-                        semver: v,
-                        date: None,
-                    }),
-                )
+                (t.0, v)
             }
             None => (&maybe_versioned_component, None),
         };


### PR DESCRIPTION
With updates to nightlies showing dates and hashes within the build metadata, there isn't a need for `PackageVersion` anymore, and we can compare versions solely based on itself:

![Screenshot 2022-09-16 at 12 30 02 PM](https://user-images.githubusercontent.com/25565268/190556968-448205c7-7b1a-4442-8dd7-119b5b88bbb6.png)
