### PR TITLE
better messages for fuelup update

### DIFF
--- a/src/ops/fuelup_update.rs
+++ b/src/ops/fuelup_update.rs
@@ -1,25 +1,35 @@
 use crate::{
     channel::Channel,
     config::Config,
+    fmt::{bold, colored_bold},
     toolchain::{OfficialToolchainDescription, Toolchain},
 };
 use anyhow::{bail, Result};
-use std::fmt::Write;
+use std::io::Write;
 use std::str::FromStr;
-use tracing::{error, info};
+use termcolor::Color;
+use tracing::info;
+
+const UPDATED: &str = "updated";
+const PARTIALLY_UPDATED: &str = "partially updated";
+const UNCHANGED: &str = "unchanged";
 
 pub fn update() -> Result<()> {
     let config = Config::from_env()?;
+    let toolchains = config.list_official_toolchains()?;
+    let mut message: Vec<(String, String)> = Vec::with_capacity(toolchains.len());
 
-    for toolchain in config.list_official_toolchains()? {
-        let mut errored_bins = String::new();
+    for toolchain in toolchains {
         let mut installed_bins = String::new();
+        let mut errored_bins = String::new();
 
         let description = OfficialToolchainDescription::from_str(&toolchain)?;
+        info!("updating the '{}' toolchain", description);
 
         let (cfgs, hash) = if let Ok((channel, hash)) = Channel::from_dist_channel(&description) {
             if let Ok(true) = config.hash_matches(&description, &hash) {
-                info!("'{}' is already installed and up to date", toolchain);
+                info!("'{}' already installed and up to date", description);
+                message.push((format!("{} {}", toolchain, UNCHANGED), "".to_string()));
                 continue;
             };
             (channel.build_download_configs(), hash)
@@ -36,23 +46,38 @@ pub fn update() -> Result<()> {
         for cfg in cfgs {
             let toolchain = Toolchain::from_path(&description.to_string())?;
             match toolchain.add_component(cfg) {
-                Ok(cfg) => writeln!(installed_bins, "- {} {}", cfg.name, cfg.version)?,
-                Err(e) => writeln!(errored_bins, "- {}", e)?,
+                Ok(cfg) => installed_bins.push_str(&format!("  - {} {}\n", cfg.name, cfg.version)),
+                Err(e) => errored_bins.push_str(&format!("  - {}\n", e)),
             };
+        }
+
+        let mut status = String::new();
+        if !installed_bins.is_empty() {
+            status = UPDATED.to_string();
+            installed_bins = format!("  updated components:\n{}", installed_bins);
         }
 
         if errored_bins.is_empty() {
             config.save_hash(&toolchain, &hash)?;
-            info!("\nUpdated:\n{}", installed_bins);
-            info!("\nThe Fuel toolchain is installed and up to date");
-        } else if installed_bins.is_empty() {
-            error!("\nfuelup failed to install:\n{}", errored_bins)
         } else {
-            info!(
-                "\nThe Fuel toolchain is partially installed.\nfuelup failed to install: {}",
-                errored_bins
-            );
+            status = PARTIALLY_UPDATED.to_string();
+            errored_bins = format!("  failed to update:\n{}", errored_bins);
         };
+
+        message.push((
+            format!("{} {}\n", toolchain, status),
+            format!("{}{}", installed_bins, errored_bins),
+        ));
+    }
+
+    info!("");
+    for msg in message {
+        if !msg.0.matches(UPDATED).collect::<String>().is_empty() {
+            colored_bold(Color::Green, |s| write!(s, "{}", msg.0));
+        } else {
+            bold(|s| write!(s, "{}", msg.0));
+        }
+        info!("{}", msg.1);
     }
 
     Ok(())

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -203,7 +203,7 @@ impl Toolchain {
         }
 
         info!(
-            "Adding component {} v{} to '{}'",
+            "\nAdding component {} v{} to '{}'",
             &download_cfg.name, &download_cfg.version, self.name
         );
 


### PR DESCRIPTION
closes #245 

- Provide a better message for `fuelup update` specifically rather than reuse what is in `fuelup toolchain install <toolchain>` by printing a summary message at the end.
- Also add a newline to `Adding component {} v{} to '{}'` to make things less clumped together in the terminal.

### Screenshots

unchanged:

![updateunchanged](https://user-images.githubusercontent.com/25565268/197934857-1de8d824-0529-41b8-8e9a-d87531c7dee4.png)

updated:

![updateupdated](https://user-images.githubusercontent.com/25565268/197934863-56ebbdef-b645-49c3-9f36-376ec0a4ef3b.png)
