### PR TITLE
bug: replace `rename` usage with remove+copy usage

### DIFF
--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 
 use crate::{
     download::{download_file_and_unpack, unpack_bins, DownloadCfg},
-    path::{fuelup_bin, fuelup_bin_dir},
+    path::fuelup_bin,
     target_triple::TargetTriple,
 };
 

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -38,22 +38,22 @@ pub fn self_update() -> Result<()> {
     };
 
     if fuelup_bin.exists() {
+        if fuelup_backup.exists() {
+            fs::remove_file(&fuelup_backup)?;
+        };
+
+        // Make a backup of fuelup within /tmp, in case download fails.
+        if let Err(e) = fs::copy(&fuelup_bin, &fuelup_backup) {
+            bail!(
+                "Failed moving {} to {}: {}",
+                &fuelup_bin.display(),
+                &fuelup_backup.display(),
+                e
+            );
+        }
+
         // Unlink the original 'fuelup', since we cannot write over a running executable.
         fs::remove_file(&fuelup_bin)?;
-    }
-
-    if fuelup_backup.exists() {
-        // Make a backup of fuelup within /tmp, in case download fails.
-        fs::remove_file(&fuelup_backup)?;
-    };
-
-    if let Err(e) = fs::copy(&fuelup_bin, &fuelup_backup) {
-        bail!(
-            "Failed moving {} to {}: {}",
-            &fuelup_bin.display(),
-            &fuelup_backup.display(),
-            e
-        );
     }
 
     info!(

--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -6,7 +6,7 @@ use tracing::{error, info};
 
 use crate::{
     download::{download_file_and_unpack, unpack_bins, DownloadCfg},
-    path::{fuelup_bin, fuelup_bin_dir},
+    path::fuelup_bin,
     target_triple::TargetTriple,
 };
 
@@ -25,11 +25,10 @@ pub fn self_update() -> Result<()> {
     )?;
 
     let fuelup_bin = fuelup_bin();
-    let fuelup_bin_dir = fuelup_bin_dir();
-    let fuelup_backup = fuelup_bin_dir.join("fuelup-backup");
 
     let fuelup_new_dir = tempdir()?;
     let fuelup_new_dir_path = fuelup_new_dir.path();
+    let fuelup_backup = fuelup_new_dir.path().join("fuelup-backup");
     let fuelup_new = fuelup_new_dir_path.join(component::FUELUP);
 
     if let Err(e) = attempt_install_self(download_cfg, fuelup_new_dir_path) {
@@ -39,8 +38,8 @@ pub fn self_update() -> Result<()> {
     };
 
     if fuelup_bin.exists() {
-        // Make a backup of fuelup, fuelup-backup.
-        if let Err(e) = fs::rename(&fuelup_bin, &fuelup_backup) {
+        // Make a backup of fuelup within /tmp, in case download fails.
+        if let Err(e) = fs::copy(&fuelup_bin, &fuelup_backup) {
             bail!(
                 "Failed moving {} to {}: {}",
                 &fuelup_bin.display(),
@@ -55,13 +54,13 @@ pub fn self_update() -> Result<()> {
         fuelup_new.display(),
         &fuelup_bin.display()
     );
-    if let Err(e) = fs::rename(&fuelup_new, &fuelup_bin) {
+    if let Err(e) = fs::copy(&fuelup_new, &fuelup_bin) {
         error!(
             "Failed to replace old fuelup with new fuelup: {}. Attempting to restore backup fuelup.",
         e);
         // If we have failed to replace the old fuelup for whatever reason, we want the backup.
         // Although unlikely, should this last step fail, we will recommend to re-install fuelup using fuelup-init.
-        if let Err(e) = fs::rename(&fuelup_backup, &fuelup_bin) {
+        if let Err(e) = fs::copy(&fuelup_backup, &fuelup_bin) {
             bail!(
                 "Could not restore backup fuelup. {}
 
@@ -69,11 +68,15 @@ You should re-install fuelup using fuelup-init:
 `curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh`",
                 e
             );
+        } else {
+            let _ = fs::remove_file(&fuelup_backup);
         }
 
         bail!(
             "Old fuelup restored because something went wrong replacing old fuelup with new fuelup.",
         );
+    } else {
+        let _ = fs::remove_file(&fuelup_new);
     };
 
     // Remove backup at the end.


### PR DESCRIPTION
closes #252 

In order to make `copy` work without running into ETXTBSY, we should first unlink the binary first.