### PR TITLE
fix: date format when publishing

### DIFF
--- a/.github/workflows/scripts/append_package_to_channel.sh
+++ b/.github/workflows/scripts/append_package_to_channel.sh
@@ -21,7 +21,7 @@ create_new_pkg() {
 create_pkg_in_channel() {
     CHANNEL_TOML_NAME=$3
     version=$2
-    date="$(date +'%Y-%m-%d')"
+    date="$(date +'%Y%m%d')"
     tag="v${2}"
     case "${1}" in
         "forc")


### PR DESCRIPTION
after #189, date format for nightlies is no longer `YYYY-MM-DD` but `YYYYMMDD`. Missed this change in the script.