### PR TITLE
feat: `add_component` adds to store

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -1,7 +1,13 @@
 use anyhow::{Context, Result};
 use std::fs;
 use std::io;
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+
+#[cfg(unix)]
+pub(crate) fn is_executable(file: &Path) -> bool {
+    file.is_file() && file.metadata().unwrap().permissions().mode() & 0o111 != 0
+}
 
 pub(crate) fn hardlink(original: &Path, link: &Path) -> io::Result<()> {
     let _ = fs::remove_file(link);

--- a/src/ops/fuelup_component/add.rs
+++ b/src/ops/fuelup_component/add.rs
@@ -51,8 +51,14 @@ You may create a custom toolchain using 'fuelup toolchain new <toolchain>'.",
 
     if toolchain.has_component(component) {
         info!(
-            "{} already exists in toolchain '{}'; replacing existing version with `latest` version",
-            &maybe_versioned_component, toolchain.name
+            "{} already exists in toolchain '{}'; replacing existing version with {}{}",
+            component,
+            toolchain.name,
+            component,
+            version
+                .is_some()
+                .then(|| format!(" ({})", &version.as_ref().unwrap().to_string()))
+                .unwrap_or_else(|| " (latest)".to_string())
         );
     }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -143,31 +143,6 @@ impl FromStr for DistToolchainDescription {
     }
 }
 
-fn install_forc_dependencies(forc_bin_path: PathBuf) -> Result<()> {
-    let fuelup_tmp_dir = fuelup_tmp_dir();
-    ensure_dir_exists(&fuelup_tmp_dir)?;
-    let temp_project = tempfile::Builder::new().prefix("temp-project").tempdir()?;
-    let temp_project_path = temp_project.path().to_str().unwrap();
-    if Command::new(&forc_bin_path)
-        .args(["init", "--path", temp_project_path])
-        .stdout(std::process::Stdio::null())
-        .status()
-        .is_ok()
-    {
-        info!("Fetching core forc dependencies");
-        if Command::new(forc_bin_path)
-            .args(["check", "--path", temp_project_path])
-            .stdout(std::process::Stdio::null())
-            .status()
-            .is_err()
-        {
-            error!("Failed to fetch core forc dependencies");
-        };
-    };
-
-    Ok(())
-}
-
 #[derive(Debug)]
 pub struct Toolchain {
     pub name: String,
@@ -276,8 +251,30 @@ impl Toolchain {
 
                     // Little hack here to download core and std lib upon installing `forc`
                     if download_cfg.name == component::FORC {
-                        install_forc_dependencies(self.bin_path.join(component::FORC))?;
-                    }
+                        let forc_bin_path = self.bin_path.join(component::FORC);
+
+                        let fuelup_tmp_dir = fuelup_tmp_dir();
+                        ensure_dir_exists(&fuelup_tmp_dir)?;
+                        let temp_project =
+                            tempfile::Builder::new().prefix("temp-project").tempdir()?;
+                        let temp_project_path = temp_project.path().to_str().unwrap();
+                        if Command::new(&forc_bin_path)
+                            .args(["init", "--path", temp_project_path])
+                            .stdout(std::process::Stdio::null())
+                            .status()
+                            .is_ok()
+                        {
+                            info!("Fetching core forc dependencies");
+                            if Command::new(forc_bin_path)
+                                .args(["check", "--path", temp_project_path])
+                                .stdout(std::process::Stdio::null())
+                                .status()
+                                .is_err()
+                            {
+                                error!("Failed to fetch core forc dependencies");
+                            };
+                        };
+                    };
                 }
                 Err(e) => bail!(
                     "Could not add component {}({}): {}",

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -267,8 +267,8 @@ impl Toolchain {
                         if is_executable(bin.as_path()) {
                             if let Some(exe_file_name) = bin.file_name() {
                                 hard_or_symlink_file(
-                                    &bin.as_path(),
-                                    &self.bin_path.join(&exe_file_name),
+                                    bin.as_path(),
+                                    &self.bin_path.join(exe_file_name),
                                 )?;
                             }
                         }
@@ -290,14 +290,14 @@ impl Toolchain {
             // We have to iterate here because `fuelup component add forc` has to account for
             // other built-in plugins as well, eg. forc-fmt
             for entry in std::fs::read_dir(
-                &store.component_dir_path(&download_cfg.name, &download_cfg.version),
+                store.component_dir_path(&download_cfg.name, &download_cfg.version),
             )? {
                 let entry = entry?;
                 let exe = entry.path();
 
                 if is_executable(exe.as_path()) {
                     if let Some(exe_file_name) = exe.file_name() {
-                        hard_or_symlink_file(exe.as_path(), &self.bin_path.join(&exe_file_name))?;
+                        hard_or_symlink_file(exe.as_path(), &self.bin_path.join(exe_file_name))?;
                     }
                 }
             }


### PR DESCRIPTION
closes #329, closes #352

incidentally because `add_component()` is re-used in many commands eg. `toolchain install`, `update`, we get the nice effect of this change everywhere!

eg. `fuelup toolchain install latest` will now symlink components from store if they're already there. No need to wait to re-download components again.

