### PR TITLE
bump v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
key updates:

* fix proxy_cli interaction; deprecate SUPPORTED_COMPONENTS by @bingcicle in https://github.com/FuelLabs/fuelup/pull/178
* install std and core libs on installing `forc` by @bingcicle in https://github.com/FuelLabs/fuelup/pull/183
* feat: auto detect http proxy setting. by @calldata in https://github.com/FuelLabs/fuelup/pull/187
* components toml by @bingcicle in https://github.com/FuelLabs/fuelup/pull/181
* deprecate package version by @bingcicle in https://github.com/FuelLabs/fuelup/pull/188