### PR TITLE
update `nightly` publishing script to support build metadata

### DIFF
--- a/.github/workflows/scripts/append_package_to_channel.sh
+++ b/.github/workflows/scripts/append_package_to_channel.sh
@@ -43,11 +43,10 @@ create_pkg_in_channel() {
 
     if [ "${2}" = "nightly" ]; then
         _repo="sway-nightly-binaries"
-        semver="$(curl -s https://api.github.com/repos/FuelLabs/${_repo}/releases | grep "tag_name" | grep "nightly-${date}" | grep "${_tarball_prefix}" | head -n 1 | cut -d "-" -f3)"
-        version="${semver}-nightly (${date})"
-        version_url_friendly="${semver}-nightly-${date}"
-        _tarball_prefix+="-${version_url_friendly}"
-        tag="${_tarball_prefix}"
+        version="$(curl -s https://api.github.com/repos/FuelLabs/${_repo}/releases | grep "tag_name" | grep "nightly.${date}" | grep "${_tarball_prefix}" | head -n 1 | cut -d "-" -f3- | cut -d "\"" -f1)"
+        _tarball_prefix+="-${version}"
+	# Replace '+' within string with '%2B' to be URL friendly
+	tag=$(echo "${_tarball_prefix}" | sed -r "s/\+/\%2B/g")
     fi
 
     # We need to recreate channel-fuel-latest.toml, generating new URLs and sha256 hashes for the download links.

--- a/.github/workflows/scripts/append_package_to_channel.sh
+++ b/.github/workflows/scripts/append_package_to_channel.sh
@@ -45,8 +45,8 @@ create_pkg_in_channel() {
         _repo="sway-nightly-binaries"
         version="$(curl -s https://api.github.com/repos/FuelLabs/${_repo}/releases | grep "tag_name" | grep "nightly.${date}" | grep "${_tarball_prefix}" | head -n 1 | cut -d "-" -f3- | cut -d "\"" -f1)"
         _tarball_prefix+="-${version}"
-	# Replace '+' within string with '%2B' to be URL friendly
-	tag=$(echo "${_tarball_prefix}" | sed -r "s/\+/\%2B/g")
+        # Replace '+' within string with '%2B' to be URL friendly
+        tag=$(echo "${_tarball_prefix}" | sed -r "s/\+/\%2B/g")
     fi
 
     # We need to recreate channel-fuel-latest.toml, generating new URLs and sha256 hashes for the download links.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -177,6 +177,51 @@ mod tests {
     }
 
     #[test]
