### PR TITLE
ci: small update to frequency of checks

### DIFF
--- a/.github/workflows/index-versions.yml
+++ b/.github/workflows/index-versions.yml
@@ -2,8 +2,8 @@ name: Check Versions
 
 on:
   schedule:
-    # Run at minute 0 and 30 every hour
-    - cron: '0,30 * * * *'
+    # Run at minute 0 every hour
+    - cron: '0 * * * *'
 env:
   LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/
 


### PR DESCRIPTION
CI is getting some errors related to rate limit - unauthenticated requests seem to be limited to [60 an hour](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-personal-accounts). Updating the check to trigger hourly instead of every 30 minutes, since it probably isn't ideal to pass our token into the Rust script as a var...

 https://github.com/FuelLabs/fuelup/actions/runs/4129790751/jobs/7135788603