### PR TITLE
do fs::remove_file before fs::copy in case of running binaries

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -303,6 +303,9 @@ pub fn unpack_bins(dir: &Path, dst_dir: &Path) -> Result<Vec<PathBuf>> {
                     &bin_file_name.to_string_lossy(),
                     dir.display()
                 );
+                if dir.join(&bin_file_name).exists() {
+                    fs::remove_file(dir.join(&bin_file_name))?;
+                }
                 fs::copy(bin_file.path(), dir.join(&bin_file_name))?;
                 downloaded.push(dst_dir.join(bin_file_name));
             }

--- a/src/download.rs
+++ b/src/download.rs
@@ -303,10 +303,12 @@ pub fn unpack_bins(dir: &Path, dst_dir: &Path) -> Result<Vec<PathBuf>> {
                     &bin_file_name.to_string_lossy(),
                     dir.display()
                 );
-                if dir.join(&bin_file_name).exists() {
-                    fs::remove_file(dir.join(&bin_file_name))?;
+
+                let dst_bin_file = dir.join(&bin_file_name);
+                if dst_bin_file.exists() {
+                    fs::remove_file(&dst_bin_file)?;
                 }
-                fs::copy(bin_file.path(), dir.join(&bin_file_name))?;
+                fs::copy(bin_file.path(), dst_bin_file)?;
                 downloaded.push(dst_dir.join(bin_file_name));
             }
 


### PR DESCRIPTION
Closes #278 

This was also the solution to a somewhat related problem we had prior, related to ETXTBSY bug: https://github.com/FuelLabs/fuelup/pull/253

The solution is to unlink (`fs::remove_file`) the running executable prior to trying to do an `fs::copy`.

Noticed that there's a `dst_dir` in the next line which could be confusing - this should probably be fixed in a separate refactor PR.