### PR TITLE
fix: prefer .last() over .nth(1) while parsing version strings

### DIFF
--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -57,7 +57,7 @@ fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version
     {
         Ok(o) => {
             let output = String::from_utf8_lossy(&o.stdout).into_owned();
-            match output.split_whitespace().nth(1) {
+            match output.split_whitespace().last() {
                 Some(v) => {
                     let version = Version::parse(v)?;
                     print!("    - ");
@@ -120,7 +120,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
             Ok(o) => {
                 let output = String::from_utf8_lossy(&o.stdout).into_owned();
 
-                match output.split_whitespace().nth(1) {
+                match output.split_whitespace().last() {
                     Some(v) => {
                         let version = Version::parse(v)?;
                         bold(|s| write!(s, "  {} - ", &component.name));

--- a/src/ops/fuelup_component/list.rs
+++ b/src/ops/fuelup_component/list.rs
@@ -57,7 +57,7 @@ pub fn list(_command: ListCommand) -> Result<()> {
                 .output()
             {
                 let output = String::from_utf8_lossy(&o.stdout).into_owned();
-                output.split_whitespace().nth(1).map_or_else(
+                output.split_whitespace().last().map_or_else(
                     || None,
                     |v| Version::parse(v).map_or_else(|_| None, |v| Some(v.to_string())),
                 )

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -19,7 +19,7 @@ fn exec_show_version(component_executable: &Path) -> Result<()> {
     {
         Ok(o) => {
             let output = String::from_utf8_lossy(&o.stdout).into_owned();
-            match output.split_whitespace().nth(1) {
+            match output.split_whitespace().last() {
                 Some(v) => {
                     let version = Version::parse(v)?;
                     info!(" : {}", version);


### PR DESCRIPTION
This was unsound code since the result of `fuel-indexer --version` is separated by more than 1 whitespace. We haven't ran into this issue so far since the other bins all have 1 whitespace separation between its version string and its bin name.