### PR TITLE
fix: uninstall logic

### DIFF
--- a/src/ops/fuelup_toolchain/uninstall.rs
+++ b/src/ops/fuelup_toolchain/uninstall.rs
@@ -13,18 +13,19 @@ use crate::{
 pub fn uninstall(command: UninstallCommand) -> Result<()> {
     let UninstallCommand { name } = command;
 
-    let mut toolchain = Toolchain::from_path(&name)?;
-
     let config = Config::from_env()?;
-    if toolchain.is_official() {
-        let description = OfficialToolchainDescription::from_str(&name)?;
-        toolchain = Toolchain::from_path(&description.to_string())?;
 
-        if config.hash_exists(&description) {
-            let hash_file = config.hashes_dir().join(description.to_string());
-            fs::remove_file(hash_file)?;
-        };
-    }
+    let toolchain = match OfficialToolchainDescription::from_str(&name) {
+        Ok(desc) => {
+            if config.hash_exists(&desc) {
+                let hash_file = config.hashes_dir().join(desc.to_string());
+                fs::remove_file(hash_file)?;
+            };
+
+            Toolchain::from_path(&desc.to_string())?
+        }
+        Err(_) => Toolchain::from_path(&name)?,
+    };
 
     if !toolchain.exists() {
         info!("toolchain '{}' does not exist", &toolchain.name);


### PR DESCRIPTION
We can't execute `fuelup toolchain uninstall beta-1` in the current version. This is a bug.

This logic change fixes the above bug, carried from the suggestion by @mitchmindtree in a previous PR (#259)