### PR TITLE
ci: check for failure for new tests

### DIFF
--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -57,12 +57,14 @@ jobs:
         run: cargo run --locked --release --bin test -- --locked
 
       - name: Cargo Run E2E Tests (EVM)
+        id: e2e-evm-tests
         run: cargo run --locked --release --bin test -- --target evm --locked
 
       - name: Build All Tests
         run: cd test/src/sdk-harness && bash build.sh --locked && cd ../../../
 
       - name: Cargo Test sway-lib-std
+        id: std-lib-tests
         run: cargo test --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
       # We use upload artifacts in the remaining steps to collect test results to be used in the subsequent index-versions job.
       #
@@ -73,15 +75,20 @@ jobs:
       #
       # We have to explicitly check for:
       # 1) e2e-tests.conclusion == 'failure'
-      # 2) std-lib-tests.conclusion == 'failure'
+      # 2) e2e-evm-tests.conclusion == 'failure'
+      # 3) std-lib-tests.conclusion == 'failure'
       # So that we create failure artifacts only if tests fail and not anywhere before so that we can retry this workflow
       # if it fails for other reasons other than tests.
       - name: Create failure artifact
-        if: ${{ failure() && (steps.e2e-tests.conclusion == 'failure' || steps.std-lib-tests.conclusion == 'failure' )}}
+        if: ${{ failure() && (steps.e2e-tests.conclusion == 'failure' || 
+                steps.e2e-evm-tests.conclusion = 'failure' ||
+                steps.std-lib-tests.conclusion == 'failure' )}}
         run: touch incompatible-forc-${{ matrix.job.forc-version }}@fuel-core-${{ matrix.job.fuel-core-version }}
 
       - name: Upload failure artifact
-        if: ${{ failure() && (steps.e2e-tests.conclusion == 'failure' || steps.std-lib-tests.conclusion == 'failure' ) }}
+        if: ${{ failure() && (steps.e2e-tests.conclusion == 'failure' ||
+                steps.e2e-evm-tests.conclusion = 'failure' ||
+                steps.std-lib-tests.conclusion == 'failure' )}}
         id: upload-failure-artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
action currently fails without publishing an incompatibility file stub - we need to add the check for the failure conditions to the step that uploads the failure artifacts in the CI.

Also added failure check for std-lib-tests which was missing before :sweat: 