### PR TITLE
refactor: rename official toolchains to distributable toolchains for consistency

### DIFF
--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -13,7 +13,7 @@ The Fuel toolchain is distributed on one [release channel]: latest (with nightly
 `fuelup` uses the `latest` channel by default, which
 represents the latest release of the Fuel toolchain.
 
-When new versions of the components within an official Fuel toolchain (`latest` or `nightly`)
+When new versions of the components within an distributable Fuel toolchain (`latest` or `nightly`)
 are released, simply type `fuelup update` to update:
 
 ```sh

--- a/docs/src/concepts/toolchains.md
+++ b/docs/src/concepts/toolchains.md
@@ -3,7 +3,7 @@
 Many `fuelup` commands deal with _toolchains_, a single installation of the
 Fuel toolchain. `fuelup` supports **two** types of toolchains.
 
-1. Official toolchains which track the official release [channels] (_latest_ and _nightly_);
+1. Distributable toolchains which track the official release [channels] (_latest_ and _nightly_);
 2. Custom toolchains and install individual components in a modular manner.
 
 [channels]: channels/index.md

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -10,7 +10,7 @@
 | `fuelup component add fuel-core@0.9.5`    | Adds _[fuel-core]_ v0.9.5 to the currently active custom toolchain                       |
 | `fuelup component remove forc`            | Removes _forc_ from the currently active custom toolchain                                |
 | `fuelup self update`                      | Updates _fuelup_                                                                         |
-| `fuelup check`                            | Checks for updates to official toolchains                                                |
+| `fuelup check`                            | Checks for updates to distributable toolchains                                           |
 | `fuelup show`                             | Shows the active toolchain and installed toolchains, as well as the host and fuelup home |
 | `fuelup toolchain help`                   | Shows the `help` page for a subcommand (like `toolchain`)                                |
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -4,7 +4,7 @@ use crate::{
         DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
-    toolchain::{DistToolchainName, OfficialToolchainDescription},
+    toolchain::{DistToolchainDescription, DistToolchainName},
 };
 use anyhow::{bail, Result};
 use component::Components;
@@ -39,7 +39,7 @@ pub struct Package {
 
 impl Channel {
     /// The returned `String` is a sha256 hash of the downloaded toolchain TOML bytes.
-    pub fn from_dist_channel(desc: &OfficialToolchainDescription) -> Result<(Self, String)> {
+    pub fn from_dist_channel(desc: &DistToolchainDescription) -> Result<(Self, String)> {
         let channel_file_name = match desc.name {
             DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
             DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -52,7 +52,7 @@ fn name_allowed(s: &str) -> Result<String> {
 
     if RESERVED_TOOLCHAIN_NAMES.contains(&name) {
         bail!(
-            "Cannot use official toolchain name '{}' as a custom toolchain name",
+            "Cannot use distributable toolchain name '{}' as a custom toolchain name",
             s
         )
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::io::{self, ErrorKind};
 use crate::file::write_file;
 use crate::fmt::format_toolchain_with_target;
 use crate::path::{ensure_dir_exists, hashes_dir, toolchains_dir};
-use crate::toolchain::{OfficialToolchainDescription, RESERVED_TOOLCHAIN_NAMES};
+use crate::toolchain::{DistToolchainDescription, RESERVED_TOOLCHAIN_NAMES};
 
 pub struct Config {
     toolchains_dir: PathBuf,
@@ -28,7 +28,7 @@ impl Config {
 
     pub(crate) fn hash_matches(
         &self,
-        description: &OfficialToolchainDescription,
+        description: &DistToolchainDescription,
         hash: &str,
     ) -> Result<bool> {
         let hash_path = self.hashes_dir.join(description.to_string());
@@ -42,7 +42,7 @@ impl Config {
         }
     }
 
-    pub(crate) fn hash_exists(&self, description: &OfficialToolchainDescription) -> bool {
+    pub(crate) fn hash_exists(&self, description: &DistToolchainDescription) -> bool {
         self.hashes_dir.join(description.to_string()).is_file()
     }
 
@@ -82,7 +82,7 @@ impl Config {
         }
     }
 
-    pub(crate) fn list_official_toolchains(&self) -> Result<Vec<String>> {
+    pub(crate) fn list_dist_toolchains(&self) -> Result<Vec<String>> {
         if self.toolchains_dir.is_dir() {
             let toolchains: Vec<String> = fs::read_dir(&self.toolchains_dir)?
                 .filter_map(io::Result::ok)

--- a/src/download.rs
+++ b/src/download.rs
@@ -22,7 +22,7 @@ use crate::constants::CHANNEL_LATEST_URL;
 use crate::file::hard_or_symlink_file;
 use crate::path::fuelup_bin;
 use crate::target_triple::TargetTriple;
-use crate::toolchain::OfficialToolchainDescription;
+use crate::toolchain::DistToolchainDescription;
 
 fn github_releases_download_url(repo: &str, tag: &Version, tarball: &str) -> String {
     format!(
@@ -123,7 +123,7 @@ pub fn get_latest_version(name: &str) -> Result<Version> {
         resp.into_reader().read_to_end(&mut data)?;
 
         if let Ok((channel, _)) =
-            Channel::from_dist_channel(&OfficialToolchainDescription::from_str("latest")?)
+            Channel::from_dist_channel(&DistToolchainDescription::from_str("latest")?)
         {
             channel
                 .pkg

--- a/src/fuelup_cli.rs
+++ b/src/fuelup_cli.rs
@@ -35,7 +35,7 @@ enum Commands {
     Toolchain(ToolchainCommand),
     /// Show the active and installed toolchains, as well as the host and fuelup home
     Show(ShowCommand),
-    /// Updates the official toolchains, if already installed
+    /// Updates the distributable toolchains, if already installed
     Update(UpdateCommand),
 }
 

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -5,7 +5,7 @@ use crate::{
     download::DownloadCfg,
     fmt::{bold, colored_bold},
     target_triple::TargetTriple,
-    toolchain::{OfficialToolchainDescription, Toolchain},
+    toolchain::{DistToolchainDescription, Toolchain},
 };
 use anyhow::{bail, Result};
 use component::{self, Components};
@@ -101,7 +101,7 @@ fn check_fuelup() -> Result<()> {
 }
 
 fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
-    let description = OfficialToolchainDescription::from_str(toolchain)?;
+    let description = DistToolchainDescription::from_str(toolchain)?;
 
     let (dist_channel, _) = Channel::from_dist_channel(&description)?;
     let latest_package_versions = collect_package_versions(dist_channel);
@@ -167,7 +167,7 @@ pub fn check(command: CheckCommand) -> Result<()> {
 
     let cfg = Config::from_env()?;
 
-    for toolchain in cfg.list_official_toolchains()? {
+    for toolchain in cfg.list_dist_toolchains()? {
         // TODO: remove once date/target are supported
         let name = toolchain.split_once('-').unwrap_or_default().0;
         check_toolchain(name, verbose)?;

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -15,7 +15,7 @@ pub fn add(command: AddCommand) -> Result<()> {
     } = command;
 
     let toolchain = Toolchain::from_settings()?;
-    if toolchain.is_official() {
+    if toolchain.is_distributed() {
         bail!(
             "Installing specific components is reserved for custom toolchains.
 You are currently using '{}'.

--- a/src/ops/fuelup_component/remove.rs
+++ b/src/ops/fuelup_component/remove.rs
@@ -7,7 +7,7 @@ pub fn remove(command: RemoveCommand) -> Result<()> {
 
     let toolchain = Toolchain::from_settings()?;
 
-    if toolchain.is_official() {
+    if toolchain.is_distributed() {
         bail!(
             "Removing specific components is reserved for custom toolchains.
 You are currently using '{}'.

--- a/src/ops/fuelup_default.rs
+++ b/src/ops/fuelup_default.rs
@@ -5,7 +5,7 @@ use tracing::info;
 use crate::{
     path::settings_file,
     settings::SettingsFile,
-    toolchain::{OfficialToolchainDescription, Toolchain},
+    toolchain::{DistToolchainDescription, Toolchain},
 };
 
 pub fn default(toolchain: Option<String>) -> Result<()> {
@@ -19,7 +19,7 @@ pub fn default(toolchain: Option<String>) -> Result<()> {
         }
     };
 
-    let new_default = match OfficialToolchainDescription::from_str(&toolchain) {
+    let new_default = match DistToolchainDescription::from_str(&toolchain) {
         Ok(desc) => Toolchain::from_path(&desc.to_string())?,
         Err(_) => Toolchain::from_path(&toolchain)?,
     };

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::path::settings_file;
 use crate::settings::SettingsFile;
-use crate::toolchain::{OfficialToolchainDescription, Toolchain};
+use crate::toolchain::{DistToolchainDescription, Toolchain};
 use crate::{channel::Channel, commands::toolchain::InstallCommand};
 use anyhow::{bail, Result};
 use std::fmt::Write;
@@ -11,7 +11,7 @@ use tracing::{error, info};
 pub fn install(command: InstallCommand) -> Result<()> {
     let InstallCommand { name } = command;
 
-    let description = OfficialToolchainDescription::from_str(&name)?;
+    let description = DistToolchainDescription::from_str(&name)?;
 
     let settings_file = settings_file();
     if !settings_file.exists() {

--- a/src/ops/fuelup_toolchain/uninstall.rs
+++ b/src/ops/fuelup_toolchain/uninstall.rs
@@ -7,7 +7,7 @@ use crate::{
     commands::toolchain::UninstallCommand,
     config::Config,
     ops::fuelup_default,
-    toolchain::{OfficialToolchainDescription, Toolchain},
+    toolchain::{DistToolchainDescription, Toolchain},
 };
 
 pub fn uninstall(command: UninstallCommand) -> Result<()> {
@@ -16,8 +16,8 @@ pub fn uninstall(command: UninstallCommand) -> Result<()> {
     let mut toolchain = Toolchain::from_path(&name)?;
 
     let config = Config::from_env()?;
-    if toolchain.is_official() {
-        let description = OfficialToolchainDescription::from_str(&name)?;
+    if toolchain.is_distributed() {
+        let description = DistToolchainDescription::from_str(&name)?;
         toolchain = Toolchain::from_path(&description.to_string())?;
 
         if config.hash_exists(&description) {

--- a/src/ops/fuelup_update.rs
+++ b/src/ops/fuelup_update.rs
@@ -2,7 +2,7 @@ use crate::{
     channel::Channel,
     config::Config,
     fmt::{bold, colored_bold},
-    toolchain::{OfficialToolchainDescription, Toolchain},
+    toolchain::{DistToolchainDescription, Toolchain},
 };
 use anyhow::{bail, Result};
 use std::io::Write;
@@ -16,14 +16,14 @@ const UNCHANGED: &str = "unchanged";
 
 pub fn update() -> Result<()> {
     let config = Config::from_env()?;
-    let toolchains = config.list_official_toolchains()?;
+    let toolchains = config.list_dist_toolchains()?;
     let mut summary: Vec<(String, String)> = Vec::with_capacity(toolchains.len());
 
     for toolchain in toolchains {
         let mut installed_bins = String::new();
         let mut errored_bins = String::new();
 
-        let description = OfficialToolchainDescription::from_str(&toolchain)?;
+        let description = DistToolchainDescription::from_str(&toolchain)?;
         info!("updating the '{}' toolchain", description);
 
         let (cfgs, hash) = if let Ok((channel, hash)) = Channel::from_dist_channel(&description) {

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -373,7 +373,7 @@ fn fuelup_toolchain_new_disallowed() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
         for toolchain in [channel::LATEST, channel::NIGHTLY] {
             let output = cfg.fuelup(&["toolchain", "new", toolchain]);
-            let expected_stderr = format!("error: Invalid value \"{toolchain}\" for '<NAME>': Cannot use official toolchain name '{toolchain}' as a custom toolchain name\n\nFor more information try --help\n");
+            let expected_stderr = format!("error: Invalid value \"{toolchain}\" for '<NAME>': Cannot use distributable toolchain name '{toolchain}' as a custom toolchain name\n\nFor more information try --help\n");
             assert_eq!(output.stderr, expected_stderr);
         }
     })?;
@@ -387,7 +387,7 @@ fn fuelup_toolchain_new_disallowed_with_target() -> Result<()> {
         let target_triple = TargetTriple::from_host().unwrap();
         let toolchain_name = "latest-".to_owned() + &target_triple.to_string();
         let output = cfg.fuelup(&["toolchain", "new", &toolchain_name]);
-        let expected_stderr = format!("error: Invalid value \"{toolchain_name}\" for '<NAME>': Cannot use official toolchain name '{toolchain_name}' as a custom toolchain name\n\nFor more information try --help\n");
+        let expected_stderr = format!("error: Invalid value \"{toolchain_name}\" for '<NAME>': Cannot use distributable toolchain name '{toolchain_name}' as a custom toolchain name\n\nFor more information try --help\n");
         assert_eq!(output.stderr, expected_stderr);
     })?;
 


### PR DESCRIPTION
Code quality related, we have `DistToolchainName` but `OfficialToolchainDescription` - both mean the same thing but have a different naming. This PR renames all references to 'official' toolchains as 'distributable' or 'distributed' toolchains to be more consistent.