### PR TITLE
feat: fuel toolchain specify version

### DIFF
--- a/src/toolchain_override.rs
+++ b/src/toolchain_override.rs
@@ -1,11 +1,15 @@
+use std::str::FromStr;
+
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use semver::Version;
+use serde::ser::SerializeSeq;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use toml_edit::{de, ser, Document};
 use tracing::warn;
 
 use crate::{
-    download::DownloadCfg, file, path::get_fuel_toolchain_toml, target_triple::TargetTriple,
-    toolchain::Toolchain,
+    download::DownloadCfg, file, ops::fuelup_component::add::split_versioned_component,
+    path::get_fuel_toolchain_toml, target_triple::TargetTriple, toolchain::Toolchain,
 };
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -16,19 +20,92 @@ pub struct ToolchainOverride {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ToolchainCfg {
     pub name: String,
-    pub components: Option<Vec<String>>,
+
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_component")]
+    #[serde(serialize_with = "serialize_component")]
+    pub components: Option<Vec<Component>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Component {
+    pub name: String,
+    pub version: Option<Version>,
+}
+
+impl Component {
+    pub fn new(name: String, version: Option<Version>) -> Self {
+        return Self { name, version };
+    }
+}
+
+fn deserialize_component<'de, D>(deserializer: D) -> Result<Option<Vec<Component>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: Option<Vec<String>> = Option::deserialize(deserializer)?;
+    if let Some(s) = s {
+        let mut res = vec![];
+        for maybe_versioned_component in s {
+            match Component::from_str(&maybe_versioned_component) {
+                Ok(component) => res.push(component),
+                Err(e) => return Err(serde::de::Error::custom(e)),
+            }
+        }
+
+        Ok(Some(res))
+    } else {
+        Ok(None)
+    }
+}
+
+fn serialize_component<S>(
+    components: &Option<Vec<Component>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match *components {
+        Some(ref components) => {
+            let mut seq = serializer.serialize_seq(Some(components.len()))?;
+            for component in components {
+                let component_str = match &component.version {
+                    Some(v) => format!("{}@{}", component.name, v),
+                    None => component.name.clone(),
+                };
+                seq.serialize_element(&component_str)?;
+            }
+
+            seq.end()
+        }
+        None => serializer.serialize_none(),
+    }
+}
+
+impl FromStr for Component {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (component, version) = split_versioned_component(s)?;
+
+        Ok(Component {
+            name: component,
+            version,
+        })
+    }
 }
 
 impl ToolchainCfg {
-    pub fn new(name: String, components: Option<Vec<String>>) -> Self {
-        Self { name, components }
+    pub fn new(name: String, components: Option<Vec<Component>>) -> Self {
+        return Self { name, components };
     }
 }
 
 impl ToolchainOverride {
     pub(crate) fn parse(toml: &str) -> Result<Self> {
-        let _override: ToolchainOverride = de::from_str(toml)?;
-        Ok(_override)
+        let toolchain_override: ToolchainOverride = de::from_str(toml)?;
+        Ok(toolchain_override)
     }
 
     pub(crate) fn to_toml(&self) -> std::result::Result<Document, ser::Error> {
@@ -60,16 +137,16 @@ impl ToolchainOverride {
             ),
             Some(components) => {
                 for component in components {
-                    if !toolchain.has_component(component) {
-                        let target_triple = TargetTriple::from_component(component).unwrap_or_else(|_| {
-                            panic!("Failed to create target triple for '{}'", component)
+                    if !toolchain.has_component(&component.name) {
+                        let target_triple = TargetTriple::from_component(&component.name).unwrap_or_else(|_| {
+                            panic!("Failed to create target triple for '{}'", component.name)
                         });
 
-                        if let Ok(download_cfg) = DownloadCfg::new(called, target_triple, None) {
+                        if let Ok(download_cfg) = DownloadCfg::new(called, target_triple, component.version.clone()) {
                             toolchain.add_component(download_cfg).unwrap_or_else(|_| {
                                 panic!(
                                     "Failed to add component '{}' to toolchain '{}'",
-                                    component, toolchain.name,
+                                    component.name, toolchain.name,
                                 )
                             });
                         }
@@ -77,6 +154,64 @@ impl ToolchainOverride {
                 }
             }
         };
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_toml() -> Result<()> {
+        let toml = r#"
+[toolchain]
+name = "latest"
+"#;
+
+        let toml_2 = r#"
+[toolchain]
+name = "nightly"
+components = []
+"#;
+
+        let toml_3 = r#"
+[toolchain]
+name = "beta-2"
+components = ["forc"]
+"#;
+
+        let toml_4 = r#"
+[toolchain]
+name = "my-toolchain"
+components = ["forc@0.31.3"]
+"#;
+
+        ToolchainOverride::parse(toml)?;
+        ToolchainOverride::parse(toml_2)?;
+        ToolchainOverride::parse(toml_3)?;
+        ToolchainOverride::parse(toml_4)?;
+        Ok(())
+    }
+
+    #[test]
+    fn parse_invalid_toml() -> Result<()> {
+        let toml_empty = r#""#;
+        let toml_no_name = r#"
+[toolchain]
+"#;
+        let toml_invalid_semver = r#"
+[toolchain]
+name = "latest"
+components = ["forc@0.31."]
+        "#;
+
+        for toml in [toml_no_name, toml_empty, toml_invalid_semver] {
+            assert!(ToolchainOverride::parse(toml)
+                .map_err(|e| e.to_string())
+                .is_err());
+        }
+
         Ok(())
     }
 }

--- a/src/toolchain_override.rs
+++ b/src/toolchain_override.rs
@@ -35,7 +35,7 @@ pub struct Component {
 
 impl Component {
     pub fn new(name: String, version: Option<Version>) -> Self {
-        return Self { name, version };
+        Self { name, version }
     }
 }
 
@@ -98,7 +98,7 @@ impl FromStr for Component {
 
 impl ToolchainCfg {
     pub fn new(name: String, components: Option<Vec<Component>>) -> Self {
-        return Self { name, components };
+        Self { name, components }
     }
 }
 

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use fuelup::settings::SettingsFile;
 use fuelup::target_triple::TargetTriple;
-use fuelup::toolchain_override::{ToolchainCfg, ToolchainOverride};
+use fuelup::toolchain_override::{Component, ToolchainCfg, ToolchainOverride};
 use std::os::unix::fs::OpenOptionsExt;
 use std::{
     env, fs,
@@ -272,10 +272,11 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
             setup_toolchain(&tmp_fuelup_root_path, &latest)?;
             setup_toolchain(&tmp_fuelup_root_path, "my-toolchain")?;
             setup_settings_file(&tmp_fuelup_root_path, &latest)?;
+            let forc = Component::new("forc".to_string(), None);
             setup_override_file(
                 tmp_home,
                 ToolchainOverride {
-                    toolchain: ToolchainCfg::new("my-toolchain".to_string(), None),
+                    toolchain: ToolchainCfg::new("my-toolchain".to_string(), Some(vec![forc])),
                 },
             )?;
         }


### PR DESCRIPTION
closes #320 

This might be far more complicated than it needed to be - ended up writing a serializer/deserializer for a `Component` struct, which contains a `name: String` and a `version: Option<semver::Version>`.

@mitchmindtree 's suggested TOML format [here](https://github.com/FuelLabs/fuelup/issues/320#issuecomment-1357169806) might reduce some complexity in parsing the file but make it slightly more verbose for the DevEx. I think this approach is a slightly nicer way to keep everything hidden from sight, but am open to changing the design/implementation at this stage before this is set in stone.

We also have to keep in mind #321 for whichever approach ends up being the final one, as this PR will affect how #321 is handled.