### PR TITLE
test: introduce store infra to test fuels_version.

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -138,7 +138,7 @@ impl Components {
     pub fn collect_show_fuels_versions() -> Result<Vec<Component>> {
         let components = Self::from_toml(COMPONENTS_TOML)?;
 
-        Ok(components
+        let mut components_to_show = components
             .component
             .values()
             .filter_map(|c| {
@@ -148,7 +148,11 @@ impl Components {
                     None
                 }
             })
-            .collect::<Vec<Component>>())
+            .collect::<Vec<Component>>();
+
+        components_to_show.sort_by_key(|c| c.name.clone());
+
+        Ok(components_to_show)
     }
     pub fn collect_plugins() -> Result<Vec<Plugin>> {
         let components = Self::from_toml(COMPONENTS_TOML)?;

--- a/src/file.rs
+++ b/src/file.rs
@@ -14,7 +14,7 @@ pub(crate) fn hardlink(original: &Path, link: &Path) -> io::Result<()> {
     fs::hard_link(original, link)
 }
 
-pub(crate) fn hard_or_symlink_file(original: &Path, link: &Path) -> Result<()> {
+pub fn hard_or_symlink_file(original: &Path, link: &Path) -> Result<()> {
     if hardlink_file(original, link).is_err() {
         symlink_file(original, link)?;
     }
@@ -32,7 +32,7 @@ pub fn hardlink_file(original: &Path, link: &Path) -> Result<()> {
 }
 
 #[cfg(unix)]
-fn symlink_file(original: &Path, link: &Path) -> Result<()> {
+pub fn symlink_file(original: &Path, link: &Path) -> Result<()> {
     std::os::unix::fs::symlink(original, link).with_context(|| {
         format!(
             "Could not create link: {}->{}",
@@ -43,7 +43,7 @@ fn symlink_file(original: &Path, link: &Path) -> Result<()> {
 }
 
 #[cfg(not(unix))]
-fn symlink_file(_original: &Path, _link: &Path) -> Result<()> {
+pub fn symlink_file(_original: &Path, _link: &Path) -> Result<()> {
     bail!("Symbolic link currently only supported on Unix");
 }
 

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -44,10 +44,15 @@ latest-{target} (default)
     - forc-wallet : 0.1.0
   fuel-core : 0.1.0
   fuel-indexer : 0.1.0
+
+fuels versions
+---------------
+forc : 0.1.0
+forc-wallet : 0.1.0
 "#
         );
+
         assert!(stdout.contains(expected_stdout));
-        assert!(!stdout.contains("fuels versions"));
     })?;
     Ok(())
 }
@@ -87,10 +92,14 @@ latest-{target} (default)
     - forc-wallet : 0.1.0
   fuel-core : 0.1.0
   fuel-indexer : 0.1.0
+
+fuels versions
+---------------
+forc : 0.1.0
+forc-wallet : 0.1.0
 "#
         );
         assert!(stdout.contains(expected_stdout));
-        assert!(!stdout.contains("fuels versions"));
 
         cfg.fuelup(&["default", "nightly"]);
         stdout = cfg.fuelup(&["show"]).stdout;
@@ -120,10 +129,14 @@ nightly-{target} (default)
     - forc-wallet : 0.2.0
   fuel-core : 0.2.0
   fuel-indexer : 0.2.0
+
+fuels versions
+---------------
+forc : 0.2.0
+forc-wallet : 0.2.0
 "#
         );
         assert!(stdout.contains(expected_stdout));
-        assert!(!stdout.contains("fuels versions"));
     })?;
 
     Ok(())
@@ -250,10 +263,14 @@ latest-{target} (default)
     - forc-wallet : 0.1.0
   fuel-core : 0.1.0
   fuel-indexer : 0.1.0
+
+fuels versions
+---------------
+forc : 0.1.0
+forc-wallet : 0.1.0
 "#,
         );
         assert!(stdout.contains(expected_stdout));
-        assert!(!stdout.contains("fuels versions"));
 
         let toolchain_override = ToolchainOverride {
             cfg: OverrideCfg::new(
@@ -297,9 +314,13 @@ latest-{target} (default)
     - forc-wallet : 0.2.0
   fuel-core : 0.2.0
   fuel-indexer : 0.2.0
+
+fuels versions
+---------------
+forc : 0.2.0
+forc-wallet : 0.2.0
 "#;
         assert!(stdout.contains(expected_stdout));
-        assert!(!stdout.contains("fuels versions"));
     })?;
     Ok(())
 }

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use component::Components;
 use fuelup::channel::{BETA_1, LATEST, NIGHTLY};
 use fuelup::constants::FUEL_TOOLCHAIN_TOML_FILE;
 use fuelup::file::hard_or_symlink_file;
@@ -174,7 +175,9 @@ fn create_fuel_executable(path: &Path) -> std::io::Result<()> {
 }
 
 fn should_check_fuels_compatibility(component_name: &str) -> bool {
-    ["forc", "forc-wallet"].contains(&component_name)
+    let components = Components::collect_show_fuels_versions().unwrap();
+
+    components.iter().any(|c| c.name == component_name)
 }
 
 fn setup_toolchain(fuelup_home_path: &Path, toolchain: &str) -> Result<()> {
@@ -187,6 +190,7 @@ fn setup_toolchain(fuelup_home_path: &Path, toolchain: &str) -> Result<()> {
     ensure_dir_exists(&toolchain_bin_dir)?;
 
     for bin in ALL_BINS {
+        // For simplicity, we use 2 dummy versions to test showing versions when switching between toolchains.
         let version = match toolchain.starts_with("latest") {
             true => VERSION,
             _ => VERSION_2,
@@ -200,6 +204,7 @@ fn setup_toolchain(fuelup_home_path: &Path, toolchain: &str) -> Result<()> {
         create_fuel_executable(&exe_path, version)?;
 
         if should_check_fuels_compatibility(bin) {
+            // For simplicity, we use 2 dummy versions to test showing versions when switching between toolchains.
             let fuels_version = match toolchain.starts_with("latest") {
                 true => VERSION,
                 _ => VERSION_2,


### PR DESCRIPTION
closes #411
follow up to #410
When we introduced the store architecture, the test infra was not updated to reflect this, so the behaviour diverged abit, even if tests passed. Instead we just had the same setup (toolchain directory created only). 

This PR updates the test environment setup by mimicking the actual environment again. Assuming the test env is created under a directory `.tmpA3bI3`:

1. create the actual executable within the store, eg. `forc` is created in `/.tmpA3bI3/.fuelup/store/forc-0.35.3` for example.
2. link the executable to the toolchain bin directory, eg. `/.tmpA3bI3/.fuelup/toolchains/my-toolchain/bin/forc`
3. execute tests as per normal.

I also added a test as a sanity check in the case where a specific `fuels_version` file is removed.