### PR TITLE
ci: update toolchain compatibility tests

### DIFF
--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -13,6 +13,7 @@ on:
         type: string
 
 env:
+  RUST_VERSION: 1.67.0
   INCOMPATIBLE_DIR: ./incompatible-versions
   LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/
 
@@ -42,32 +43,26 @@ jobs:
           path: . 
           ref: v${{ matrix.job.forc-version }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        toolchain: ${{ env.RUST_VERSION }}
+      
+      - uses: Swatinem/rust-cache@v2
 
-      - uses: Swatinem/rust-cache@v1
-
-        # In the next 3 steps we run the integration tests found in the Sway CI:
+        # In the next steps we run the integration tests found in the Sway CI:
         # https://github.com/FuelLabs/sway/blob/3bd8eaf4a0f11a3009c9421100cc06c2e897b6c2/.github/workflows/ci.yml#L229-L270
       - name: Cargo Run E2E Tests 
         id: e2e-tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: run
-          args: --locked --release --bin test -- --locked
+        run: cargo run --locked --release --bin test -- --locked
+
+      - name: Cargo Run E2E Tests (EVM)
+        run: cargo run --locked --release --bin test -- --target evm --locked
 
       - name: Build All Tests
         run: cd test/src/sdk-harness && bash build.sh --locked && cd ../../../
 
       - name: Cargo Test sway-lib-std
-        id: std-lib-tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --manifest-path ./test/src/sdk-harness/Cargo.toml -- --test-threads=1 --nocapture
-
+        run: cargo test --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
       # We use upload artifacts in the remaining steps to collect test results to be used in the subsequent index-versions job.
       #
       # See:


### PR DESCRIPTION
Applies the changes of https://github.com/FuelLabs/sway/pull/3961 on the compatibility checks.

Note that in the fuelup compatibility check CI, we are only interested in the e2e tests, so this PR only updates the existing e2e test targetting the FuelVM, and adds the tests for the EVM.