### PR TITLE
fix: default bug

### DIFF
--- a/src/ops/fuelup_default.rs
+++ b/src/ops/fuelup_default.rs
@@ -10,20 +10,24 @@ use crate::{
 };
 
 pub fn default(toolchain: Option<String>) -> Result<()> {
-    let current_toolchain = Toolchain::from_settings()?;
+    let maybe_current_toolchain = Toolchain::from_settings();
 
     let toolchain = match toolchain {
         Some(toolchain) => toolchain,
         None => {
             let mut result = String::new();
             if let Some(to) = ToolchainOverride::from_project_root() {
-                let name = match DistToolchainDescription::from_str(&to.cfg.toolchain.channel) {
+                let name = match DistToolchainDescription::from_str(&to.cfg.toolchain.channel.name)
+                {
                     Ok(desc) => desc.to_string(),
-                    Err(_) => to.cfg.toolchain.channel,
+                    Err(_) => to.cfg.toolchain.channel.to_string(),
                 };
                 result.push_str(&format!("{} (override), ", name))
             }
-            result.push_str(&format!("{} (default)", current_toolchain.name));
+
+            if let Ok(current_toolchain) = maybe_current_toolchain {
+                result.push_str(&format!("{} (default)", current_toolchain.name));
+            }
 
             info!("{}", result);
             return Ok(());

--- a/src/ops/fuelup_default.rs
+++ b/src/ops/fuelup_default.rs
@@ -10,12 +10,12 @@ use crate::{
 };
 
 pub fn default(toolchain: Option<String>) -> Result<()> {
-    let current_toolchain = Toolchain::from_settings()?;
-
     let toolchain = match toolchain {
         Some(toolchain) => toolchain,
         None => {
             let mut result = String::new();
+
+            let current_toolchain = Toolchain::from_settings()?;
             if let Some(to) = ToolchainOverride::from_project_root() {
                 let name =
                     match DistToolchainDescription::from_str(&to.cfg.toolchain.channel.to_string())

--- a/src/ops/fuelup_default.rs
+++ b/src/ops/fuelup_default.rs
@@ -14,8 +14,8 @@ pub fn default(toolchain: Option<String>) -> Result<()> {
         Some(toolchain) => toolchain,
         None => {
             let mut result = String::new();
-
             let current_toolchain = Toolchain::from_settings()?;
+
             if let Some(to) = ToolchainOverride::from_project_root() {
                 let name =
                     match DistToolchainDescription::from_str(&to.cfg.toolchain.channel.to_string())

--- a/src/ops/fuelup_default.rs
+++ b/src/ops/fuelup_default.rs
@@ -10,24 +10,27 @@ use crate::{
 };
 
 pub fn default(toolchain: Option<String>) -> Result<()> {
-    let maybe_current_toolchain = Toolchain::from_settings();
+    let current_toolchain = Toolchain::from_settings()?;
 
     let toolchain = match toolchain {
         Some(toolchain) => toolchain,
         None => {
             let mut result = String::new();
             if let Some(to) = ToolchainOverride::from_project_root() {
-                let name = match DistToolchainDescription::from_str(&to.cfg.toolchain.channel.name)
-                {
-                    Ok(desc) => desc.to_string(),
-                    Err(_) => to.cfg.toolchain.channel.to_string(),
-                };
-                result.push_str(&format!("{} (override), ", name))
+                let name =
+                    match DistToolchainDescription::from_str(&to.cfg.toolchain.channel.to_string())
+                    {
+                        Ok(desc) => desc.to_string(),
+                        Err(_) => to.cfg.toolchain.channel,
+                    };
+                result.push_str(&format!("{} (override)", name));
+
+                if current_toolchain.exists() {
+                    result.push_str(", ")
+                }
             }
 
-            if let Ok(current_toolchain) = maybe_current_toolchain {
-                result.push_str(&format!("{} (default)", current_toolchain.name));
-            }
+            result.push_str(&format!("{} (default)", current_toolchain.name));
 
             info!("{}", result);
             return Ok(());

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -169,18 +169,18 @@ impl Toolchain {
 
     pub fn from_settings() -> Result<Self> {
         let settings = SettingsFile::new(settings_file());
-        let toolchain_name = match settings.with(|s| Ok(s.default_toolchain.clone()))? {
-            Some(t) => t,
-            None => {
-                bail!("No default toolchain detected. Please install or create a toolchain first.")
+
+        if settings_file().exists() {
+            if let Some(t) = settings.with(|s| Ok(s.default_toolchain.clone()))? {
+                return Ok(Self {
+                    name: t.clone(),
+                    path: toolchain_dir(&t),
+                    bin_path: toolchain_bin_dir(&t),
+                });
             }
         };
 
-        Ok(Self {
-            name: toolchain_name.clone(),
-            path: toolchain_dir(&toolchain_name),
-            bin_path: toolchain_bin_dir(&toolchain_name),
-        })
+        bail!("No default toolchain detected. Please install or create a toolchain first.")
     }
 
     pub fn is_distributed(&self) -> bool {

--- a/tests/commands.rs
+++ b/tests/commands.rs
@@ -384,6 +384,7 @@ fn fuelup_default_empty() -> Result<()> {
             "No default toolchain detected. Please install or create a toolchain first.\n";
 
         assert_eq!(output.stdout, expected_stdout);
+        assert!(!cfg.home.join("settings.toml").exists());
     })?;
 
     Ok(())


### PR DESCRIPTION
closes #339 

So the cause of the bug was actually running `fuelup default` prior to installing any toolchain. As a result of the ordering of the code, a `settings.toml` file is generated but with no content inside, and on the next run of `fuelup default`, we always error out of the command, since `Toolchain::from_settings()` is the first fn call.

Changes:
- in `Toolchain::from_settings()` - check if `settings.toml` exists first.
- Reorder some code in `fuelup default`
- Added a line to assert that `settings.toml` isn't mistakenly created when `fuelup default` is ran on an empty setup.

There are 2 modes that `fuelup default` runs in. You can either execute:
1) `fuelup default`, or
2) `fuelup default <toolchain>`

The former prints out your current default toolchain and the latter switches your default toolchain. In the case of 2) we actually don't care if there's a current default toolchain - we only want to switch toolchains. Hence the move of this:

```rust
let current_toolchain = Toolchain::from_settings()?;
```
into the `Some` match statement, for when there is something to switch to.