### PR TITLE
release: v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Big update - support for `fuel-toolchain.toml`! Depends on the below:

Features:
- [x] feat: allow usage of fuel-toolchain.toml in projects by @bingcicle in https://github.com/FuelLabs/fuelup/pull/317
- [ ] #335

Bug fixes:
- [x] fix: default bug by @bingcicle in https://github.com/FuelLabs/fuelup/pull/340
- [x] Fix crash when `.fuelup` doesn't exist by @IGI-111 in https://github.com/FuelLabs/fuelup/pull/344