### PR TITLE
feat: `fuelup show` should show the overridden toolchain

### DIFF
--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use fuelup::{channel, fmt::format_toolchain_with_target, target_triple::TargetTriple};
+use fuelup::{
+    channel, constants::FUEL_TOOLCHAIN_TOML_FILE, fmt::format_toolchain_with_target,
+    target_triple::TargetTriple,
+};
 use std::{env, path::Path};
 
 mod testcfg;
@@ -312,6 +315,49 @@ my_toolchain (default)
   fuel-core - not found
   fuel-indexer - not found
 "#
+        );
+        assert!(stdout.contains(expected_stdout));
+    })?;
+    Ok(())
+}
+
+#[test]
+fn fuelup_show_override() -> Result<()> {
+    testcfg::setup(FuelupState::LatestAndNightlyWithBetaOverride, &|cfg| {
+        let stdout = cfg.fuelup(&["show"]).stdout;
+
+        let mut lines = stdout.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            &format!("Default host: {}", TargetTriple::from_host().unwrap())
+        );
+        assert!(lines.next().unwrap().contains("fuelup home: "));
+
+        let target = TargetTriple::from_host().unwrap();
+        let expected_stdout = &format!(
+            r#"
+installed toolchains
+--------------------
+latest-{target} (default)
+nightly-{target}
+
+active toolchain
+-----------------
+beta-1-{target} (override), path: {}
+  forc - not found
+    - forc-client
+      - forc-deploy - not found
+      - forc-run - not found
+    - forc-doc - not found
+    - forc-explore - not found
+    - forc-fmt - not found
+    - forc-index - not found
+    - forc-lsp - not found
+    - forc-wallet - not found
+  fuel-core - not found
+  fuel-indexer - not found
+"#,
+            cfg.home.join(FUEL_TOOLCHAIN_TOML_FILE).display()
         );
         assert!(stdout.contains(expected_stdout));
     })?;


### PR DESCRIPTION
Closes #330 

Example, with `fuel-toolchain.toml` declaring `beta-2` as the overriding toolchain:

![image](https://user-images.githubusercontent.com/25565268/211256501-14b0f75c-16bf-466b-ab22-abbcb58d56ff.png)
