### PR TITLE
ci: publish forc-client in CI

### DIFF
--- a/.github/workflows/publish-nightly-channel.yml
+++ b/.github/workflows/publish-nightly-channel.yml
@@ -30,6 +30,7 @@ jobs:
             echo -e "published_by = \"https://github.com/FuelLabs/fuelup/actions/runs/${GITHUB_RUN_ID}\"\n" >> $CHANNEL_TOML
 
             ./.github/workflows/scripts/append_package_to_channel.sh forc nightly $CHANNEL_TOML
+            ./.github/workflows/scripts/append_package_to_channel.sh forc-client nightly $CHANNEL_TOML
             ./.github/workflows/scripts/append_package_to_channel.sh fuel-core nightly $CHANNEL_TOML
 
             # Remove extra newline at the end

--- a/.github/workflows/scripts/append_package_to_channel.sh
+++ b/.github/workflows/scripts/append_package_to_channel.sh
@@ -29,6 +29,15 @@ create_pkg_in_channel() {
             _repo="sway"
             _tarball_prefix="forc-binaries"
             ;;
+        "forc-client")
+            _targets=("aarch64-apple-darwin" "aarch64-unknown-linux-gnu" "x86_64-apple-darwin" "x86_64-unknown-linux-gnu")
+            _repo="forc-client"
+            _tarball_prefix="forc-client"
+
+            if [ "${2}" != "nightly" ]; then
+                _tarball_prefix+="-${version}"
+            fi
+            ;;
         "fuel-core")
             _targets=("aarch64-apple-darwin" "aarch64-unknown-linux-gnu" "x86_64-apple-darwin" "x86_64-unknown-linux-gnu")
             _repo="fuel-core"

--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -155,6 +155,7 @@ jobs:
             echo -e "published_by = \"https://github.com/FuelLabs/fuelup/actions/runs/${GITHUB_RUN_ID}\"\n" >> $CHANNEL_TOML
 
             ./.github/workflows/scripts/append_package_to_channel.sh forc ${{ env.LATEST_COMPATIBLE_FORC }} $CHANNEL_TOML
+            ./.github/workflows/scripts/append_package_to_channel.sh forc-client 0.24.4 $CHANNEL_TOML
             ./.github/workflows/scripts/append_package_to_channel.sh fuel-core ${{ env.LATEST_COMPATIBLE_FUEL_CORE }} $CHANNEL_TOML
 
             # Remove extra newline at the end


### PR DESCRIPTION
Closes #185 

Add `forc-client` to channel within the CI.

Note that in the `latest` channel, we're hardcoding versions for now. 

We probably want the same `forc-client` that is used to run tests here, since `forc-client` is fetched as a dep in the tests. However, forc-client version is also fixed there. Perhaps we also need some sort of detection mechanism to run tests everytime a new forc-client is released.
