### PR TITLE
fix: add fuel-core-keygen to expected files

### DIFF
--- a/tests/component.rs
+++ b/tests/component.rs
@@ -13,7 +13,10 @@ fn fuelup_component_add() -> Result<()> {
         let _ = cfg.fuelup(&["toolchain", "new", "my_toolchain"]);
 
         let _ = cfg.fuelup(&["component", "add", "fuel-core"]);
-        expect_files_exist(&cfg.toolchain_bin_dir("my_toolchain"), &["fuel-core"]);
+        expect_files_exist(
+            &cfg.toolchain_bin_dir("my_toolchain"),
+            &["fuel-core", "fuel-core-keygen"],
+        );
     })?;
 
     Ok(())
@@ -24,8 +27,11 @@ fn fuelup_component_add_with_version() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
         let _ = cfg.fuelup(&["toolchain", "new", "my_toolchain"]);
 
-        let _ = cfg.fuelup(&["component", "add", "fuel-core@0.9.8"]);
-        expect_files_exist(&cfg.toolchain_bin_dir("my_toolchain"), &["fuel-core"]);
+        let _ = cfg.fuelup(&["component", "add", "fuel-core@0.17.0"]);
+        expect_files_exist(
+            &cfg.toolchain_bin_dir("my_toolchain"),
+            &["fuel-core", "fuel-core-keygen"],
+        );
     })?;
 
     Ok(())


### PR DESCRIPTION
Closes #395

hotfix for failing CI in this PR #392

`fuel-core` has a new binary in the newest version which we should expect.