### PR TITLE
fix forc-client tests

### DIFF
--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -254,6 +254,7 @@ fn fuelup_component_add() -> Result<()> {
         let _ = cfg.fuelup(&["component", "add", "forc"]);
         expect_files_exist(&cfg.toolchain_bin_dir("my_toolchain"), FORC_BINS);
 
+        let _ = cfg.fuelup(&["component", "add", "forc-client"]);
         let _ = cfg.fuelup(&["component", "add", "fuel-core@0.9.5"]);
         expect_files_exist(&cfg.toolchain_bin_dir("my_toolchain"), ALL_BINS);
     })?;

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -24,14 +24,7 @@ pub struct TestOutput {
     pub status: ExitStatus,
 }
 
-pub const FORC_BINS: &[&str] = &[
-    "forc",
-    "forc-deploy",
-    "forc-explore",
-    "forc-fmt",
-    "forc-lsp",
-    "forc-run",
-];
+pub const FORC_BINS: &[&str] = &["forc", "forc-explore", "forc-fmt", "forc-lsp"];
 
 pub static ALL_BINS: &[&str] = &[
     "forc",


### PR DESCRIPTION
fix some tests related to the recent addition of forc-client - more specifically the `component_add` test expected `forc-deploy` and `forc-run` to still come with `forc`.