### PR TITLE
feat: use update hashes

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -35,7 +35,7 @@ pub struct Package {
 }
 
 impl Channel {
-    pub fn from_dist_channel(desc: &OfficialToolchainDescription) -> Result<Self> {
+    pub fn from_dist_channel(desc: &OfficialToolchainDescription) -> Result<(Self, String)> {
         let channel_file_name = match desc.name {
             DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
             DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,
@@ -47,7 +47,8 @@ impl Channel {
             Err(_) => bail!("Could not read {}", &channel_url),
         };
 
-        Self::from_toml(&toml)
+        let actual_hash = format!("{:x}", hasher.finalize());
+        Ok((Self::from_toml(&toml)?, actual_hash))
     }
 
     pub fn from_toml(toml: &str) -> Result<Self> {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -38,6 +38,7 @@ pub struct Package {
 }
 
 impl Channel {
+    /// The returned `String` is a sha256 hash of the downloaded toolchain TOML bytes.
     pub fn from_dist_channel(desc: &OfficialToolchainDescription) -> Result<(Self, String)> {
         let channel_file_name = match desc.name {
             DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,7 @@ impl Config {
         self.hashes_dir.join(description.to_string()).is_file()
     }
 
-    pub(crate) fn save_hash(self, toolchain: &str, hash: &str) -> Result<()> {
+    pub(crate) fn save_hash(&self, toolchain: &str, hash: &str) -> Result<()> {
         ensure_dir_exists(&self.hashes_dir)?;
         write_file(&self.hashes_dir.join(toolchain), hash)?;
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,11 @@ impl Config {
         })
     }
 
-    pub(crate) fn hash_exists(
+    pub(crate) fn hashes_dir(self) -> PathBuf {
+        self.hashes_dir
+    }
+
+    pub(crate) fn hash_matches(
         &self,
         description: &OfficialToolchainDescription,
         hash: &str,
@@ -32,6 +36,10 @@ impl Config {
             Ok(h) => h == hash,
             _ => false,
         }
+    }
+
+    pub(crate) fn hash_exists(&self, description: &OfficialToolchainDescription) -> bool {
+        self.hashes_dir.join(description.to_string()).is_file()
     }
 
     pub(crate) fn save_hash(self, toolchain: &str, hash: &str) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Result};
 use std::io::{self, ErrorKind};
 
-use crate::file::{read_file, write_file};
+use crate::file::write_file;
 use crate::path::{ensure_dir_exists, hashes_dir, toolchains_dir};
 use crate::target_triple::TargetTriple;
 use crate::toolchain::{OfficialToolchainDescription, RESERVED_TOOLCHAIN_NAMES};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use std::io;
@@ -21,8 +21,8 @@ impl Config {
         })
     }
 
-    pub(crate) fn hashes_dir(self) -> PathBuf {
-        self.hashes_dir
+    pub(crate) fn hashes_dir(&self) -> &Path {
+        self.hashes_dir.as_path()
     }
 
     pub(crate) fn hash_matches(

--- a/src/download.rs
+++ b/src/download.rs
@@ -121,22 +121,21 @@ pub fn get_latest_version(name: &str) -> Result<Version> {
         let resp = handle.get(CHANNEL_LATEST_URL).call()?;
 
         resp.into_reader().read_to_end(&mut data)?;
+
+        if let Ok((channel, _)) =
+            Channel::from_dist_channel(&OfficialToolchainDescription::from_str("latest")?)
         {
-            if let Ok(channel) =
-                Channel::from_dist_channel(&OfficialToolchainDescription::from_str("latest")?)
-            {
-                channel
-                    .pkg
-                    .get(name)
-                    .ok_or_else(|| {
-                        anyhow!(
+            channel
+                .pkg
+                .get(name)
+                .ok_or_else(|| {
+                    anyhow!(
                         "'{name}' is not a valid, downloadable package in the 'latest' channel."
                     )
-                    })
-                    .map(|p| p.version.clone())
-            } else {
-                bail!("Failed to get 'latest' channel")
-            }
+                })
+                .map(|p| p.version.clone())
+        } else {
+            bail!("Failed to get 'latest' channel")
         }
     }
 }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -103,7 +103,7 @@ fn check_fuelup() -> Result<()> {
 fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     let description = OfficialToolchainDescription::from_str(toolchain)?;
 
-    let dist_channel = Channel::from_dist_channel(&description)?;
+    let (dist_channel, _) = Channel::from_dist_channel(&description)?;
     let latest_package_versions = collect_package_versions(dist_channel);
 
     let toolchain = Toolchain::new(toolchain)?;

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -29,7 +29,7 @@ pub fn install(command: InstallCommand) -> Result<()> {
 
     let toolchain = Toolchain::from_path(&description.to_string())?;
     let (cfgs, hash) = if let Ok((channel, hash)) = Channel::from_dist_channel(&description) {
-        if config.hash_matches(&description, &hash) {
+        if let Ok(true) = config.hash_matches(&description, &hash) {
             info!("'{}' is already installed and up to date", toolchain.name);
             return Ok(());
         };

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -26,7 +26,7 @@ pub fn install(command: InstallCommand) -> Result<()> {
     let config = Config::from_env()?;
 
     let (cfgs, hash) = if let Ok((channel, hash)) = Channel::from_dist_channel(&description) {
-        if config.hash_exists(&description, &hash) {
+        if config.hash_matches(&description, &hash) {
             info!("'{}' is already installed and up to date", toolchain.name);
             return Ok(());
         };

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -27,6 +27,7 @@ pub fn install(command: InstallCommand) -> Result<()> {
 
     let config = Config::from_env()?;
 
+    let toolchain = Toolchain::from_path(&description.to_string())?;
     let (cfgs, hash) = if let Ok((channel, hash)) = Channel::from_dist_channel(&description) {
         if config.hash_matches(&description, &hash) {
             info!("'{}' is already installed and up to date", toolchain.name);
@@ -44,7 +45,6 @@ pub fn install(command: InstallCommand) -> Result<()> {
             .collect::<String>()
     );
 
-    let toolchain = Toolchain::from_path(&description.to_string())?;
     for cfg in cfgs {
         match toolchain.add_component(cfg) {
             Ok(cfg) => writeln!(installed_bins, "- {} {}", cfg.name, cfg.version)?,

--- a/src/ops/fuelup_toolchain/uninstall.rs
+++ b/src/ops/fuelup_toolchain/uninstall.rs
@@ -1,10 +1,11 @@
-use std::str::FromStr;
-
 use anyhow::Result;
+use std::fs;
+use std::str::FromStr;
 use tracing::info;
 
 use crate::{
     commands::toolchain::UninstallCommand,
+    config::Config,
     toolchain::{OfficialToolchainDescription, Toolchain},
 };
 
@@ -16,6 +17,13 @@ pub fn uninstall(command: UninstallCommand) -> Result<()> {
     if toolchain.is_official() {
         let description = OfficialToolchainDescription::from_str(&name)?;
         toolchain = Toolchain::from(&description.to_string())?;
+
+        let config = Config::from_env()?;
+
+        if toolchain.exists() && config.hash_exists(&description) {
+            let hash_file = config.hashes_dir().join(description.to_string());
+            fs::remove_file(hash_file)?;
+        };
     }
 
     if !toolchain.exists() {

--- a/src/ops/fuelup_toolchain/uninstall.rs
+++ b/src/ops/fuelup_toolchain/uninstall.rs
@@ -20,7 +20,7 @@ pub fn uninstall(command: UninstallCommand) -> Result<()> {
 
         let config = Config::from_env()?;
 
-        if toolchain.exists() && config.hash_exists(&description) {
+        if config.hash_exists(&description) {
             let hash_file = config.hashes_dir().join(description.to_string());
             fs::remove_file(hash_file)?;
         };

--- a/src/path.rs
+++ b/src/path.rs
@@ -24,6 +24,10 @@ pub fn settings_file() -> PathBuf {
     fuelup_dir().join("settings.toml")
 }
 
+pub fn hashes_dir() -> PathBuf {
+    fuelup_dir().join("hashes")
+}
+
 pub fn toolchains_dir() -> PathBuf {
     fuelup_dir().join("toolchains")
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -307,7 +307,7 @@ mod tests {
             let desc = OfficialToolchainDescription::from_str(name)?;
             assert_eq!(desc.name, DistToolchainName::from_str(name).unwrap());
             assert_eq!(desc.date, None);
-            assert_eq!(desc.target, None);
+            assert_eq!(desc.target, Some(TargetTriple::from_host().unwrap()));
         }
 
         Ok(())

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -97,7 +97,7 @@ impl FromStr for OfficialToolchainDescription {
             Ok(Self {
                 name: DistToolchainName::from_str(name)?,
                 date: None,
-                target: None,
+                target: TargetTriple::from_host().ok(),
             })
         } else if let Ok((_, _)) = parse_metadata(metadata.to_string()) {
             bail!(


### PR DESCRIPTION
closes #69 
unblocks #208 

- saves the sha256 hash of the channel to a file with file name of the toolchain eg. `latest-x86-apple-darwin` to a new directory, `~/.fuelup/hashes`
- we use this hash to avoid re-downloading a toolchain if it already exists.
- the hash is saved ONLY if the entire toolchain is installed (skipped if there are partial installations)
- the hash is deleted upon uninstallation of a toolchain i.e. `fuelup toolchain uninstall latest`

This unblocks #208 since we want to check for hashes before trying to update `latest` and `nightly`.