### PR TITLE
refactor: update usages of tmp dir to use default OS tmp path

### DIFF
--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use component;
 use std::{fs, path::Path};
-use tempfile::tempdir_in;
+use tempfile::tempdir;
 use tracing::{error, info};
 
 use crate::{
@@ -28,7 +28,7 @@ pub fn self_update() -> Result<()> {
     let fuelup_bin_dir = fuelup_bin_dir();
     let fuelup_backup = fuelup_bin_dir.join("fuelup-backup");
 
-    let fuelup_new_dir = tempdir_in(&fuelup_bin_dir)?;
+    let fuelup_new_dir = tempdir()?;
     let fuelup_new_dir_path = fuelup_new_dir.path();
     let fuelup_new = fuelup_new_dir_path.join(component::FUELUP);
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -224,10 +224,9 @@ impl Toolchain {
                 let fuelup_tmp_dir = fuelup_tmp_dir();
                 ensure_dir_exists(&fuelup_tmp_dir)?;
                 let forc_bin_path = self.bin_path.join(component::FORC);
-                let temp_project = tempfile::Builder::new()
-                    .prefix("temp-project")
-                    .tempdir_in(fuelup_tmp_dir)?;
+                let temp_project = tempfile::Builder::new().prefix("temp-project").tempdir()?;
                 let temp_project_path = temp_project.path().to_str().unwrap();
+                println!("temp: {}", temp_project_path);
                 if Command::new(&forc_bin_path)
                     .args(["init", "--path", temp_project_path])
                     .stdout(std::process::Stdio::null())

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -226,7 +226,6 @@ impl Toolchain {
                 let forc_bin_path = self.bin_path.join(component::FORC);
                 let temp_project = tempfile::Builder::new().prefix("temp-project").tempdir()?;
                 let temp_project_path = temp_project.path().to_str().unwrap();
-                println!("temp: {}", temp_project_path);
                 if Command::new(&forc_bin_path)
                     .args(["init", "--path", temp_project_path])
                     .stdout(std::process::Stdio::null())

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, ExitStatus},
 };
-use tempfile::tempdir_in;
+use tempfile::tempdir;
 
 pub enum FuelupState {
     AllInstalled,
@@ -124,7 +124,7 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
         .expect("fuelup's directory")
         .to_path_buf();
 
-    let testdir = tempdir_in(&root).unwrap();
+    let testdir = tempdir().unwrap();
     let tmp_home = testdir.path();
 
     let tmp_fuelup_root_path = tmp_home.join(".fuelup");


### PR DESCRIPTION
closes #236 
closes #240 

The motivation is described within #240, and handling it this way coincidentally solves/closes #236 as well.