### PR TITLE
ci: cd into s way when testing

### DIFF
--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: fuellabs/sway
-          path: . 
+          path: sway
           ref: v${{ matrix.job.forc-version }}
 
       - name: Install toolchain
@@ -51,25 +51,25 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install Forc
-        run: cargo install --locked --debug --path ./forc
+        run: cd sway && cargo install --locked --debug --path ./forc
 
       - name: Build sway-lib-core and sway-lib-std
-        run: forc build --path sway-lib-core && forc build --path sway-lib-std
+        run: cd sway && forc build --path sway-lib-core && forc build --path sway-lib-std
      
         # In the next steps we run the integration tests found in the Sway CI:
         # https://github.com/FuelLabs/sway/blob/3bd8eaf4a0f11a3009c9421100cc06c2e897b6c2/.github/workflows/ci.yml#L229-L270
       - name: Cargo Run E2E Tests 
         id: e2e-tests
-        run: cargo run --locked --release --bin test -- --locked
+        run: cd sway && cargo run --locked --release --bin test -- --locked
 
       - name: Cargo Run E2E Tests (EVM)
-        run: cargo run --locked --release --bin test -- --target evm --locked
+        run: cd sway && cargo run --locked --release --bin test -- --target evm --locked
 
       - name: Build All Tests
-        run: cd test/src/sdk-harness && bash build.sh --locked && cd ../../../
+        run: cd sway/test/src/sdk-harness && bash build.sh --locked && cd ../../../../
 
       - name: Cargo Test sway-lib-std
-        run: cargo test --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
+        run: cd sway && cargo test --manifest-path ./test/src/sdk-harness/Cargo.toml -- --nocapture
       # We use upload artifacts in the remaining steps to collect test results to be used in the subsequent index-versions job.
       #
       # See:


### PR DESCRIPTION
related: https://github.com/FuelLabs/fuelup/pull/388 

The PR above fixes not being able to source dependency, but the [Forc.toml for the storage purity test](https://github.com/FuelLabs/sway/blob/9a00b5ab67ce67c5f525bdc332f15d6b6e06eb38/test/src/e2e_vm_tests/test_programs/should_fail/storage_clear_incorrect_purity_annotation/Forc.toml) cds an additional level up to the `sway` repo. Fixing this here instead by creating a dedicated sway repo when running e2e tests

edit: maybe this is the cause actually, instead of the build step above.