### PR TITLE
fix: remove usage of tmp dirs when installing toolchains

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -123,23 +123,25 @@ pub fn get_latest_version(name: &str) -> Result<Version> {
         let resp = handle.get(CHANNEL_LATEST_URL).call()?;
 
         resp.into_reader().read_to_end(&mut data)?;
-        let tmp_dir = tempdir_in(&fuelup_dir())?;
+        {
+            let tmp_dir = tempdir_in(&fuelup_dir())?;
+            println!("tmp: {}", tmp_dir.path().display());
 
-        if let Ok(channel) = Channel::from_dist_channel(
-            &OfficialToolchainDescription::from_str("latest")?,
-            tmp_dir.into_path(),
-        ) {
-            channel
-                .pkg
-                .get(name)
-                .ok_or_else(|| {
-                    anyhow!(
+            if let Ok(channel) =
+                Channel::from_dist_channel(&OfficialToolchainDescription::from_str("latest")?)
+            {
+                channel
+                    .pkg
+                    .get(name)
+                    .ok_or_else(|| {
+                        anyhow!(
                         "'{name}' is not a valid, downloadable package in the 'latest' channel."
                     )
-                })
-                .map(|p| p.version.clone())
-        } else {
-            bail!("Failed to get 'latest' channel")
+                    })
+                    .map(|p| p.version.clone())
+            } else {
+                bail!("Failed to get 'latest' channel")
+            }
         }
     }
 }
@@ -158,6 +160,47 @@ fn unpack(tar_path: &Path, dst: &Path) -> Result<()> {
 
     fs::remove_file(&tar_path)?;
     Ok(())
+}
+
+pub fn download(url: &str, hasher: &mut Sha256) -> Result<Vec<u8>> {
+    const RETRY_ATTEMPTS: u8 = 4;
+    const RETRY_DELAY_SECS: u64 = 3;
+
+    // auto detect http proxy setting.
+    let handle = if let Ok(proxy) = env::var("http_proxy") {
+        ureq::builder()
+            .user_agent("fuelup")
+            .proxy(ureq::Proxy::new(proxy)?)
+            .build()
+    } else {
+        ureq::builder().user_agent("fuelup").build()
+    };
+
+    for _ in 1..RETRY_ATTEMPTS {
+        match handle.get(url).call() {
+            Ok(response) => {
+                let mut data = Vec::new();
+                response.into_reader().read_to_end(&mut data)?;
+
+                hasher.update(data.clone());
+                return Ok(data);
+            }
+            Err(ureq::Error::Status(404, r)) => {
+                // We've reached download_file stage, which means the tag must be correct.
+                error!("Failed to download from {}", &url);
+                let retry: Option<u64> = r.header("retry-after").and_then(|h| h.parse().ok());
+                let retry = retry.unwrap_or(RETRY_DELAY_SECS);
+                info!("Retrying..");
+                thread::sleep(Duration::from_secs(retry));
+            }
+            Err(e) => {
+                // handle other status code and non-status code errors
+                bail!("Unexpected error: {}", e.to_string());
+            }
+        }
+    }
+
+    bail!("Could not read file");
 }
 
 pub fn download_file(url: &str, path: &PathBuf, hasher: &mut Sha256) -> Result<()> {

--- a/src/download.rs
+++ b/src/download.rs
@@ -13,7 +13,6 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::{fs, thread};
 use tar::Archive;
-use tempfile::tempdir_in;
 use tracing::warn;
 use tracing::{error, info};
 
@@ -22,7 +21,6 @@ use crate::channel::Package;
 use crate::constants::CHANNEL_LATEST_URL;
 use crate::file::hard_or_symlink_file;
 use crate::path::fuelup_bin;
-use crate::path::fuelup_dir;
 use crate::target_triple::TargetTriple;
 use crate::toolchain::OfficialToolchainDescription;
 
@@ -124,9 +122,6 @@ pub fn get_latest_version(name: &str) -> Result<Version> {
 
         resp.into_reader().read_to_end(&mut data)?;
         {
-            let tmp_dir = tempdir_in(&fuelup_dir())?;
-            println!("tmp: {}", tmp_dir.path().display());
-
             if let Ok(channel) =
                 Channel::from_dist_channel(&OfficialToolchainDescription::from_str("latest")?)
             {

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -4,7 +4,6 @@ use crate::{
     config::Config,
     download::DownloadCfg,
     fmt::{bold, colored_bold},
-    path::fuelup_dir,
     target_triple::TargetTriple,
     toolchain::{OfficialToolchainDescription, Toolchain},
 };
@@ -18,7 +17,6 @@ use std::{
     path::Path,
 };
 use std::{collections::HashMap, process::Command};
-use tempfile::tempdir_in;
 use termcolor::Color;
 use tracing::error;
 
@@ -105,10 +103,7 @@ fn check_fuelup() -> Result<()> {
 fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     let description = OfficialToolchainDescription::from_str(toolchain)?;
 
-    let fuelup_dir = fuelup_dir();
-    let tmp_dir = tempdir_in(&fuelup_dir)?;
-
-    let dist_channel = Channel::from_dist_channel(&description, tmp_dir.into_path())?;
+    let dist_channel = Channel::from_dist_channel(&description)?;
     let latest_package_versions = collect_package_versions(dist_channel);
 
     let toolchain = Toolchain::new(toolchain)?;

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -1,8 +1,7 @@
-use crate::constants::{CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME};
 use crate::download::DownloadCfg;
 use crate::path::settings_file;
 use crate::settings::SettingsFile;
-use crate::toolchain::{DistToolchainName, OfficialToolchainDescription, Toolchain};
+use crate::toolchain::{OfficialToolchainDescription, Toolchain};
 use crate::{channel::Channel, commands::toolchain::InstallCommand};
 use anyhow::{bail, Result};
 use std::fmt::Write;

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -1,14 +1,12 @@
 use crate::constants::{CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME};
 use crate::download::DownloadCfg;
-use crate::path::{fuelup_dir, settings_file};
+use crate::path::settings_file;
 use crate::settings::SettingsFile;
 use crate::toolchain::{DistToolchainName, OfficialToolchainDescription, Toolchain};
 use crate::{channel::Channel, commands::toolchain::InstallCommand};
 use anyhow::{bail, Result};
 use std::fmt::Write;
-use std::fs;
 use std::str::FromStr;
-use tempfile::tempdir_in;
 use tracing::{error, info};
 
 pub fn install(command: InstallCommand) -> Result<()> {
@@ -26,49 +24,38 @@ pub fn install(command: InstallCommand) -> Result<()> {
     let mut errored_bins = String::new();
     let mut installed_bins = String::new();
 
-    let fuelup_dir = fuelup_dir();
-    let tmp_dir = tempdir_in(&fuelup_dir)?;
-    let tmp_dir_path = tmp_dir.into_path();
-
-    let cfgs: Vec<DownloadCfg> =
-        if let Ok(channel) = Channel::from_dist_channel(&description, tmp_dir_path.clone()) {
+    {
+        let cfgs: Vec<DownloadCfg> = if let Ok(channel) = Channel::from_dist_channel(&description) {
             channel.build_download_configs()
         } else {
             bail!("Could not build download configs from channel")
         };
 
-    info!(
-        "Downloading: {}",
-        cfgs.iter()
-            .map(|c| c.name.clone() + " ")
-            .collect::<String>()
-    );
-    for cfg in cfgs {
-        match toolchain.add_component(cfg) {
-            Ok(cfg) => writeln!(installed_bins, "- {} {}", cfg.name, cfg.version)?,
-            Err(e) => writeln!(errored_bins, "- {}", e)?,
+        info!(
+            "Downloading: {}",
+            cfgs.iter()
+                .map(|c| c.name.clone() + " ")
+                .collect::<String>()
+        );
+        for cfg in cfgs {
+            match toolchain.add_component(cfg) {
+                Ok(cfg) => writeln!(installed_bins, "- {} {}", cfg.name, cfg.version)?,
+                Err(e) => writeln!(errored_bins, "- {}", e)?,
+            };
+        }
+
+        if errored_bins.is_empty() {
+            info!("\nInstalled:\n{}", installed_bins);
+            info!("\nThe Fuel toolchain is installed and up to date");
+        } else if installed_bins.is_empty() {
+            error!("\nfuelup failed to install:\n{}", errored_bins)
+        } else {
+            info!(
+                "\nThe Fuel toolchain is partially installed.\nfuelup failed to install: {}",
+                errored_bins
+            );
         };
     }
-
-    let channel_file_name = match description.name {
-        DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
-        DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,
-    };
-    if errored_bins.is_empty() {
-        fs::copy(
-            tmp_dir_path.join(channel_file_name),
-            toolchain.path.join(channel_file_name),
-        )?;
-        info!("\nInstalled:\n{}", installed_bins);
-        info!("\nThe Fuel toolchain is installed and up to date");
-    } else if installed_bins.is_empty() {
-        error!("\nfuelup failed to install:\n{}", errored_bins)
-    } else {
-        info!(
-            "\nThe Fuel toolchain is partially installed.\nfuelup failed to install: {}",
-            errored_bins
-        );
-    };
 
     Ok(())
 }


### PR DESCRIPTION
closes #230 

We do not need to save the channel as a file, but simply reading into memory will do. This way we avoid saving the channel to a tmp file to clean up later.

This avoids multiple file I/O steps as well (creating tmp dirs, tmp files, reading files).