### PR TITLE
feat: beta-2 toolchain

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{
-        CHANNEL_BETA_1_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
-        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
+        CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_LATEST_FILE_NAME,
+        CHANNEL_NIGHTLY_FILE_NAME, DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -18,6 +18,7 @@ use tracing::warn;
 pub const LATEST: &str = "latest";
 pub const STABLE: &str = "stable";
 pub const BETA_1: &str = "beta-1";
+pub const BETA_2: &str = "beta-2";
 pub const NIGHTLY: &str = "nightly";
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -37,6 +38,10 @@ pub struct Package {
     pub version: Version,
 }
 
+pub fn is_beta_toolchain(name: &str) -> bool {
+    name == BETA_1 || name == BETA_2
+}
+
 impl Channel {
     /// The returned `String` is a sha256 hash of the downloaded toolchain TOML bytes.
     pub fn from_dist_channel(desc: &DistToolchainDescription) -> Result<(Self, String)> {
@@ -44,6 +49,7 @@ impl Channel {
             DistToolchainName::Latest => CHANNEL_LATEST_FILE_NAME,
             DistToolchainName::Nightly => CHANNEL_NIGHTLY_FILE_NAME,
             DistToolchainName::Beta1 => CHANNEL_BETA_1_FILE_NAME,
+            DistToolchainName::Beta2 => CHANNEL_BETA_2_FILE_NAME,
         };
 
         let mut channel_url = FUELUP_GH_PAGES.to_owned();

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -7,6 +7,7 @@ pub const CHANNEL_LATEST_URL: &str =
 pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-latest.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
 pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
+pub const CHANNEL_BETA_2_FILE_NAME: &str = "channel-fuel-beta-2.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use time::Date;
 use tracing::{error, info};
 
-use crate::channel;
+use crate::channel::{self, is_beta_toolchain};
 use crate::constants::DATE_FORMAT;
 use crate::download::{download_file_and_unpack, link_to_fuelup, unpack_bins, DownloadCfg};
 use crate::ops::fuelup_self::self_update;
@@ -22,6 +22,7 @@ use crate::target_triple::TargetTriple;
 pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::LATEST,
     channel::BETA_1,
+    channel::BETA_2,
     channel::NIGHTLY,
     channel::STABLE,
 ];
@@ -29,6 +30,7 @@ pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
 #[derive(Debug, Eq, PartialEq)]
 pub enum DistToolchainName {
     Beta1,
+    Beta2,
     Latest,
     Nightly,
 }
@@ -39,6 +41,7 @@ impl fmt::Display for DistToolchainName {
             DistToolchainName::Latest => write!(f, "{}", channel::LATEST),
             DistToolchainName::Nightly => write!(f, "{}", channel::NIGHTLY),
             DistToolchainName::Beta1 => write!(f, "{}", channel::BETA_1),
+            DistToolchainName::Beta2 => write!(f, "{}", channel::BETA_2),
         }
     }
 }
@@ -50,6 +53,7 @@ impl FromStr for DistToolchainName {
             channel::LATEST => Ok(Self::Latest),
             channel::NIGHTLY => Ok(Self::Nightly),
             channel::BETA_1 => Ok(Self::Beta1),
+            channel::BETA_2 => Ok(Self::Beta2),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }
@@ -121,7 +125,7 @@ impl FromStr for DistToolchainDescription {
                     target,
                 }),
                 Err(e) => {
-                    if s == channel::BETA_1 {
+                    if is_beta_toolchain(s) {
                         Ok(Self {
                             name: DistToolchainName::from_str(s)?,
                             date: None,


### PR DESCRIPTION
supports installation of `beta-2` toolchain: `fuelup toolchain install beta-2`.