### PR TITLE
test: add forc-wallet; other minor cleanups

### DIFF
--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -229,10 +229,18 @@ fn fuelup_component_add() -> Result<()> {
 
         let _ = cfg.fuelup(&["component", "add", "forc"]);
         expect_files_exist(&cfg.toolchain_bin_dir("my_toolchain"), FORC_BINS);
+    })?;
 
-        let _ = cfg.fuelup(&["component", "add", "forc-client"]);
-        let _ = cfg.fuelup(&["component", "add", "fuel-core@0.9.5"]);
-        expect_files_exist(&cfg.toolchain_bin_dir("my_toolchain"), ALL_BINS);
+    Ok(())
+}
+
+#[test]
+fn fuelup_component_add_with_version() -> Result<()> {
+    testcfg::setup(FuelupState::Empty, &|cfg| {
+        let _ = cfg.fuelup(&["toolchain", "new", "my_toolchain"]);
+
+        let _ = cfg.fuelup(&["component", "add", "forc@0.24.5"]);
+        expect_files_exist(&cfg.toolchain_bin_dir("my_toolchain"), FORC_BINS);
     })?;
 
     Ok(())

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -34,6 +34,7 @@ pub static ALL_BINS: &[&str] = &[
     "forc-fmt",
     "forc-lsp",
     "forc-run",
+    "forc-wallet",
     "fuel-core",
 ];
 


### PR DESCRIPTION
unblocks #220 

2 small changes:

- add `forc-wallet` to `ALL_BINS` to check for during tests.
- split the component adding tests to differentiate between specifying a version and not specifying one.