### PR TITLE
fix(ci): missing install step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Install build-channel script
+        run: cargo install --debug --path ./ci/build-channel
+
       - name: Checkout gh-pages
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Failed to install the `build-channel` script prior to trying to use it in the job.