### PR TITLE
feat: add beta-1 toolchain

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,6 +1,6 @@
 use crate::{
     constants::{
-        CHANNEL_BETA1_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
+        CHANNEL_BETA_1_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
         DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
@@ -17,8 +17,7 @@ use tracing::warn;
 
 pub const LATEST: &str = "latest";
 pub const STABLE: &str = "stable";
-pub const BETA: &str = "beta";
-pub const BETA1: &str = "beta1";
+pub const BETA_1: &str = "beta-1";
 pub const NIGHTLY: &str = "nightly";
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -44,7 +43,7 @@ impl Channel {
         let channel_file_name = match desc.name {
             DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
             DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,
-            DistToolchainName::Beta1 => CHANNEL_BETA1_FILE_NAME,
+            DistToolchainName::Beta1 => CHANNEL_BETA_1_FILE_NAME,
         };
 
         let mut channel_url = FUELUP_GH_PAGES.to_owned();

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -18,7 +18,7 @@ use tracing::warn;
 pub const LATEST: &str = "latest";
 pub const STABLE: &str = "stable";
 pub const BETA: &str = "beta";
-pub const BETA1: &str = "beta-1";
+pub const BETA1: &str = "beta1";
 pub const NIGHTLY: &str = "nightly";
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{
-        CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME, DATE_FORMAT_URL_FRIENDLY,
-        FUELUP_GH_PAGES,
+        CHANNEL_BETA1_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
+        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainName, OfficialToolchainDescription},
@@ -18,6 +18,7 @@ use tracing::warn;
 pub const LATEST: &str = "latest";
 pub const STABLE: &str = "stable";
 pub const BETA: &str = "beta";
+pub const BETA1: &str = "beta-1";
 pub const NIGHTLY: &str = "nightly";
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -43,6 +44,7 @@ impl Channel {
         let channel_file_name = match desc.name {
             DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
             DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,
+            DistToolchainName::Beta1 => CHANNEL_BETA1_FILE_NAME,
         };
 
         let mut channel_url = FUELUP_GH_PAGES.to_owned();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,7 +6,7 @@ pub const CHANNEL_LATEST_URL: &str =
     "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-latest.toml";
 pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-latest.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
-pub const CHANNEL_BETA1_FILE_NAME: &str = "channel-fuel-beta1.toml";
+pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,6 +6,7 @@ pub const CHANNEL_LATEST_URL: &str =
     "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-latest.toml";
 pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-latest.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
+pub const CHANNEL_BETA1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,7 +6,7 @@ pub const CHANNEL_LATEST_URL: &str =
     "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-latest.toml";
 pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-latest.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
-pub const CHANNEL_BETA1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
+pub const CHANNEL_BETA1_FILE_NAME: &str = "channel-fuel-beta1.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -28,6 +28,7 @@ pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum DistToolchainName {
+    Beta1,
     Latest,
     Nightly,
 }
@@ -37,6 +38,7 @@ impl fmt::Display for DistToolchainName {
         match self {
             DistToolchainName::Latest => write!(f, "{}", channel::LATEST),
             DistToolchainName::Nightly => write!(f, "{}", channel::NIGHTLY),
+            DistToolchainName::Beta1 => write!(f, "{}", channel::BETA1),
         }
     }
 }
@@ -47,6 +49,7 @@ impl FromStr for DistToolchainName {
         match s {
             channel::LATEST => Ok(Self::Latest),
             channel::NIGHTLY => Ok(Self::Nightly),
+            channel::BETA1 => Ok(Self::Beta1),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -21,7 +21,7 @@ use crate::target_triple::TargetTriple;
 
 pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::LATEST,
-    channel::BETA,
+    channel::BETA_1,
     channel::NIGHTLY,
     channel::STABLE,
 ];
@@ -38,7 +38,7 @@ impl fmt::Display for DistToolchainName {
         match self {
             DistToolchainName::Latest => write!(f, "{}", channel::LATEST),
             DistToolchainName::Nightly => write!(f, "{}", channel::NIGHTLY),
-            DistToolchainName::Beta1 => write!(f, "{}", channel::BETA1),
+            DistToolchainName::Beta1 => write!(f, "{}", channel::BETA_1),
         }
     }
 }
@@ -49,7 +49,7 @@ impl FromStr for DistToolchainName {
         match s {
             channel::LATEST => Ok(Self::Latest),
             channel::NIGHTLY => Ok(Self::Nightly),
-            channel::BETA1 => Ok(Self::Beta1),
+            channel::BETA_1 => Ok(Self::Beta1),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }
@@ -120,7 +120,17 @@ impl FromStr for OfficialToolchainDescription {
                     date,
                     target,
                 }),
-                Err(e) => bail!("Invalid toolchain metadata within input '{}' - {}", s, e),
+                Err(e) => {
+                    if s == channel::BETA_1 {
+                        Ok(Self {
+                            name: DistToolchainName::from_str(s)?,
+                            date: None,
+                            target: TargetTriple::from_host().ok(),
+                        })
+                    } else {
+                        bail!("Invalid toolchain metadata within input '{}' - {}", s, e)
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
channel published at: https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-1.toml

With this code update users can do `fuelup toolchain install beta-1`.