### PR TITLE
bug: fix initial installation

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -279,14 +279,6 @@ pub fn download_file_and_unpack(download_cfg: &DownloadCfg, dst_dir_path: &Path)
     Ok(())
 }
 
-pub fn link_to_fuelup(bins: Vec<PathBuf>) -> Result<()> {
-    let fuelup_bin_path = fuelup_bin();
-    for path in bins {
-        hard_or_symlink_file(&fuelup_bin_path, &path)?;
-    }
-    Ok(())
-}
-
 pub fn unpack_bins(dir: &Path, dst_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut downloaded: Vec<PathBuf> = Vec::new();
     for entry in std::fs::read_dir(dir)? {

--- a/src/download.rs
+++ b/src/download.rs
@@ -19,8 +19,6 @@ use tracing::{error, info};
 use crate::channel::Channel;
 use crate::channel::Package;
 use crate::constants::CHANNEL_LATEST_URL;
-use crate::file::hard_or_symlink_file;
-use crate::path::fuelup_bin;
 use crate::target_triple::TargetTriple;
 use crate::toolchain::DistToolchainDescription;
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -245,13 +245,13 @@ impl Toolchain {
         let fuelup_bin_dir = fuelup_bin_dir();
         ensure_dir_exists(&fuelup_bin_dir)?;
 
-        // if !fuelup_bin().is_file() {
-        //     info!("fuelup not found - attempting to self update");
-        //     match self_update() {
-        //         Ok(()) => info!("fuelup installed."),
-        //         Err(e) => bail!("Could not install fuelup: {}", e),
-        //     };
-        // }
+        if !fuelup_bin().is_file() {
+            info!("fuelup not found - attempting to self update");
+            match self_update() {
+                Ok(()) => info!("fuelup installed."),
+                Err(e) => bail!("Could not install fuelup: {}", e),
+            };
+        }
 
         let store = Store::from_env()?;
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -245,13 +245,13 @@ impl Toolchain {
         let fuelup_bin_dir = fuelup_bin_dir();
         ensure_dir_exists(&fuelup_bin_dir)?;
 
-        if !fuelup_bin().is_file() {
-            info!("fuelup not found - attempting to self update");
-            match self_update() {
-                Ok(()) => info!("fuelup installed."),
-                Err(e) => bail!("Could not install fuelup: {}", e),
-            };
-        }
+        // if !fuelup_bin().is_file() {
+        //     info!("fuelup not found - attempting to self update");
+        //     match self_update() {
+        //         Ok(()) => info!("fuelup installed."),
+        //         Err(e) => bail!("Could not install fuelup: {}", e),
+        //     };
+        // }
 
         let store = Store::from_env()?;
 
@@ -270,6 +270,12 @@ impl Toolchain {
                                     bin.as_path(),
                                     &self.bin_path.join(exe_file_name),
                                 )?;
+                                if !fuelup_bin_dir.join(exe_file_name).exists() {
+                                    hard_or_symlink_file(
+                                        bin.as_path(),
+                                        &fuelup_bin_dir.join(exe_file_name),
+                                    )?;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
During the initial installation of fuelup and subsequently a toolchain, a fresh install would not have `.fuelup/bin` and also the linked binaries within that directory. We need to check for the linked binary within `.fuelup/bin` whenever we install a component, in case it was removed.