### PR TITLE
fix: update component remove

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -24,6 +24,7 @@ pub struct Component {
     pub executables: Vec<String>,
     pub repository_url: String,
     pub targets: Vec<String>,
+    pub publish: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -42,6 +43,30 @@ impl Components {
     pub fn from_toml(toml: &str) -> Result<Self> {
         let components: Components = de::from_str(toml)?;
         Ok(components)
+    }
+
+    pub fn collect() -> Result<Components> {
+        let components = Self::from_toml(COMPONENTS_TOML)?;
+        Ok(components)
+    }
+
+    pub fn collect_publishables() -> Result<Vec<Component>> {
+        let components = Self::from_toml(COMPONENTS_TOML)?;
+
+        let mut publishables: Vec<Component> = components
+            .component
+            .keys()
+            .map(|c| {
+                components
+                    .component
+                    .get(c)
+                    .expect("Failed to parse components.toml")
+            })
+            .filter_map(|c| c.publish.and_then(|_| Some(c.clone())))
+            .collect();
+
+        publishables.sort_by_key(|c| c.name.clone());
+        Ok(publishables)
     }
 
     pub fn collect_exclude_plugins() -> Result<Vec<Component>> {

--- a/components.toml
+++ b/components.toml
@@ -1,9 +1,10 @@
 [component.forc]
 name = "forc"
 tarball_prefix = "forc-binaries"
-executables = ["forc"]
+executables = ["forc", "forc-fmt", "forc-lsp", "forc-explore"]
 repository_url = "https://github.com/FuelLabs/sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+publish = true
 
 [component.forc-fmt]
 name = "forc-fmt"
@@ -36,6 +37,7 @@ is_plugin = true
 executables = ["forc-deploy", "forc-run"]
 repository_url = "https://github.com/FuelLabs/sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+publish = true
 
 [component.fuel-core]
 name = "fuel-core"
@@ -43,3 +45,4 @@ tarball_prefix = "fuel-core"
 executables = ["fuel-core"]
 repository_url = "https://github.com/FuelLabs/fuel-core"
 targets = [ "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin" ]
+publish = true

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -41,7 +41,7 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
             None => (&maybe_versioned_component, None),
         };
 
-    if toolchain.has_component(&component) {
+    if toolchain.has_component(component) {
         info!(
             "{} already exists in toolchain '{}'; replacing existing version with `latest` version",
             &maybe_versioned_component, toolchain.name

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -25,13 +25,6 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
         )
     };
 
-    if toolchain.has_component(&maybe_versioned_component) {
-        info!(
-            "{} already exists in toolchain '{}'; replacing existing version with `latest` version",
-            &maybe_versioned_component, toolchain.name
-        );
-    }
-
     let (component, version): (&str, Option<Version>) =
         match maybe_versioned_component.split_once('@') {
             Some(t) => {
@@ -47,6 +40,13 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
             }
             None => (&maybe_versioned_component, None),
         };
+
+    if toolchain.has_component(&component) {
+        info!(
+            "{} already exists in toolchain '{}'; replacing existing version with `latest` version",
+            &maybe_versioned_component, toolchain.name
+        );
+    }
 
     let download_cfg =
         DownloadCfg::new(component, TargetTriple::from_component(component)?, version)?;

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -168,7 +168,10 @@ impl Toolchain {
     }
 
     pub fn has_component(&self, component: &str) -> bool {
-        let executables = &Components::collect().unwrap().component[component].executables;
+        let executables = &Components::collect()
+            .expect("Failed to collect components")
+            .component[component]
+            .executables;
 
         executables.iter().all(|e| self.bin_path.join(e).is_file())
     }


### PR DESCRIPTION
Currently trying to remove `forc-client` doesn't work, since we are checking for `forc-client` to exist within the directory. This PR uses the `Components` abstraction to collect executables listed in the toml and remove them instead.