### PR TITLE
fix clippy lints related to the new rust version

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ impl Config {
     ) -> Result<bool> {
         let hash_path = self.hashes_dir.join(description.to_string());
 
-        match fs::read_to_string(&hash_path) {
+        match fs::read_to_string(hash_path) {
             Ok(h) => Ok(h == hash),
             Err(e) => match e.kind() {
                 ErrorKind::NotFound => Ok(false),

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -113,10 +113,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     for component in Components::collect_exclude_plugins()? {
         if let Some(latest_version) = latest_package_versions.get(&component.name) {
             let component_executable = toolchain.bin_path.join(&component.name);
-            match Command::new(&component_executable)
-                .arg("--version")
-                .output()
-            {
+            match Command::new(component_executable).arg("--version").output() {
                 Ok(o) => {
                     let output = String::from_utf8_lossy(&o.stdout).into_owned();
 

--- a/tests/testcfg.rs
+++ b/tests/testcfg.rs
@@ -159,10 +159,10 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
     let tmp_fuelup_bin_dir_path = tmp_home.join(".fuelup").join("bin");
     fs::create_dir(&tmp_fuelup_root_path).unwrap();
     fs::create_dir(&tmp_fuelup_bin_dir_path).unwrap();
-    fs::create_dir(&tmp_fuelup_root_path.join("toolchains")).unwrap();
+    fs::create_dir(tmp_fuelup_root_path.join("toolchains")).unwrap();
     fs::hard_link(
         root.parent().unwrap().join("fuelup"),
-        &tmp_fuelup_bin_dir_path.join("fuelup"),
+        tmp_fuelup_bin_dir_path.join("fuelup"),
     )?;
 
     let target = TargetTriple::from_host().unwrap();
@@ -189,13 +189,13 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
             setup_toolchain(&tmp_fuelup_root_path, &latest)?;
             setup_settings_file(&tmp_fuelup_root_path, &latest)?;
 
-            fs::create_dir_all(&tmp_home.join(".local/bin"))?;
+            fs::create_dir_all(tmp_home.join(".local/bin"))?;
             create_fuel_executable(&tmp_home.join(".local/bin/forc"))?;
 
             create_fuel_executable(&tmp_home.join(".local/bin/forc-wallet"))?;
             create_fuel_executable(&tmp_home.join(".fuelup/bin/forc-wallet"))?;
 
-            fs::create_dir_all(&tmp_home.join(".cargo/bin"))?;
+            fs::create_dir_all(tmp_home.join(".cargo/bin"))?;
 
             create_fuel_executable(&tmp_home.join(".cargo/bin/forc-explore"))?;
             create_fuel_executable(&tmp_home.join(".fuelup/bin/forc-explore"))?;


### PR DESCRIPTION
As per title, fix some lints to do with needless borrows.