### PR TITLE
test: general cleanup

### DIFF
--- a/tests/default.rs
+++ b/tests/default.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use fuelup::{fmt::format_toolchain_with_target, target_triple::TargetTriple};
 
 pub mod testcfg;
-use testcfg::{FuelupState, DATE};
+use testcfg::{FuelupState, CUSTOM_TOOLCHAIN_NAME, DATE};
 
 #[test]
 fn fuelup_default_empty() -> Result<()> {
@@ -42,8 +42,8 @@ fn fuelup_default_latest_and_custom() -> Result<()> {
 
         assert_eq!(output.stdout, expected_stdout);
 
-        let output = cfg.fuelup(&["default", "my-toolchain"]);
-        let expected_stdout = "default toolchain set to 'my-toolchain'\n";
+        let output = cfg.fuelup(&["default", CUSTOM_TOOLCHAIN_NAME]);
+        let expected_stdout = format!("default toolchain set to '{CUSTOM_TOOLCHAIN_NAME}'\n");
 
         assert_eq!(output.stdout, expected_stdout);
     })?;
@@ -68,7 +68,7 @@ fn fuelup_default_uninstalled_toolchain() -> Result<()> {
 
 #[test]
 fn fuelup_default_nightly() -> Result<()> {
-    testcfg::setup(FuelupState::LatestAndNightlyInstalled, &|cfg| {
+    testcfg::setup(FuelupState::AllInstalled, &|cfg| {
         let output = cfg.fuelup(&["default", "nightly"]);
         let expected_stdout = format!(
             "default toolchain set to 'nightly-{}'\n",
@@ -105,7 +105,7 @@ fn fuelup_default_nightly_and_nightly_date() -> Result<()> {
 
 #[test]
 fn fuelup_default_override() -> Result<()> {
-    testcfg::setup(FuelupState::LatestAndNightlyWithBetaOverride, &|cfg| {
+    testcfg::setup(FuelupState::LatestWithBetaOverride, &|cfg| {
         let output = cfg.fuelup(&["default"]);
         let triple = TargetTriple::from_host().unwrap();
 

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -52,7 +52,7 @@ my_toolchain (default)
 
 #[test]
 fn fuelup_show_override() -> Result<()> {
-    testcfg::setup(FuelupState::LatestAndNightlyWithBetaOverride, &|cfg| {
+    testcfg::setup(FuelupState::LatestWithBetaOverride, &|cfg| {
         let stdout = cfg.fuelup(&["show"]).stdout;
 
         let mut lines = stdout.lines();
@@ -68,7 +68,6 @@ fn fuelup_show_override() -> Result<()> {
 installed toolchains
 --------------------
 latest-{target} (default)
-nightly-{target}
 
 active toolchain
 -----------------

--- a/tests/toolchain.rs
+++ b/tests/toolchain.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use fuelup::{channel, fmt::format_toolchain_with_target, target_triple::TargetTriple};
 
 pub mod testcfg;
-use testcfg::{FuelupState, ALL_BINS, DATE};
+use testcfg::{FuelupState, ALL_BINS, CUSTOM_TOOLCHAIN_NAME, DATE};
 
 mod expects;
 use expects::expect_files_exist;
@@ -135,7 +135,7 @@ fn fuelup_toolchain_uninstall_active_switches_default() -> Result<()> {
         cfg.fuelup(&["toolchain", "uninstall", "latest"]);
         let stdout = cfg.fuelup(&["default"]).stdout;
 
-        assert_eq!(stdout, "my-toolchain (default)\n")
+        assert_eq!(stdout, format!("{CUSTOM_TOOLCHAIN_NAME} (default)\n"))
     })?;
 
     Ok(())
@@ -144,17 +144,16 @@ fn fuelup_toolchain_uninstall_active_switches_default() -> Result<()> {
 #[test]
 fn fuelup_toolchain_new() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
-        let name = "my-toolchain";
-        let output = cfg.fuelup(&["toolchain", "new", name]);
+        let output = cfg.fuelup(&["toolchain", "new", CUSTOM_TOOLCHAIN_NAME]);
         let expected_stdout = format!(
-            "New toolchain initialized: {name}
-default toolchain set to '{name}'\n"
+            "New toolchain initialized: {CUSTOM_TOOLCHAIN_NAME}
+default toolchain set to '{CUSTOM_TOOLCHAIN_NAME}'\n"
         );
 
         assert_eq!(output.stdout, expected_stdout);
-        assert!(cfg.toolchain_bin_dir(name).is_dir());
+        assert!(cfg.toolchain_bin_dir(CUSTOM_TOOLCHAIN_NAME).is_dir());
         let default = cfg.default_toolchain();
-        assert_eq!(default, Some(name.to_string()));
+        assert_eq!(default, Some(CUSTOM_TOOLCHAIN_NAME.to_string()));
     })?;
 
     Ok(())


### PR DESCRIPTION
This PR contains a bunch of minor cleanups to tests. Because these cleanups are spread across different places, will briefly explain some of the changes:

- I wrote doc comments at places where I think is necessary to get the gist of what's going on in tests (in the setup, in the `FuelupState` enum)
- Removed the `LatestAndNightlyInstalled` enum member from `FuelupState` since only 1 test uses this. We can reuse `AllInstalled` instead.
- Repurposed `LatestAndNightlyWithBetaOverride` to `LatestWithBetaOverride` just to cut down on the variable name and we don't require 2 toolchains anyway for the purpose of testing overrides.
- Created a `pub const CUSTOM_TOOLCHAIN_NAME` for tests that use and assert `my-toolchain` custom name.
- Remove `root` from `TestCfg` since it served no purpose.