### PR TITLE
ci: filter by CI runs only

### DIFF
--- a/scripts/compare-versions/src/main.rs
+++ b/scripts/compare-versions/src/main.rs
@@ -44,6 +44,7 @@ struct File {
 
 #[derive(Debug, Serialize, Deserialize)]
 struct WorkflowRun {
+    name: String,
     head_branch: String,
     html_url: String,
 }
@@ -83,6 +84,7 @@ fn collect_new_versions(channel: &Document, repo: &str) -> Result<Vec<Version>> 
     let new_versions: Vec<Version> = response
         .workflow_runs
         .iter()
+        .filter(|r| r.name == "CI")
         .map_while(|r| {
             // Fine to unwrap here since branches strictly follow the format v"x.y.z"
             Version::from_str(&r.head_branch[1..])

--- a/src/download.rs
+++ b/src/download.rs
@@ -152,7 +152,7 @@ fn unpack(tar_path: &Path, dst: &Path) -> Result<()> {
         );
     };
 
-    fs::remove_file(&tar_path)?;
+    fs::remove_file(tar_path)?;
     Ok(())
 }
 
@@ -211,7 +211,7 @@ pub fn download_file(url: &str, path: &PathBuf, hasher: &mut Sha256) -> Result<(
         ureq::builder().user_agent("fuelup").build()
     };
 
-    let mut file = OpenOptions::new().write(true).create(true).open(&path)?;
+    let mut file = OpenOptions::new().write(true).create(true).open(path)?;
 
     for _ in 1..RETRY_ATTEMPTS {
         match handle.get(url).call() {
@@ -291,7 +291,7 @@ pub fn link_to_fuelup(bins: Vec<PathBuf>) -> Result<()> {
 
 pub fn unpack_bins(dir: &Path, dst_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut downloaded: Vec<PathBuf> = Vec::new();
-    for entry in std::fs::read_dir(&dir)? {
+    for entry in std::fs::read_dir(dir)? {
         let sub_path = entry?.path();
 
         if sub_path.is_dir() {

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -51,7 +51,7 @@ fn compare_and_print_versions(current_version: &Version, latest_version: &Versio
 }
 
 fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version) -> Result<()> {
-    match std::process::Command::new(&plugin_executable)
+    match std::process::Command::new(plugin_executable)
         .arg("--version")
         .output()
     {

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -77,7 +77,7 @@ pub fn show() -> Result<()> {
                     info!("");
                     for executable in plugin.executables.iter() {
                         bold(|s| write!(s, "      - {}", &executable));
-                        let plugin_executable = active_toolchain.bin_path.join(&executable);
+                        let plugin_executable = active_toolchain.bin_path.join(executable);
                         exec_show_version(plugin_executable.as_path())?;
                     }
                 } else {


### PR DESCRIPTION
Noticed that in the latest few compatibility checks, there were duplicate checks for the same versions ([example](https://github.com/FuelLabs/fuelup/actions/runs/3367112366)).  This is a result of there being 2 runs for the same tag: CI and Markdown Lint. We should filter for `name=CI` instead since both `forc` and `fuel-core` repos use that as the CI names.