### PR TITLE
Fix crash when `.fuelup` doesn't exist

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,6 +21,11 @@ impl SettingsFile {
 
     fn write_settings(&self) -> Result<()> {
         let s = self.cache.borrow().as_ref().unwrap().clone();
+
+        let parent_exists = self.path.parent().map(|dir| dir.exists()).unwrap_or(true);
+        if !parent_exists {
+            std::fs::create_dir_all(self.path.parent().unwrap())?;
+        }
         file::write_file(&self.path, &s.to_string()?)?;
         Ok(())
     }


### PR DESCRIPTION
`write_settings` assumes its parent directory exists when writing
`settings.toml` which is not guaranteed.
This results in a crash when invoking `fuelup toolchain install latest`
if there is no existing `.fuelup`