### PR TITLE
fix 'toolchain install' tooltip and add testnet toolchain docs

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,6 +8,8 @@
   - [Channels](concepts/channels/index.md)
     - [latest](concepts/channels/latest.md)
     - [nightly](concepts/channels/nightly.md)
+    - [beta-1](concepts/channels/beta-1.md)
+    - [beta-2](concepts/channels/beta-2.md)
   - [Toolchains](concepts/toolchains.md)
   - [Components](concepts/components.md)
   - [Proxies](concepts/proxies.md)

--- a/docs/src/concepts/channels/beta-1.md
+++ b/docs/src/concepts/channels/beta-1.md
@@ -1,0 +1,4 @@
+# The `beta-1` channel
+
+The `beta-1` channel is a published TOML file describing the toolchain that is compatible with our [beta-1 testnet](https://fuel-labs.ghost.io/introducing-beta-1-testnet/).
+This toolchain should be used to interact with and build on the testnet. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-1.toml).

--- a/docs/src/concepts/channels/beta-2.md
+++ b/docs/src/concepts/channels/beta-2.md
@@ -1,0 +1,4 @@
+# The `beta-2` channel
+
+The `beta-2` channel is a published TOML file describing the toolchain that is compatible with our [beta-2 testnet](https://fuel-labs.ghost.io/announcing-beta-2-testnet/).
+This toolchain should be used to interact with and build on the testnet. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-2.toml).

--- a/docs/src/concepts/channels/index.md
+++ b/docs/src/concepts/channels/index.md
@@ -5,9 +5,11 @@
 | Channel       | Source          | Integration Tested   | Update Frequency         | Available |
 | ------------- | --------------- | -------------------- | ------------------------ | --------- |
 | **[latest]**  | published bins  | ✔️                   | checked every 30 minutes | ✔️        |
-| **[nightly]** | `master` branch | ➖                   | nightly (1:00 AM UTC)    | ✔️        |
-| **beta**      | published bins  | ✔️                   | every 6 weeks            | ➖        |
-| **stable**    | published bins  | ✔️ + successful beta | every 6 weeks            | ➖        |
+| **[nightly]** | `master` branch | ➖                  | nightly (1:00 AM UTC)    | ✔️        |
+| **beta-1**    | published bins  | ➖                  | ➖                       | ➖        |
+| **beta-2**    | published bins  | ➖                  | ➖                       | ➖        |
 
 [latest]: latest.html
 [nightly]: nightly.html
+[beta-1]: beta-1.html
+[beta-2]: beta-2.html

--- a/docs/src/concepts/channels/index.md
+++ b/docs/src/concepts/channels/index.md
@@ -6,8 +6,8 @@
 | ------------- | --------------- | -------------------- | ------------------------ | --------- |
 | **[latest]**  | published bins  | ✔️                    | checked every 30 minutes  | ✔️         |
 | **[nightly]** | `master` branch | ➖                   | nightly (1:00 AM UTC)     | ✔️         |
-| **beta-1**    | published bins  | ➖                   | only when necessary       | ✔️         |
-| **beta-2**    | published bins  | ➖                   | only when necessary       | ✔️         |
+| **[beta-1]**  | published bins  | ➖                   | only when necessary       | ✔️         |
+| **[beta-2]**  | published bins  | ➖                   | only when necessary       | ✔️         |
 
 [latest]: latest.html
 [nightly]: nightly.html

--- a/docs/src/concepts/channels/index.md
+++ b/docs/src/concepts/channels/index.md
@@ -4,10 +4,10 @@
 
 | Channel       | Source          | Integration Tested   | Update Frequency         | Available |
 | ------------- | --------------- | -------------------- | ------------------------ | --------- |
-| **[latest]**  | published bins  | ✔️                   | checked every 30 minutes | ✔️        |
-| **[nightly]** | `master` branch | ➖                  | nightly (1:00 AM UTC)    | ✔️        |
-| **beta-1**    | published bins  | ➖                  | ➖                       | ➖        |
-| **beta-2**    | published bins  | ➖                  | ➖                       | ➖        |
+| **[latest]**  | published bins  | ✔️                    | checked every 30 minutes  | ✔️         |
+| **[nightly]** | `master` branch | ➖                   | nightly (1:00 AM UTC)     | ✔️         |
+| **beta-1**    | published bins  | ➖                   | only when necessary       | ✔️         |
+| **beta-2**    | published bins  | ➖                   | only when necessary       | ✔️         |
 
 [latest]: latest.html
 [nightly]: nightly.html

--- a/docs/src/concepts/toolchains.md
+++ b/docs/src/concepts/toolchains.md
@@ -3,7 +3,7 @@
 Many `fuelup` commands deal with _toolchains_, a single installation of the
 Fuel toolchain. `fuelup` supports **two** types of toolchains.
 
-1. Distributable toolchains which track the official release [channels] (_latest_ and _nightly_);
+1. Distributable toolchains which track the official release [channels] (eg, _latest_, _nightly_);
 2. Custom toolchains and install individual components in a modular manner.
 
 [channels]: channels/index.md

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -19,7 +19,7 @@ pub enum ToolchainCommand {
 
 #[derive(Debug, Parser)]
 pub struct InstallCommand {
-    /// Toolchain name [possible values: latest, beta-1, nightly]
+    /// Toolchain name [possible values: latest, beta-1, beta-2, nightly]
     pub name: String,
 }
 


### PR DESCRIPTION
- Small fix to the help text of `fuelup toolchain install`
- add missing docs for testnet-specific toolchains.