### PR TITLE
Add beta-3 entry under Channels in Fuelup book

### DIFF
--- a/docs/src/concepts/channels/beta-3.md
+++ b/docs/src/concepts/channels/beta-3.md
@@ -1,1 +1,3 @@
+# The `beta-3` channel
+
 The `beta-3` channel is a published TOML file describing the toolchain that is compatible with our [beta-3 testnet](https://fuel-labs.ghost.io/announcing-beta-3-testnet/). This toolchain should be used to interact with and build on the testnet. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-3.toml).

--- a/docs/src/concepts/channels/beta-3.md
+++ b/docs/src/concepts/channels/beta-3.md
@@ -1,0 +1,1 @@
+The `beta-3` channel is a published TOML file describing the toolchain that is compatible with our [beta-3 testnet](https://fuel-labs.ghost.io/announcing-beta-3-testnet/). This toolchain should be used to interact with and build on the testnet. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-3.toml).

--- a/docs/src/concepts/channels/index.md
+++ b/docs/src/concepts/channels/index.md
@@ -8,8 +8,10 @@
 | **[nightly]** | `master` branch | ➖                   | nightly (1:00 AM UTC)     | ✔️         |
 | **[beta-1]**  | published bins  | ➖                   | only when necessary       | ✔️         |
 | **[beta-2]**  | published bins  | ➖                   | only when necessary       | ✔️         |
+| **[beta-3]**  | published bins  | ➖                   | only when necessary       | ✔️         |
 
 [latest]: latest.html
 [nightly]: nightly.html
 [beta-1]: beta-1.html
 [beta-2]: beta-2.html
+[beta-3]: beta-3.html


### PR DESCRIPTION
This PR adds a `beta-3` entry in the Channels `index.md`. Additionally, adds a new page under Channels chapter to cover `beta-3`.

Closes #399