### PR TITLE
 custom toolchain: creating a new toolchain should set it as default

### DIFF
--- a/src/ops/fuelup_toolchain/new.rs
+++ b/src/ops/fuelup_toolchain/new.rs
@@ -26,16 +26,18 @@ pub fn new(command: NewCommand) -> Result<()> {
     let toolchain_bin_dir = toolchain_bin_dir(&name);
 
     let settings_file = settings_file();
-    if !settings_file.exists() {
-        let settings = SettingsFile::new(settings_file);
-        settings.with_mut(|s| {
-            s.default_toolchain = Some(name.clone());
-            Ok(())
-        })?;
-    }
+
+    let settings = SettingsFile::new(settings_file);
+    settings.with_mut(|s| {
+        s.default_toolchain = Some(name.clone());
+        Ok(())
+    })?;
 
     ensure_dir_exists(&toolchains_dir.join(toolchain_bin_dir))?;
-    info!("New toolchain initialized: {}", &name);
+    info!(
+        "New toolchain initialized: {name}
+default toolchain set to '{name}'"
+    );
 
     Ok(())
 }

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -224,14 +224,7 @@ fn fuelup_toolchain_new_disallowed_with_target() -> Result<()> {
 #[test]
 fn fuelup_component_add() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
-        let output = cfg.fuelup(&["toolchain", "new", "my_toolchain"]);
-        let expected_stdout = "New toolchain initialized: my_toolchain\n";
-        assert_eq!(output.stdout, expected_stdout);
-
-        let output = cfg.fuelup(&["default", "my_toolchain"]);
-        let expected_stdout = "default toolchain set to 'my_toolchain'\n";
-        assert_eq!(output.stdout, expected_stdout);
-        assert!(cfg.toolchain_bin_dir("my_toolchain").is_dir());
+        let _ = cfg.fuelup(&["toolchain", "new", "my_toolchain"]);
 
         let _ = cfg.fuelup(&["component", "add", "forc"]);
         expect_files_exist(&cfg.toolchain_bin_dir("my_toolchain"), FORC_BINS);

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -188,11 +188,8 @@ default toolchain set to '{name}'\n"
 
         assert_eq!(output.stdout, expected_stdout);
         assert!(cfg.toolchain_bin_dir(name).is_dir());
-        let default = cfg
-            .settings_file()
-            .with(|s| Ok(s.default_toolchain.clone()))
-            .unwrap();
-        assert_eq!(default.unwrap(), name);
+        let default = cfg.default_toolchain();
+        assert_eq!(default, Some(name.to_string()));
     })?;
 
     Ok(())

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use fuelup::settings::SettingsFile;
 use std::{
     env, fs,
     path::PathBuf,
@@ -55,6 +56,10 @@ impl TestCfg {
             .join("toolchains")
             .join(toolchain)
             .join("bin")
+    }
+
+    pub fn settings_file(&self) -> SettingsFile {
+        SettingsFile::new(self.home.join(".fuelup").join("settings.toml"))
     }
 
     pub fn fuelup(&mut self, args: &[&str]) -> TestOutput {

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -62,6 +62,12 @@ impl TestCfg {
         SettingsFile::new(self.home.join(".fuelup").join("settings.toml"))
     }
 
+    pub fn default_toolchain(&self) -> Option<String> {
+        self.settings_file()
+            .with(|s| Ok(s.default_toolchain.clone()))
+            .unwrap()
+    }
+
     pub fn fuelup(&mut self, args: &[&str]) -> TestOutput {
         let output = Command::new(&self.fuelup_path)
             .args(args)


### PR DESCRIPTION
Closes #216 

As suggested by @Braqzen - currently you would have to switch toolchains upon creating one. eg:

```
fuelup toolchain new my-toolchain
fuelup default my-toolchain
fuelup component add ...
```

This PR combines the steps so that creating a new toolchain automatically sets it as the default, and you can carry on with whatever:

```
fuelup toolchain new my-toolchain (this step switches 'my-toolchain' to the default)
fuelup component add ...
```

This is one less step, and makes sense as a change since if you created a toolchain you would likely switch to it anyway.