### PR TITLE
docs: better explanation for components; update forc-explore references

### DIFF
--- a/docs/src/concepts/components.md
+++ b/docs/src/concepts/components.md
@@ -4,27 +4,33 @@ Each [toolchain] has several "components", which are tools used to develop on Fu
 
 The `fuelup component` command is used to manage the installed components.
 
-Components can be added to a already-installed toolchain with the `fuelup component` command:
+Components can be added to an already-installed toolchain with the `fuelup component` command:
 
 ```sh
-fuelup component add fuel-core
+fuelup component add forc
 ```
 
-The following is an overview of the different components:
+In custom toolchains, you also have the choice of adding a specific version of a component:
 
-- [`forc`] — The Fuel Orchestrator, a suite of tools to work with the Fuel ecosystem.
+```sh
+fuelup component add forc@0.30.1
+```
+
+## Components overview
+
+The following is an overview of components installable through `fuelup`:
+
+- [`forc`] — The Fuel Orchestrator, a suite of tools to work with the Fuel ecosystem. This comes
+with some built-in plugin executables, namely [`forc-client`], [`forc-fmt`] and [`forc-lsp`].
 - [`fuel-core`] — Full node implementation of the Fuel v2 protocol, written in Rust.
 - [`forc-explore`] — A Forc plugin for running the Fuel Block Explorer.
-- [`forc-fmt`] — A Forc plugin for running the Sway code formatter.
-- [`forc-lsp`] - A Forc plugin for the Sway LSP (Language Server Protocol) implementation.
-- [`forc-client`] - A Forc plugin for interacting with a Fuel node. Contains the `forc-deploy` and `forc-run` binaries.
 - [`forc-wallet`] - A Forc plugin for managing Fuel wallets.
 
 [toolchain]: toolchains.md
 [`forc`]: https://fuellabs.github.io/sway/master/forc/index.html
 [`fuel-core`]: https://github.com/FuelLabs/fuel-core
-[`forc-explore`]: https://fuellabs.github.io/sway/master/forc_explore.html
-[`forc-fmt`]: https://fuellabs.github.io/sway/master/forc_fmt.html
-[`forc-lsp`]: https://fuellabs.github.io/sway/master/forc_lsp.html
-[`forc-client`]: https://fuellabs.github.io/sway/master/forc_client.html
+[`forc-explore`]: https://fuellabs.github.io/sway/master/forc/plugins/forc_explore.html
+[`forc-fmt`]: https://fuellabs.github.io/sway/master/forc/plugins/forc_fmt.html
+[`forc-lsp`]: https://fuellabs.github.io/sway/master/forc/plugins/forc_lsp.html
+[`forc-client`]: https://fuellabs.github.io/sway/master/forc/plugins/forc_client/index.html
 [`forc-wallet`]: https://github.com/FuelLabs/forc-wallet

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -1,7 +1,7 @@
 # Installation
 
 `fuelup` installs `forc` and `fuel-core`, and other plugins like
-`forc-client`, `forc-fmt`, `forc-lsp` and `forc-explore` to Fuelup's `bin` directory.
+`forc-client`, `forc-fmt`, `forc-lsp` and to Fuelup's `bin` directory.
 On Unix it is located at `$HOME/.fuelup/bin`.
 
 This directory can automatically be in your `PATH` environment variable if
@@ -17,7 +17,7 @@ Run the following command:
 curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
 ```
 
-This will install `forc`, `forc-client`, `forc-fmt`, `forc-explore`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
+This will install `forc`, `forc-client`, `forc-fmt`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
 
 Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so:
 
@@ -32,7 +32,6 @@ fuelup --version
 forc --version
 fuel-core --version
 forc-deploy --version
-forc-explore --version
 forc-fmt --version
 forc-lsp --version
 forc-run --version

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -1,7 +1,7 @@
 # Installation
 
 `fuelup` installs `forc` and `fuel-core`, and other plugins like
-`forc-client`, `forc-fmt`, `forc-lsp` and to Fuelup's `bin` directory.
+`forc-client` and `forc-fmt` to Fuelup's `bin` directory.
 On Unix it is located at `$HOME/.fuelup/bin`.
 
 This directory can automatically be in your `PATH` environment variable if
@@ -17,7 +17,7 @@ Run the following command:
 curl --proto '=https' --tlsv1.2 -sSf https://fuellabs.github.io/fuelup/fuelup-init.sh | sh
 ```
 
-This will install `forc`, `forc-client`, `forc-fmt`, `forc-lsp` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
+This will install `forc`, `forc-client`, `forc-fmt`, `forc-lsp`, `forc-wallet` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
 
 Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so:
 


### PR DESCRIPTION
Updated the components page in the book to only list specifically only installable components, instead of listing all components (some of which are already packaged with `forc` like `forc-fmt`). This was probably the source of confusion of what is possible with `fuelup component add <component>`.

Also fixed links to forc plugins that was caused by the update here: https://github.com/FuelLabs/sway/pull/3182