### PR TITLE
fix: install overridden components to store instead of to the toolchain dir

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -165,6 +165,15 @@ impl Components {
 
         Ok(executables)
     }
+
+    pub fn is_distributed_by_forc(plugin_name: &str) -> bool {
+        let components = Self::from_toml(COMPONENTS_TOML).expect("Failed to parse components toml");
+        if let Some(forc) = components.component.get(FORC) {
+            return forc.executables.contains(&plugin_name.to_string());
+        };
+
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/download.rs
+++ b/src/download.rs
@@ -282,6 +282,15 @@ pub fn download_file_and_unpack(download_cfg: &DownloadCfg, dst_dir_path: &Path)
     Ok(())
 }
 
+pub fn link_to_toolchain(toolchain_dir: PathBuf, bins: Vec<PathBuf>) -> Result<()> {
+    for path in bins {
+        if let Some(file_name) = path.file_name() {
+            hard_or_symlink_file(&path, &toolchain_dir.join(file_name))?;
+        }
+    }
+    Ok(())
+}
+
 pub fn link_to_fuelup(bins: Vec<PathBuf>) -> Result<()> {
     let fuelup_bin_path = fuelup_bin();
     for path in bins {

--- a/src/download.rs
+++ b/src/download.rs
@@ -282,11 +282,9 @@ pub fn download_file_and_unpack(download_cfg: &DownloadCfg, dst_dir_path: &Path)
     Ok(())
 }
 
-pub fn link_to_toolchain(toolchain_dir: PathBuf, bins: Vec<PathBuf>) -> Result<()> {
-    for path in bins {
-        if let Some(file_name) = path.file_name() {
-            hard_or_symlink_file(&path, &toolchain_dir.join(file_name))?;
-        }
+pub fn link_to_toolchain(toolchain_dir: &Path, bin_path: &Path) -> Result<()> {
+    if let Some(file_name) = bin_path.file_name() {
+        hard_or_symlink_file(bin_path, &toolchain_dir.join(file_name))?;
     }
     Ok(())
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -282,13 +282,6 @@ pub fn download_file_and_unpack(download_cfg: &DownloadCfg, dst_dir_path: &Path)
     Ok(())
 }
 
-pub fn link_to_toolchain(toolchain_dir: &Path, bin_path: &Path) -> Result<()> {
-    if let Some(file_name) = bin_path.file_name() {
-        hard_or_symlink_file(bin_path, &toolchain_dir.join(file_name))?;
-    }
-    Ok(())
-}
-
 pub fn link_to_fuelup(bins: Vec<PathBuf>) -> Result<()> {
     let fuelup_bin_path = fuelup_bin();
     for path in bins {

--- a/src/store.rs
+++ b/src/store.rs
@@ -61,7 +61,6 @@ impl Store {
         // We ensure that component_dir exists above, so its parent must exist here.
         if let Ok(downloaded) = unpack_bins(&component_dir, &component_dir) {
             ensure_dir_exists(&toolchain_dir)?;
-            ensure_dir_exists(&toolchain_dir.join("bin"))?;
             link_to_toolchain(toolchain_dir, downloaded)?;
         }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -29,8 +29,6 @@ impl Store {
 
     pub(crate) fn has_component(&self, component_name: &str, version: &Version) -> bool {
         let dirname = component_dirname(component_name, version);
-        println!("dirname: {}", self.path().join(dirname.clone()).display());
-        println!("exists:{}", self.path().join(&dirname).exists());
         self.path().join(dirname).exists()
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use semver::Version;
 
 use crate::{
-    download::{download_file_and_unpack, link_to_toolchain, unpack_bins, DownloadCfg},
+    download::{download_file_and_unpack, unpack_bins, DownloadCfg},
     path::{ensure_dir_exists, store_dir},
 };
 
@@ -36,34 +36,14 @@ impl Store {
         self.path.join(component_dirname(component_name, version))
     }
 
-    pub(crate) fn install_component(&self, cfg: &DownloadCfg) -> Result<()> {
-        let component_dir = self.component_dir_path(&cfg.name, &cfg.version);
-
-        ensure_dir_exists(&component_dir)?;
-        download_file_and_unpack(cfg, &component_dir)?;
-        // We ensure that component_dir exists above, so its parent must exist here.
-        unpack_bins(&component_dir, &component_dir)?;
-
-        Ok(())
-    }
-
     // This function installs a component into a directory within '/.fuelup/store'.
     // The directory is named '<component_name>-<version>', eg. 'fuel-core-0.15.1'.
-    pub(crate) fn install_toolchain_component(
-        &self,
-        toolchain_dir: PathBuf,
-        cfg: &DownloadCfg,
-    ) -> Result<()> {
+    pub(crate) fn install_component(&self, cfg: &DownloadCfg) -> Result<Vec<PathBuf>> {
         let component_dir = self.component_dir_path(&cfg.name, &cfg.version);
 
         ensure_dir_exists(&component_dir)?;
         download_file_and_unpack(cfg, &component_dir)?;
         // We ensure that component_dir exists above, so its parent must exist here.
-        if let Ok(downloaded) = unpack_bins(&component_dir, &component_dir) {
-            ensure_dir_exists(&toolchain_dir)?;
-            link_to_toolchain(toolchain_dir, downloaded)?;
-        }
-
-        Ok(())
+        unpack_bins(&component_dir, &component_dir)
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -18,6 +18,7 @@ use crate::path::{
     toolchain_bin_dir, toolchain_dir,
 };
 use crate::settings::SettingsFile;
+use crate::store::Store;
 use crate::target_triple::TargetTriple;
 
 pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
@@ -281,12 +282,13 @@ impl Toolchain {
         if !self.exists() {
             info!("toolchain '{}' does not exist; installing", description);
             if let Ok((channel, hash)) = Channel::from_dist_channel(description) {
+                let store = Store::from_env()?;
                 let config = Config::from_env()?;
                 if let Ok(true) = config.hash_matches(description, &hash) {
                     info!("'{}' is already installed and up to date", self.name);
                 };
                 for cfg in channel.build_download_configs() {
-                    self.add_component(cfg)?;
+                    store.install_toolchain_component(self.bin_path.clone(), &cfg)?;
                 }
             }
         };

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -11,7 +11,9 @@ use tracing::{error, info};
 use crate::channel::{self, is_beta_toolchain, Channel};
 use crate::config::Config;
 use crate::constants::DATE_FORMAT;
-use crate::download::{download_file_and_unpack, link_to_fuelup, unpack_bins, DownloadCfg};
+use crate::download::{
+    download_file_and_unpack, link_to_fuelup, link_to_toolchain, unpack_bins, DownloadCfg,
+};
 use crate::ops::fuelup_self::self_update;
 use crate::path::{
     ensure_dir_exists, fuelup_bin, fuelup_bin_dir, fuelup_tmp_dir, settings_file,
@@ -288,7 +290,10 @@ impl Toolchain {
                     info!("'{}' is already installed and up to date", self.name);
                 };
                 for cfg in channel.build_download_configs() {
-                    store.install_toolchain_component(self.bin_path.clone(), &cfg)?;
+                    let downloaded = store.install_component(&cfg)?;
+                    for bin in downloaded {
+                        link_to_toolchain(&self.path, &bin)?;
+                    }
                 }
             }
         };

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -11,13 +11,11 @@ use tracing::{error, info};
 use crate::channel::{self, is_beta_toolchain, Channel};
 use crate::config::Config;
 use crate::constants::DATE_FORMAT;
-use crate::download::{
-    download_file_and_unpack, link_to_fuelup, link_to_toolchain, unpack_bins, DownloadCfg,
-};
+use crate::download::{download_file_and_unpack, link_to_fuelup, unpack_bins, DownloadCfg};
 use crate::file::hard_or_symlink_file;
 use crate::ops::fuelup_self::self_update;
 use crate::path::{
-    ensure_dir_exists, fuelup_bin, fuelup_bin_dir, fuelup_tmp_dir, settings_file, store_dir,
+    ensure_dir_exists, fuelup_bin, fuelup_bin_dir, fuelup_tmp_dir, settings_file,
     toolchain_bin_dir, toolchain_dir,
 };
 use crate::settings::SettingsFile;

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -14,9 +14,10 @@ use crate::constants::DATE_FORMAT;
 use crate::download::{
     download_file_and_unpack, link_to_fuelup, link_to_toolchain, unpack_bins, DownloadCfg,
 };
+use crate::file::hard_or_symlink_file;
 use crate::ops::fuelup_self::self_update;
 use crate::path::{
-    ensure_dir_exists, fuelup_bin, fuelup_bin_dir, fuelup_tmp_dir, settings_file,
+    ensure_dir_exists, fuelup_bin, fuelup_bin_dir, fuelup_tmp_dir, settings_file, store_dir,
     toolchain_bin_dir, toolchain_dir,
 };
 use crate::settings::SettingsFile;
@@ -284,15 +285,25 @@ impl Toolchain {
         if !self.exists() {
             info!("toolchain '{}' does not exist; installing", description);
             if let Ok((channel, hash)) = Channel::from_dist_channel(description) {
+                ensure_dir_exists(&self.bin_path)?;
                 let store = Store::from_env()?;
                 let config = Config::from_env()?;
                 if let Ok(true) = config.hash_matches(description, &hash) {
                     info!("'{}' is already installed and up to date", self.name);
                 };
                 for cfg in channel.build_download_configs() {
-                    let downloaded = store.install_component(&cfg)?;
-                    for bin in downloaded {
-                        link_to_toolchain(&self.path, &bin)?;
+                    if store.has_component(&cfg.name, &cfg.version) {
+                        hard_or_symlink_file(
+                            &store
+                                .component_dir_path(&cfg.name, &cfg.version)
+                                .join(&cfg.name),
+                            &self.bin_path.join(&cfg.name),
+                        )?;
+                    } else {
+                        let downloaded = store.install_component(&cfg)?;
+                        for bin in downloaded {
+                            hard_or_symlink_file(&bin, &self.bin_path.join(&cfg.name))?;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
closes #353 

Logic in `proxy_cli.rs` was broken - previously, installation of a toolchain worked as it did in the past, but in the new store paradigm, we have to install components to the store and then put symlinks in the toolchain directory instead. This PR implements this change.