### PR TITLE
clippy: fixes for 1.67

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -55,9 +55,7 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
     match desc.name {
         DistToolchainName::Latest => {
             if let Some(date) = desc.date {
-                url.push_str(&format!(
-                    "channels/latest/channel-fuel-latest-{date}.toml"
-                ))
+                url.push_str(&format!("channels/latest/channel-fuel-latest-{date}.toml"))
             } else {
                 url.push_str(CHANNEL_LATEST_FILE_NAME)
             }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -56,8 +56,7 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
         DistToolchainName::Latest => {
             if let Some(date) = desc.date {
                 url.push_str(&format!(
-                    "channels/latest/channel-fuel-latest-{}.toml",
-                    date
+                    "channels/latest/channel-fuel-latest-{date}.toml"
                 ))
             } else {
                 url.push_str(CHANNEL_LATEST_FILE_NAME)

--- a/src/download.rs
+++ b/src/download.rs
@@ -26,8 +26,7 @@ use crate::toolchain::DistToolchainDescription;
 
 fn github_releases_download_url(repo: &str, tag: &Version, tarball: &str) -> String {
     format!(
-        "https://github.com/FuelLabs/{}/releases/download/v{}/{}",
-        repo, tag, tarball
+        "https://github.com/FuelLabs/{repo}/releases/download/v{tag}/{tarball}"
     )
 }
 
@@ -97,9 +96,9 @@ impl DownloadCfg {
 
 pub fn tarball_name(tarball_prefix: &str, version: &Version, target: &TargetTriple) -> String {
     if tarball_prefix == "forc-binaries" {
-        format!("{}-{}.tar.gz", tarball_prefix, target)
+        format!("{tarball_prefix}-{target}.tar.gz")
     } else {
-        format!("{}-{}-{}.tar.gz", tarball_prefix, version, target)
+        format!("{tarball_prefix}-{version}-{target}.tar.gz")
     }
 }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -25,9 +25,7 @@ use crate::target_triple::TargetTriple;
 use crate::toolchain::DistToolchainDescription;
 
 fn github_releases_download_url(repo: &str, tag: &Version, tarball: &str) -> String {
-    format!(
-        "https://github.com/FuelLabs/{repo}/releases/download/v{tag}/{tarball}"
-    )
+    format!("https://github.com/FuelLabs/{repo}/releases/download/v{tag}/{tarball}")
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/file.rs
+++ b/src/file.rs
@@ -42,7 +42,7 @@ fn symlink_file(_original: &Path, _link: &Path) -> Result<()> {
 }
 
 pub fn read_file(name: &'static str, path: &Path) -> Result<String> {
-    fs::read_to_string(path).with_context(|| format!("Failed to read {}", name))
+    fs::read_to_string(path).with_context(|| format!("Failed to read {name}"))
 }
 
 pub fn write_file(path: &Path, contents: &str) -> io::Result<()> {

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -29,7 +29,7 @@ where
 
 pub fn print_header(header: &str) {
     let mut stdout = StandardStream::stdout(ColorChoice::Auto);
-    bold(|s| writeln!(s, "{}", header));
+    bold(|s| writeln!(s, "{header}"));
     writeln!(stdout, "{}", "-".repeat(header.len())).expect("Unexpected error writing to stdout");
     let _ = stdout.reset();
 }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -34,16 +34,16 @@ fn compare_and_print_versions(current_version: &Version, latest_version: &Versio
     match current_version.cmp(latest_version) {
         Less => {
             colored_bold(Color::Yellow, |s| write!(s, "Update available"));
-            println!(" : {} -> {}", current_version, latest_version);
+            println!(" : {current_version} -> {latest_version}");
         }
         Equal => {
             colored_bold(Color::Green, |s| write!(s, "Up to date"));
-            println!(" : {}", current_version);
+            println!(" : {current_version}");
         }
         Greater => {
-            print!(" : {}", current_version);
+            print!(" : {current_version}");
             colored_bold(Color::Yellow, |s| write!(s, " (unstable)"));
-            print!(" -> {}", latest_version);
+            print!(" -> {latest_version}");
             colored_bold(Color::Green, |s| writeln!(s, " (recommended)"));
         }
     }
@@ -61,7 +61,7 @@ fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version
                 Some(v) => {
                     let version = Version::parse(v)?;
                     print!("    - ");
-                    bold(|s| write!(s, "{}", plugin));
+                    bold(|s| write!(s, "{plugin}"));
                     print!(" - ");
                     compare_and_print_versions(&version, latest_version)?;
                 }
@@ -72,10 +72,10 @@ fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version
         }
         Err(e) => {
             print!("    - ");
-            bold(|s| write!(s, "{}", plugin));
+            bold(|s| write!(s, "{plugin}"));
             print!(" - ");
             if plugin_executable.exists() {
-                println!("execution error - {}", e);
+                println!("execution error - {e}");
             } else {
                 println!("not found");
             }

--- a/src/ops/fuelup_default.rs
+++ b/src/ops/fuelup_default.rs
@@ -23,7 +23,7 @@ pub fn default(toolchain: Option<String>) -> Result<()> {
                         Ok(desc) => desc.to_string(),
                         Err(_) => to.cfg.toolchain.channel.to_string(),
                     };
-                result.push_str(&format!("{} (override)", name));
+                result.push_str(&format!("{name} (override)"));
 
                 if current_toolchain.exists() {
                     result.push_str(", ")

--- a/src/ops/fuelup_toolchain/install.rs
+++ b/src/ops/fuelup_toolchain/install.rs
@@ -49,7 +49,7 @@ pub fn install(command: InstallCommand) -> Result<()> {
     for cfg in cfgs {
         match toolchain.add_component(cfg) {
             Ok(cfg) => writeln!(installed_bins, "- {} {}", cfg.name, cfg.version)?,
-            Err(e) => writeln!(errored_bins, "- {}", e)?,
+            Err(e) => writeln!(errored_bins, "- {e}")?,
         };
     }
 

--- a/src/ops/fuelup_update.rs
+++ b/src/ops/fuelup_update.rs
@@ -32,7 +32,7 @@ pub fn update() -> Result<()> {
         let (cfgs, hash) = if let Ok((channel, hash)) = Channel::from_dist_channel(&description) {
             if let Ok(true) = config.hash_matches(&description, &hash) {
                 info!("'{}' already installed and up to date", description);
-                summary.push((format!("{} {}", toolchain, UNCHANGED), "".to_string()));
+                summary.push((format!("{toolchain} {UNCHANGED}"), "".to_string()));
                 continue;
             };
             (channel.build_download_configs(), hash)
@@ -50,26 +50,26 @@ pub fn update() -> Result<()> {
             let toolchain = Toolchain::from_path(&description.to_string());
             match toolchain.add_component(cfg) {
                 Ok(cfg) => installed_bins.push_str(&format!("  - {} {}\n", cfg.name, cfg.version)),
-                Err(e) => errored_bins.push_str(&format!("  - {}\n", e)),
+                Err(e) => errored_bins.push_str(&format!("  - {e}\n")),
             };
         }
 
         let mut status = String::new();
         if !installed_bins.is_empty() {
             status = UPDATED.to_string();
-            installed_bins = format!("  updated components:\n{}", installed_bins);
+            installed_bins = format!("  updated components:\n{installed_bins}");
         }
 
         if errored_bins.is_empty() {
             config.save_hash(&toolchain, &hash)?;
         } else {
             status = PARTIALLY_UPDATED.to_string();
-            errored_bins = format!("  failed to update:\n{}", errored_bins);
+            errored_bins = format!("  failed to update:\n{errored_bins}");
         };
 
         summary.push((
-            format!("{} {}\n", toolchain, status),
-            format!("{}{}", installed_bins, errored_bins),
+            format!("{toolchain} {status}\n"),
+            format!("{installed_bins}{errored_bins}"),
         ));
     }
 
@@ -80,9 +80,9 @@ pub fn update() -> Result<()> {
             .collect::<String>()
             .is_empty()
         {
-            colored_bold(Color::Green, |s| write!(s, "{}", toolchain_info));
+            colored_bold(Color::Green, |s| write!(s, "{toolchain_info}"));
         } else {
-            bold(|s| write!(s, "{}", toolchain_info));
+            bold(|s| write!(s, "{toolchain_info}"));
         }
         info!("{}", components_info);
     }

--- a/src/proxy_cli.rs
+++ b/src/proxy_cli.rs
@@ -95,8 +95,7 @@ fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: &Toolchain) -> Re
             ErrorKind::NotFound => Err(Error::new(
                 ErrorKind::NotFound,
                 format!(
-                    "component '{}' not found in currently active toolchain '{}'",
-                    proc_name, toolchain_name
+                    "component '{proc_name}' not found in currently active toolchain '{toolchain_name}'"
                 ),
             )),
             _ => Err(error),

--- a/src/target_triple.rs
+++ b/src/target_triple.rs
@@ -53,7 +53,7 @@ impl TargetTriple {
             unsupported_os => bail!("Unsupported os: {}", unsupported_os),
         };
 
-        let target_triple = format!("{}-{}-{}", architecture, vendor, os);
+        let target_triple = format!("{architecture}-{vendor}-{os}");
 
         Ok(Self(target_triple))
     }
@@ -72,7 +72,7 @@ impl TargetTriple {
                     unsupported_arch => bail!("Unsupported architecture: {}", unsupported_arch),
                 };
 
-                Ok(Self(format!("{}_{}", os, architecture)))
+                Ok(Self(format!("{os}_{architecture}")))
             }
             _ => {
                 let architecture = match std::env::consts::ARCH {
@@ -91,7 +91,7 @@ impl TargetTriple {
                     unsupported_os => bail!("Unsupported os: {}", unsupported_os),
                 };
 
-                Ok(Self(format!("{}-{}-{}", architecture, vendor, os)))
+                Ok(Self(format!("{architecture}-{vendor}-{os}")))
             }
         }
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -153,7 +153,7 @@ pub struct Toolchain {
 impl Toolchain {
     pub fn new(name: &str) -> Result<Self> {
         let target = TargetTriple::from_host()?;
-        let toolchain = format!("{}-{}", name, target);
+        let toolchain = format!("{name}-{target}");
         Ok(Self {
             name: toolchain.clone(),
             path: toolchain_dir(&toolchain),
@@ -313,7 +313,7 @@ impl Toolchain {
         let executables = &Components::collect().unwrap().component[component].executables;
         for executable in executables {
             remove_file(self.bin_path.join(executable))
-                .with_context(|| format!("failed to remove executable '{}'", executable))?;
+                .with_context(|| format!("failed to remove executable '{executable}'"))?;
         }
         Ok(())
     }

--- a/tests/component.rs
+++ b/tests/component.rs
@@ -41,11 +41,10 @@ fn fuelup_component_add_disallowed() -> Result<()> {
         let output = cfg.fuelup(&["component", "add", "forc@0.19.1"]);
         let expected_stdout = format!(
             r#"Installing specific components is reserved for custom toolchains.
-You are currently using '{}'.
+You are currently using '{latest}'.
 
 You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
-"#,
-            latest
+"#
         );
         assert_eq!(output.stdout, expected_stdout);
 
@@ -57,11 +56,10 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
         let output = cfg.fuelup(&["component", "add", "forc@.19.1"]);
         let expected_stdout = format!(
             r#"Installing specific components is reserved for custom toolchains.
-You are currently using '{}'.
+You are currently using '{nightly}'.
 
 You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
-"#,
-            nightly
+"#
         );
         assert_eq!(output.stdout, expected_stdout);
 
@@ -73,11 +71,10 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
         let output = cfg.fuelup(&["component", "add", "forc@.19.1"]);
         let expected_stdout = format!(
             r#"Installing specific components is reserved for custom toolchains.
-You are currently using '{}'.
+You are currently using '{nightly_date}'.
 
 You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
-"#,
-            nightly_date
+"#
         );
         assert_eq!(output.stdout, expected_stdout);
 
@@ -117,11 +114,10 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
 
         let expected_stdout = format!(
             r#"Removing specific components is reserved for custom toolchains.
-You are currently using '{}'.
+You are currently using '{nightly_date}'.
 
 You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.
-"#,
-            nightly_date
+"#
         );
         assert_eq!(output.stdout, expected_stdout);
         expect_files_exist(&latest_toolchain_bin_dir, ALL_BINS);

--- a/tests/default.rs
+++ b/tests/default.rs
@@ -23,7 +23,7 @@ fn fuelup_default() -> Result<()> {
     let latest = format_toolchain_with_target("latest");
     testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
         let output = cfg.fuelup(&["default"]);
-        let expected_stdout = format!("{} (default)\n", latest);
+        let expected_stdout = format!("{latest} (default)\n");
 
         assert_eq!(output.stdout, expected_stdout);
     })?;
@@ -91,7 +91,7 @@ fn fuelup_default_nightly_and_nightly_date() -> Result<()> {
         );
         assert_eq!(output.stdout, expected_stdout);
 
-        let output = cfg.fuelup(&["default", &format!("nightly-{}", DATE)]);
+        let output = cfg.fuelup(&["default", &format!("nightly-{DATE}")]);
         let expected_stdout = format!(
             "default toolchain set to 'nightly-{}-{}'\n",
             DATE,

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -145,7 +145,7 @@ fn setup_settings_file(settings_dir: &Path, default_toolchain: &str) -> Result<(
     let settings_path = settings_dir.join("settings.toml");
     fs::write(
         settings_path,
-        format!("default_toolchain = \"{}\"", default_toolchain),
+        format!("default_toolchain = \"{default_toolchain}\""),
     )
     .expect("Failed to copy settings");
     Ok(())
@@ -155,7 +155,7 @@ fn setup_override_file(toolchain_override: ToolchainOverride) -> Result<()> {
     let document = toolchain_override.to_toml();
 
     fs::write(toolchain_override.path, document.to_string())
-        .unwrap_or_else(|_| panic!("Failed to write {}", FUEL_TOOLCHAIN_TOML_FILE));
+        .unwrap_or_else(|_| panic!("Failed to write {FUEL_TOOLCHAIN_TOML_FILE}"));
 
     Ok(())
 }
@@ -181,9 +181,9 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
     )?;
 
     let target = TargetTriple::from_host().unwrap();
-    let latest = format!("latest-{}", target);
-    let nightly = format!("nightly-{}", target);
-    let beta_1 = format!("beta-1-{}", target);
+    let latest = format!("latest-{target}");
+    let nightly = format!("nightly-{target}");
+    let beta_1 = format!("beta-1-{target}");
 
     match state {
         FuelupState::Empty => {}
@@ -192,7 +192,7 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
             setup_toolchain(&tmp_fuelup_root_path, &nightly)?;
             setup_toolchain(
                 &tmp_fuelup_root_path,
-                &format!("nightly-{}-{}", DATE, target),
+                &format!("nightly-{DATE}-{target}"),
             )?;
             setup_settings_file(&tmp_fuelup_root_path, &latest)?;
         }
@@ -224,11 +224,11 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
         FuelupState::NightlyDateInstalled => {
             setup_toolchain(
                 &tmp_fuelup_root_path,
-                &format!("nightly-{}-{}", DATE, target),
+                &format!("nightly-{DATE}-{target}"),
             )?;
             setup_settings_file(
                 &tmp_fuelup_root_path,
-                &format!("nightly-{}-{}", DATE, target),
+                &format!("nightly-{DATE}-{target}"),
             )?;
         }
         FuelupState::LatestAndCustomInstalled => {
@@ -245,7 +245,7 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
             setup_toolchain(&tmp_fuelup_root_path, &nightly)?;
             setup_toolchain(
                 &tmp_fuelup_root_path,
-                &format!("nightly-{}-{}", DATE, target),
+                &format!("nightly-{DATE}-{target}"),
             )?;
             setup_settings_file(&tmp_fuelup_root_path, &nightly)?;
         }
@@ -253,7 +253,7 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
             setup_toolchain(&tmp_fuelup_root_path, &beta_1)?;
             setup_toolchain(
                 &tmp_fuelup_root_path,
-                &format!("beta-1-{}-{}", DATE, target),
+                &format!("beta-1-{DATE}-{target}"),
             )?;
             setup_settings_file(&tmp_fuelup_root_path, &beta_1)?;
         }

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -190,10 +190,7 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
         FuelupState::AllInstalled => {
             setup_toolchain(&tmp_fuelup_root_path, &latest)?;
             setup_toolchain(&tmp_fuelup_root_path, &nightly)?;
-            setup_toolchain(
-                &tmp_fuelup_root_path,
-                &format!("nightly-{DATE}-{target}"),
-            )?;
+            setup_toolchain(&tmp_fuelup_root_path, &format!("nightly-{DATE}-{target}"))?;
             setup_settings_file(&tmp_fuelup_root_path, &latest)?;
         }
         FuelupState::LatestToolchainInstalled => {
@@ -222,14 +219,8 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
             setup_settings_file(&tmp_fuelup_root_path, &nightly)?;
         }
         FuelupState::NightlyDateInstalled => {
-            setup_toolchain(
-                &tmp_fuelup_root_path,
-                &format!("nightly-{DATE}-{target}"),
-            )?;
-            setup_settings_file(
-                &tmp_fuelup_root_path,
-                &format!("nightly-{DATE}-{target}"),
-            )?;
+            setup_toolchain(&tmp_fuelup_root_path, &format!("nightly-{DATE}-{target}"))?;
+            setup_settings_file(&tmp_fuelup_root_path, &format!("nightly-{DATE}-{target}"))?;
         }
         FuelupState::LatestAndCustomInstalled => {
             setup_toolchain(&tmp_fuelup_root_path, &latest)?;
@@ -243,18 +234,12 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
         }
         FuelupState::NightlyAndNightlyDateInstalled => {
             setup_toolchain(&tmp_fuelup_root_path, &nightly)?;
-            setup_toolchain(
-                &tmp_fuelup_root_path,
-                &format!("nightly-{DATE}-{target}"),
-            )?;
+            setup_toolchain(&tmp_fuelup_root_path, &format!("nightly-{DATE}-{target}"))?;
             setup_settings_file(&tmp_fuelup_root_path, &nightly)?;
         }
         FuelupState::Beta1Installed => {
             setup_toolchain(&tmp_fuelup_root_path, &beta_1)?;
-            setup_toolchain(
-                &tmp_fuelup_root_path,
-                &format!("beta-1-{DATE}-{target}"),
-            )?;
+            setup_toolchain(&tmp_fuelup_root_path, &format!("beta-1-{DATE}-{target}"))?;
             setup_settings_file(&tmp_fuelup_root_path, &beta_1)?;
         }
         FuelupState::LatestAndNightlyWithBetaOverride => {

--- a/tests/toolchain.rs
+++ b/tests/toolchain.rs
@@ -105,22 +105,22 @@ fn fuelup_toolchain_install_date_target_disallowed() -> Result<()> {
 #[test]
 fn fuelup_toolchain_uninstall() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
-        let toolchains = ["latest", "nightly", &format!("nightly-{}", DATE)];
+        let toolchains = ["latest", "nightly", &format!("nightly-{DATE}")];
         for toolchain in toolchains {
             let toolchain_with_target = format_toolchain_with_target(toolchain);
             let output = cfg.fuelup(&["toolchain", "uninstall", toolchain]);
-            let expected_stdout = format!("toolchain '{}' does not exist\n", toolchain_with_target);
+            let expected_stdout = format!("toolchain '{toolchain_with_target}' does not exist\n");
 
             assert_eq!(output.stdout, expected_stdout);
         }
     })?;
 
     testcfg::setup(FuelupState::AllInstalled, &|cfg| {
-        let toolchains = ["latest", "nightly", &format!("nightly-{}", DATE)];
+        let toolchains = ["latest", "nightly", &format!("nightly-{DATE}")];
         for toolchain in toolchains {
             let toolchain_with_target = format_toolchain_with_target(toolchain);
             let output = cfg.fuelup(&["toolchain", "uninstall", toolchain]);
-            let expected_stdout = format!("toolchain '{}' uninstalled\n", toolchain_with_target);
+            let expected_stdout = format!("toolchain '{toolchain_with_target}' uninstalled\n");
 
             assert!(output.stdout.contains(&expected_stdout));
         }


### PR DESCRIPTION
fixes [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) lint.