### PR TITLE
ci: index other components

### DIFF
--- a/.github/workflows/index-versions.yml
+++ b/.github/workflows/index-versions.yml
@@ -1,7 +1,6 @@
 name: Check Versions
 
 on:
-  workflow_dispatch:
   schedule:
     # Run at minute 0 every hour
     - cron: '0 * * * *'
@@ -46,6 +45,8 @@ jobs:
       - name: Compare versions and set variables for tests if needed
         id: set-version-matrix
         run: |
+          compare-versions compatibility >> out
+          VERSIONS=''
           # If file is empty, we have no new versions and we are done.
           if [ -s out ]; then
 
@@ -90,7 +91,7 @@ jobs:
   # between forc and fuel-core.
   #
   # This is only run if should-run is set to true.
-  test-toolchain-compatibility:
+  test-compatibility:
     name: Test compatibility
     needs: compare-versions
     if: ${{ needs.compare-versions.outputs.should-run == 'true' }}
@@ -100,7 +101,7 @@ jobs:
 
   check-other-components-latest:
     name: Check other components for their latest versions
-    needs: [compare-versions]
+    needs: compare-versions
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/index-versions.yml
+++ b/.github/workflows/index-versions.yml
@@ -1,6 +1,7 @@
 name: Check Versions
 
 on:
+  workflow_dispatch:
   schedule:
     # Run at minute 0 every hour
     - cron: '0 * * * *'
@@ -21,10 +22,11 @@ jobs:
     steps:
       - name: checkout master
         uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - uses: Swatinem/rust-cache@v2
 
       - name: Checkout fuelup gh-pages
         uses: actions/checkout@v3
@@ -34,16 +36,16 @@ jobs:
           ref: gh-pages
 
       - uses: Swatinem/rust-cache@v1
+
       - name: Install compare-versions script
         uses: actions-rs/cargo@v1
         with:
           command: install
           args: --debug --path ./ci/compare-versions
+
       - name: Compare versions and set variables for tests if needed
         id: set-version-matrix
         run: |
-          compare-versions >> out
-          VERSIONS=''
           # If file is empty, we have no new versions and we are done.
           if [ -s out ]; then
 
@@ -88,10 +90,61 @@ jobs:
   # between forc and fuel-core.
   #
   # This is only run if should-run is set to true.
-  test-compatibility:
+  test-toolchain-compatibility:
     name: Test compatibility
     needs: compare-versions
     if: ${{ needs.compare-versions.outputs.should-run == 'true' }}
     uses: ./.github/workflows/test-toolchain-compatibility.yml
     with:
       version-matrix: ${{ needs.compare-versions.outputs.version-matrix }}
+
+  check-other-components-latest:
+    name: Check other components for their latest versions
+    needs: [compare-versions]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
+      
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install compare-versions script
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: --debug --path ./ci/compare-versions
+
+      - name: Install build-channel script
+        run: cargo install --debug --path ./ci/build-channel
+
+      - name: Check for latest versions of other components and execute build-channel
+        run: compare-versions rest
+
+      - name: Prepare channel with compatible versions
+        run: |
+            mkdir -p ${{ env.LATEST_CHANNEL_DIR }}
+            CHANNEL_TOML="channel-fuel-latest.toml"
+
+            cp $CHANNEL_TOML ${{ env.LATEST_CHANNEL_DIR }}
+
+            mkdir archive
+            PUBLISHED_DATE=$(date +'%Y-%m-%d')
+            cp $CHANNEL_TOML archive/channel-fuel-latest-${PUBLISHED_DATE}.toml
+
+      - name: Deploy latest channel
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ${{ env.LATEST_CHANNEL_DIR }}
+          keep_files: true
+          destination_dir: ./
+
+      - name: Deploy latest channel (archive)
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./archive
+          keep_files: true
+          destination_dir: ./channels/latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,9 +196,11 @@ name = "compare-versions"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "component",
  "semver",
  "serde",
  "serde_json",
+ "time 0.3.14",
  "toml_edit 0.14.4",
  "ureq",
 ]

--- a/ci/compare-versions/Cargo.toml
+++ b/ci/compare-versions/Cargo.toml
@@ -8,8 +8,10 @@ publish = false
 
 [dependencies]
 anyhow = "1" 
+component = { path = "../../component" }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+time = { version = "0.3", features = ["macros", "parsing", "formatting", "serde-well-known"] }
 toml_edit = "0.14"
 ureq = "2.4"

--- a/ci/compare-versions/Cargo.toml
+++ b/ci/compare-versions/Cargo.toml
@@ -12,6 +12,6 @@ component = { path = "../../component" }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-time = { version = "0.3", features = ["macros", "parsing", "formatting", "serde-well-known"] }
+time = { version = "0.3" }
 toml_edit = "0.14"
 ureq = "2.4"

--- a/ci/compare-versions/src/main.rs
+++ b/ci/compare-versions/src/main.rs
@@ -88,19 +88,12 @@ fn get_latest_release_version(repo: &str) -> Result<Version> {
     );
 
     let handle = ureq::builder().user_agent("fuelup").build();
-    let resp = match handle.get(&url).call() {
-        Ok(r) => r
-            .into_string()
-            .expect("Could not convert channel to string"),
+    let response: LatestReleaseApiResponse = match handle.get(&url).call() {
+        Ok(r) => serde_json::from_reader(r.into_reader())?,
         Err(e) => {
-            bail!(
-                "Unexpected error trying to fetch channel: {} - retrying at the next scheduled time",
-                e
-            );
+            bail!("Could not get latest release for {}: {}", repo, e);
         }
     };
-
-    let response: LatestReleaseApiResponse = serde_json::from_str(&resp)?;
 
     let version_str = response.tag_name["v".len()..].to_string();
 

--- a/tests/expects/mod.rs
+++ b/tests/expects/mod.rs
@@ -4,7 +4,6 @@ pub fn expect_files_exist(dir: &Path, expected: &[&str]) {
     let mut actual: Vec<String> = dir
         .read_dir()
         .expect("Could not read directory")
-        .into_iter()
         .map(|b| b.unwrap().file_name().to_string_lossy().to_string())
         .collect();
 


### PR DESCRIPTION
closes #377

Adds an alternative mode to `compare-versions` to check for other components other than `forc` and `fuel-core`. Modes are selected by inputting an arg after running the `compare-versions` Rust program. `compare-versions` is still ran every hour by the fuelup gh CI, and the workflow is edited to run them as appropriate.

You may either input *compatibility* or *rest*:

**compatibility**: 

runs the same check we had as always. This is run prior to the toolchain compatibility tests - no changes here.

**rest**:

runs a check that compares latest actual released versions versus latest indexed versions in our `channel-fuel-latest.toml` TOML file, and executes the build-channel script to build a new channel if there are any new versions detected.

Note that this excludes `forc` and `fuel-core`. If for example, a new `forc-index` version is discovered, the `compare-versions` script will call `build-channel` to build a new latest channel, with forc and fuel-core versions parsed from the current latest indexed versions. **We cannot indiscriminately build the new latest channel with the latest `forc` and `fuel-core` since they may not pass compatibility checks.**

I haven't tested this scenario but there may be a race condition where a new version of `forc-index` is published and overwritten by an older version if the compatibility tests are running at the same time and finishes after the publishing is done from this seperate check, but IMO this is inconsequential since a new check will commence an hour later anyway.

My only concern here is potentially being rate-limited by GH CI since there's quite a number of components here, but let's see. The CI fails now and then but so far I've ignored it, because it isn't really critical that we missed 1 check every 24 hours when the check runs every hour anyway.