### PR TITLE
refactor: rewrite sh commands into build-channel script

### DIFF
--- a/.github/workflows/publish-nightly-channel.yml
+++ b/.github/workflows/publish-nightly-channel.yml
@@ -33,13 +33,7 @@ jobs:
 
             CHANNEL_TOML="channel-fuel-nightly.toml"
 
-            # Create header for channel
-            touch $CHANNEL_TOML
-            echo -e "published_by = \"https://github.com/FuelLabs/fuelup/actions/runs/${GITHUB_RUN_ID}\"\n" >> $CHANNEL_TOML
-            build-channel nightly $CHANNEL_TOML
-
-            # Remove extra newline at the end
-            truncate -s -1 $CHANNEL_TOML
+            build-channel nightly $CHANNEL_TOML $GITHUB_RUN_ID
 
             cp $CHANNEL_TOML ${{ env.NIGHTLY_CHANNEL_DIR }}
 

--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -155,16 +155,9 @@ jobs:
         if: ${{ env.LATEST_COMPATIBLE_FORC && env.LATEST_COMPATIBLE_FUEL_CORE }}
         run: |
             mkdir -p ${{ env.LATEST_CHANNEL_DIR }}
-
             CHANNEL_TOML="channel-fuel-latest.toml"
 
-            # Create header for channel
-            touch $CHANNEL_TOML
-            echo -e "published_by = \"https://github.com/FuelLabs/fuelup/actions/runs/${GITHUB_RUN_ID}\"\n" >> $CHANNEL_TOML
-            build-channel latest $CHANNEL_TOML forc=${{ env.LATEST_COMPATIBLE_FORC }} fuel-core=${{ env.LATEST_COMPATIBLE_FUEL_CORE }}
-
-            # Remove extra newline at the end
-            truncate -s -1 $CHANNEL_TOML
+            build-channel latest $CHANNEL_TOML $GITHUB_RUN_ID forc=${{ env.LATEST_COMPATIBLE_FORC }} fuel-core=${{ env.LATEST_COMPATIBLE_FUEL_CORE }}
 
             cp $CHANNEL_TOML ${{ env.LATEST_CHANNEL_DIR }}
 

--- a/ci/build-channel/src/main.rs
+++ b/ci/build-channel/src/main.rs
@@ -30,6 +30,8 @@ struct Args {
     pub channel: String,
     /// the TOML file name
     pub out_file: String,
+    /// the Github run ID
+    pub github_run_id: String,
     /// Component name [possible values: latest]
     #[clap(value_parser = parse_key_val::<String, Version>)]
     pub packages: Vec<(String, Version)>,
@@ -226,7 +228,14 @@ fn main() -> Result<()> {
     }
 
     println!("writing channel: '{}'", &args.out_file);
-    fs::write(args.out_file, document.to_string())?;
+
+    let mut channel_str = String::new();
+    channel_str.push_str(&format!(
+        "published_by = \"https://github.com/FuelLabs/fuelup/actions/runs/{}\"\n",
+        args.github_run_id
+    ));
+    channel_str.push_str(&document.to_string());
+    fs::write(&args.out_file, channel_str.to_string())?;
 
     Ok(())
 }


### PR DESCRIPTION
The `published_by` metadata was missing for a while in the [published channels](https://github.com/FuelLabs/fuelup/blob/f9a43d08d50aaba0ba716eec7da923903dddd831/channel-fuel-latest.toml), this PR fixes that as well as serves as a general cleanup to reduce reliance on shell commands and rather use the Rust script instead for greater reliability.