+    fn channel_from_toml_nightly() {
+        let channel_path = std::env::current_dir()
+            .unwrap()
+            .join("tests/channel-fuel-nightly-example.toml");
+        let channel_file = read_file("channel-fuel-nightly-example", &channel_path).unwrap();
+        let channel = Channel::from_toml(&channel_file).unwrap();
+
+        assert_eq!(channel.pkg.keys().len(), 2);
+        assert!(channel.pkg.contains_key("forc"));
+        assert_eq!(
+            channel.pkg["forc"].version.semver,
+            Version::parse("0.24.3+nightly.2022-09-15.0b69f4d4").unwrap()
+        );
+        assert!(channel.pkg.contains_key("fuel-core"));
+        assert_eq!(
+            channel.pkg["fuel-core"].version.semver,
+            Version::parse("0.10.1+").unwrap()
+        );
+
+        let targets = &channel.pkg["forc"].target;
+        assert_eq!(targets.len(), 4);
+
+        for target in targets.keys() {
+            assert!(!targets[target].url.is_empty());
+            assert!(!targets[target].hash.is_empty());
+        }
+        assert!(targets.contains_key("darwin_amd64"));
+        assert!(targets.contains_key("darwin_arm64"));
+        assert!(targets.contains_key("linux_amd64"));
+        assert!(targets.contains_key("linux_arm64"));
+
+        let targets = &channel.pkg["fuel-core"].target;
+        assert_eq!(targets.len(), 4);
+
+        for target in targets.keys() {
+            assert!(!targets[target].url.is_empty());
+            assert!(!targets[target].hash.is_empty());
+        }
+        assert!(targets.contains_key("aarch64-apple-darwin"));
+        assert!(targets.contains_key("aarch64-unknown-linux-gnu"));
+        assert!(targets.contains_key("x86_64-apple-darwin"));
+        assert!(targets.contains_key("x86_64-unknown-linux-gnu"));
+    }
+
+    #[test]
     fn download_cfgs_from_channel() {
         let channel_path = std::env::current_dir()
             .unwrap()

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -188,12 +188,12 @@ mod tests {
         assert!(channel.pkg.contains_key("forc"));
         assert_eq!(
             channel.pkg["forc"].version.semver,
-            Version::parse("0.24.3+nightly.2022-09-15.0b69f4d4").unwrap()
+            Version::parse("0.24.3+nightly.20220915.0b69f4d4").unwrap()
         );
         assert!(channel.pkg.contains_key("fuel-core"));
         assert_eq!(
             channel.pkg["fuel-core"].version.semver,
-            Version::parse("0.10.1+").unwrap()
+            Version::parse("0.10.1+nightly.20220915.bd5901f").unwrap()
         );
 
         let targets = &channel.pkg["forc"].target;

--- a/tests/channel-fuel-nightly-example.toml
+++ b/tests/channel-fuel-nightly-example.toml
@@ -1,0 +1,35 @@
+[pkg.forc]
+version = "0.24.3+nightly.2022-09-15.0b69f4d4"
+[pkg.forc.target.darwin_amd64]
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.2022-09-15.0b69f4d4-darwin_amd64.tar.gz"
+hash = "7781989c3a8cf01628d1de3d113b4904e5d70eedbed7b2d8a10bb9c1670bb7d6"
+
+[pkg.forc.target.darwin_arm64]
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.2022-09-15.0b69f4d4-darwin_arm64.tar.gz"
+hash = "d4ca70821da34164ccee973ab885cf99599476c06858f6e7bceb1bd086297866"
+
+[pkg.forc.target.linux_amd64]
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.2022-09-15.0b69f4d4-linux_amd64.tar.gz"
+hash = "e81dc4df677d30f3b8953a069fb963c61d9d12d502ce82b53884342c611d5408"
+
+[pkg.forc.target.linux_arm64]
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.2022-09-15.0b69f4d4-linux_arm64.tar.gz"
+hash = "d6346052a7fb9626deb6c09856ba5b36c67f0b2c6b4d26dee84c8d7c30eece93"
+
+[pkg.fuel-core]
+version = "0.10.1+nightly.2022-09-15.bd5901f"
+[pkg.fuel-core.target.aarch64-apple-darwin]
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.2022-09-15.bd5901f-aarch64-apple-darwin.tar.gz"
+hash = "a0433c009ac6886f4a6708147f019aff3c1965539c633a60a6e084b765874097"
+
+[pkg.fuel-core.target.aarch64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.2022-09-15.bd5901f-aarch64-unknown-linux-gnu.tar.gz"
+hash = "143e8312d39995038b57d86fab5bdfcb1b0808615bc0605fd85c11797e7a2e0b"
+
+[pkg.fuel-core.target.x86_64-apple-darwin]
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.2022-09-15.bd5901f-x86_64-apple-darwin.tar.gz"
+hash = "dd0e16bb3e02f3f5fac037ca22c1344224448c24bb07a44dffc7f23134ab222f"
+
+[pkg.fuel-core.target.x86_64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.2022-09-15.bd5901f-x86_64-unknown-linux-gnu.tar.gz"
+hash = "503c3e8cf406c62e6fb83fc209e48faf1f9afeb0c12e09734fc16164ebfc486c"

--- a/tests/channel-fuel-nightly-example.toml
+++ b/tests/channel-fuel-nightly-example.toml
@@ -1,35 +1,35 @@
 [pkg.forc]
-version = "0.24.3+nightly.2022-09-15.0b69f4d4"
+version = "0.24.3+nightly.20220915.0b69f4d4"
 [pkg.forc.target.darwin_amd64]
-url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.2022-09-15.0b69f4d4-darwin_amd64.tar.gz"
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.20220915.0b69f4d4-darwin_amd64.tar.gz"
 hash = "7781989c3a8cf01628d1de3d113b4904e5d70eedbed7b2d8a10bb9c1670bb7d6"
 
 [pkg.forc.target.darwin_arm64]
-url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.2022-09-15.0b69f4d4-darwin_arm64.tar.gz"
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.20220915.0b69f4d4-darwin_arm64.tar.gz"
 hash = "d4ca70821da34164ccee973ab885cf99599476c06858f6e7bceb1bd086297866"
 
 [pkg.forc.target.linux_amd64]
-url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.2022-09-15.0b69f4d4-linux_amd64.tar.gz"
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.20220915.0b69f4d4-linux_amd64.tar.gz"
 hash = "e81dc4df677d30f3b8953a069fb963c61d9d12d502ce82b53884342c611d5408"
 
 [pkg.forc.target.linux_arm64]
-url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.2022-09-15.0b69f4d4-linux_arm64.tar.gz"
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/forc-binaries-0.24.3%2Bnightly.2022-09-15.0b69f4d4/forc-binaries-0.24.3+nightly.20220915.0b69f4d4-linux_arm64.tar.gz"
 hash = "d6346052a7fb9626deb6c09856ba5b36c67f0b2c6b4d26dee84c8d7c30eece93"
 
 [pkg.fuel-core]
-version = "0.10.1+nightly.2022-09-15.bd5901f"
+version = "0.10.1+nightly.20220915.bd5901f"
 [pkg.fuel-core.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.2022-09-15.bd5901f-aarch64-apple-darwin.tar.gz"
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.20220915.bd5901f-aarch64-apple-darwin.tar.gz"
 hash = "a0433c009ac6886f4a6708147f019aff3c1965539c633a60a6e084b765874097"
 
 [pkg.fuel-core.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.2022-09-15.bd5901f-aarch64-unknown-linux-gnu.tar.gz"
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.20220915.bd5901f-aarch64-unknown-linux-gnu.tar.gz"
 hash = "143e8312d39995038b57d86fab5bdfcb1b0808615bc0605fd85c11797e7a2e0b"
 
 [pkg.fuel-core.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.2022-09-15.bd5901f-x86_64-apple-darwin.tar.gz"
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.20220915.bd5901f-x86_64-apple-darwin.tar.gz"
 hash = "dd0e16bb3e02f3f5fac037ca22c1344224448c24bb07a44dffc7f23134ab222f"
 
 [pkg.fuel-core.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.2022-09-15.bd5901f-x86_64-unknown-linux-gnu.tar.gz"
+url = "https://github.com/FuelLabs/sway-nightly-binaries/releases/download/fuel-core-0.10.1%2Bnightly.2022-09-15.bd5901f/fuel-core-0.10.1+nightly.20220915.bd5901f-x86_64-unknown-linux-gnu.tar.gz"
 hash = "503c3e8cf406c62e6fb83fc209e48faf1f9afeb0c12e09734fc16164ebfc486c"


### PR DESCRIPTION
Closes #190 

The updated CI workflow in `sway-nightly-binaries` now append build metadata onto the version using [`cargo set-version`](https://github.com/killercup/cargo-edit#cargo-set-version).

Example version with build metadata:

`0.24.3+nightly.20220915-abcdefg`

This way, we can have the date/hash of the binaries within the build metadata to properly support some functions of fuelup (eg. `fuelup show`, `fuelup check`), and in future, when we allow users to install specific dated versions of nightly built components, instead of having to have an ugly pre-compile build script in each crate that we plan to distribute as a clap app, eg. https://github.com/FuelLabs/sway/pull/2772 and https://github.com/FuelLabs/fuel-core/pull/621
