### PR TITLE
fix: fuelup check

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -84,17 +84,21 @@ impl Config {
 
     pub(crate) fn list_dist_toolchains(&self) -> Result<Vec<String>> {
         if self.toolchains_dir.is_dir() {
-            let toolchains: Vec<String> = fs::read_dir(&self.toolchains_dir)?
+            let mut dist_toolchains: Vec<String> = Vec::new();
+            let installed_toolchains: Vec<String> = fs::read_dir(&self.toolchains_dir)?
                 .filter_map(io::Result::ok)
-                .filter(|e| {
-                    e.file_type().map(|f| f.is_dir()).unwrap_or(false)
-                        && RESERVED_TOOLCHAIN_NAMES.iter().any(|t| {
-                            e.file_name().to_string_lossy() == format_toolchain_with_target(t)
-                        })
-                })
+                .filter(|e| e.file_type().map(|f| f.is_dir()).unwrap_or(false))
                 .map(|e| e.file_name().into_string().ok().unwrap_or_default())
                 .collect();
-            Ok(toolchains)
+
+            for name in RESERVED_TOOLCHAIN_NAMES {
+                let dist_toolchain = format_toolchain_with_target(name);
+                if installed_toolchains.contains(&dist_toolchain) {
+                    dist_toolchains.push(name.to_string())
+                }
+            }
+
+            Ok(dist_toolchains)
         } else {
             Ok(Vec::new())
         }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -168,9 +168,7 @@ pub fn check(command: CheckCommand) -> Result<()> {
     let cfg = Config::from_env()?;
 
     for toolchain in cfg.list_dist_toolchains()? {
-        // TODO: remove once date/target are supported
-        let name = toolchain.split_once('-').unwrap_or_default().0;
-        check_toolchain(name, verbose)?;
+        check_toolchain(&toolchain, verbose)?;
     }
 
     check_fuelup()?;

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -196,14 +196,20 @@ fn fuelup_check() -> Result<()> {
     // Test that only the 'latest' toolchain shows.
     testcfg::setup(FuelupState::LatestAndCustomInstalled, &|cfg| {
         let output = cfg.fuelup(&["check"]);
-        assert_eq!(output.stdout, "latest-x86_64-unknown-linux-gnu\n\n");
+        assert_eq!(
+            output.stdout,
+            format!("latest-{}\n\n", TargetTriple::from_host().unwrap())
+        );
         assert!(output.status.success());
     })?;
 
     // Test that toolchain names with '-' inside are parsed correctly.
     testcfg::setup(FuelupState::Beta1Installed, &|cfg| {
         let output = cfg.fuelup(&["check"]);
-        assert_eq!(output.stdout, "beta-1-x86_64-unknown-linux-gnu\n\n");
+        assert_eq!(
+            output.stdout,
+            format!("beta-1-{}\n\n", TargetTriple::from_host().unwrap())
+        );
         assert!(output.status.success());
     })?;
 

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -193,6 +193,20 @@ fn fuelup_check() -> Result<()> {
         assert!(output.status.success());
     })?;
 
+    // Test that only the 'latest' toolchain shows.
+    testcfg::setup(FuelupState::LatestAndCustomInstalled, &|cfg| {
+        let output = cfg.fuelup(&["check"]);
+        assert_eq!(output.stdout, "latest-x86_64-unknown-linux-gnu\n\n");
+        assert!(output.status.success());
+    })?;
+
+    // Test that toolchain names with '-' inside are parsed correctly.
+    testcfg::setup(FuelupState::Beta1Installed, &|cfg| {
+        let output = cfg.fuelup(&["check"]);
+        assert_eq!(output.stdout, "beta-1-x86_64-unknown-linux-gnu\n\n");
+        assert!(output.status.success());
+    })?;
+
     Ok(())
 }
 

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -17,6 +17,7 @@ pub enum FuelupState {
     LatestAndCustomInstalled,
     LatestAndNightlyInstalled,
     NightlyAndNightlyDateInstalled,
+    Beta1Installed,
 }
 
 pub struct TestCfg {
@@ -140,6 +141,7 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
     let target = TargetTriple::from_host().unwrap();
     let latest = format!("latest-{}", target);
     let nightly = format!("nightly-{}", target);
+    let beta_1 = format!("beta-1-{}", target);
 
     match state {
         FuelupState::Empty => {}
@@ -187,6 +189,14 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
                 &format!("nightly-{}-{}", DATE, target),
             )?;
             setup_settings_file(&tmp_fuelup_root_path, &nightly)?;
+        }
+        FuelupState::Beta1Installed => {
+            setup_toolchain(&tmp_fuelup_root_path, &beta_1)?;
+            setup_toolchain(
+                &tmp_fuelup_root_path,
+                &format!("beta-1-{}-{}", DATE, target),
+            )?;
+            setup_settings_file(&tmp_fuelup_root_path, &beta_1)?;
         }
     }
 


### PR DESCRIPTION
`fuelup check` got broken by the addition of `beta-1` and `beta-2` toolchains:

```sh
latest-x86_64-unknown-linux-gnu
  forc - Up to date : 0.31.1
  fuel-core - Up to date : 0.14.1
Unknown name for toolchain: beta
```

The problem was with the name parsing, which was trying for `beta` and not `beta-1`.