### PR TITLE
fix: nightly workflow

### DIFF
--- a/.github/workflows/publish-nightly-channel.yml
+++ b/.github/workflows/publish-nightly-channel.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Publish nightly channel
         id: setup
         run: |
-            PUBLISHED_DATE=$(date + '%Y-%m-%d')
+            PUBLISHED_DATE=$(date +'%Y-%m-%d')
             FORMATTED_PUBLISHED_DATE=$(date +'%Y/%m/%d')
             mkdir -p ${{ env.NIGHTLY_CHANNEL_DIR }}
 


### PR DESCRIPTION
extra space in the shell command causing failure here https://github.com/FuelLabs/fuelup/actions/runs/3907520619/jobs/6676820728