### PR TITLE
add forc-doc; remove forc-explore

### DIFF
--- a/components.toml
+++ b/components.toml
@@ -1,7 +1,7 @@
 [component.forc]
 name = "forc"
 tarball_prefix = "forc-binaries"
-executables = ["forc", "forc-fmt", "forc-lsp", "forc-explore"]
+executables = ["forc", "forc-fmt", "forc-lsp", "forc-doc"]
 repository_name = "sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 publish = true
@@ -24,11 +24,12 @@ targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 
 [component.forc-explore]
 name = "forc-explore"
-tarball_prefix = "forc-binaries"
+tarball_prefix = "forc-explore"
 is_plugin = true
 executables = ["forc-explore"]
-repository_name = "sway"
-targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+repository_name = "forc-explorer"
+targets = [ "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin" ]
+publish = true
 
 [component.forc-client]
 name = "forc-client"

--- a/components.toml
+++ b/components.toml
@@ -6,6 +6,14 @@ repository_name = "sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 publish = true
 
+[component.forc-doc]
+name = "forc-doc"
+tarball_prefix = "forc-binaries"
+is_plugin = true
+executables = ["forc-doc"]
+repository_name = "sway"
+targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+
 [component.forc-fmt]
 name = "forc-fmt"
 tarball_prefix = "forc-binaries"

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -220,6 +220,7 @@ my_toolchain (default)
     - forc-client
       - forc-deploy - not found
       - forc-run - not found
+    - forc-doc - not found
     - forc-explore - not found
     - forc-fmt - not found
     - forc-lsp - not found


### PR DESCRIPTION
closes #251 officially

- Adds `forc-doc` to the list of executables under `forc`
- Separates `forc-explore` from `forc`.