### PR TITLE
fix: has_component check

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -191,12 +191,18 @@ impl Toolchain {
     }
 
     pub fn has_component(&self, component: &str) -> bool {
-        let executables = &Components::collect()
+        if let Some(component) = Components::collect()
             .expect("Failed to collect components")
-            .component[component]
-            .executables;
-
-        executables.iter().all(|e| self.bin_path.join(e).is_file())
+            .component
+            .get(component)
+        {
+            component
+                .executables
+                .iter()
+                .all(|e| self.bin_path.join(e).is_file())
+        } else {
+            false
+        }
     }
 
     fn can_remove(&self, component: &str) -> bool {


### PR DESCRIPTION
Closes #274 

Adding an invalid component currently panicks, as reported by @camiinthisthang:

```console
$ fuelup component add forc-core@0.14.1
thread 'main' panicked at 'no entry found for key', src/toolchain.rs:190:28
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is caused by the `has_component()` check which was checking if a component existed in the currently active toolchain before trying to add it, by doing `component[component]`. We should use `get()` instead.