### PR TITLE
fix: proxy_cli erroneously executes `forc` when forc plugins are called

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -14,7 +14,7 @@ pub(crate) fn hardlink(original: &Path, link: &Path) -> io::Result<()> {
     fs::hard_link(original, link)
 }
 
-pub(crate) fn hard_or_symlink_file(original: &Path, link: &Path) -> Result<()> {
+pub fn hard_or_symlink_file(original: &Path, link: &Path) -> Result<()> {
     if hardlink_file(original, link).is_err() {
         symlink_file(original, link)?;
     }

--- a/src/proxy_cli.rs
+++ b/src/proxy_cli.rs
@@ -50,7 +50,8 @@ fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: &Toolchain) -> Re
             } else {
                 proc_name
             };
-            // Install components within [components] that are declared but missing from the store.
+
+            // If a specific version is declared, we want to call it from the store and not from the toolchain directory.
             if let Some(version) = to.get_component_version(component_name) {
                 let store = Store::from_env()?;
 
@@ -60,6 +61,7 @@ fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: &Toolchain) -> Re
                         TargetTriple::from_component(component_name)?,
                         Some(version.clone()),
                     )?;
+                    // Install components within [components] that are declared but missing from the store.
                     store.install_component(&download_cfg)?;
                 };
 
@@ -70,10 +72,7 @@ fn direct_proxy(proc_name: &str, args: &[OsString], toolchain: &Toolchain) -> Re
                     description.to_string(),
                 )
             } else {
-                (
-                    toolchain.bin_path.join(component_name),
-                    description.to_string(),
-                )
+                (toolchain.bin_path.join(proc_name), description.to_string())
             }
         }
         None => (

--- a/tests/override.rs
+++ b/tests/override.rs
@@ -9,12 +9,12 @@ use fuelup::{
 use testcfg::FuelupState;
 
 #[test]
-fn check_correct_forc_deploy_called() -> Result<()> {
+fn check_correct_forc_plugin_called() -> Result<()> {
     testcfg::setup(FuelupState::AllInstalled, &|cfg| {
-        let mut stdout = cfg.forc(&["deploy", "--version"]).stdout;
-        assert_eq!(stdout, "forc-deploy 0.1.0\n");
-        stdout = cfg.exec("forc-deploy", &["--version"]).stdout;
-        assert_eq!(stdout, "forc-deploy 0.1.0\n");
+        let mut stdout = cfg.forc(&["wallet", "--version"]).stdout;
+        assert_eq!(stdout, "forc-wallet 0.1.0\n");
+        stdout = cfg.exec("forc-wallet", &["--version"]).stdout;
+        assert_eq!(stdout, "forc-wallet 0.1.0\n");
 
         let toolchain_override = ToolchainOverride {
             cfg: OverrideCfg::new(
@@ -27,10 +27,10 @@ fn check_correct_forc_deploy_called() -> Result<()> {
         };
         testcfg::setup_override_file(toolchain_override).unwrap();
 
-        stdout = cfg.forc(&["deploy", "--version"]).stdout;
-        assert_eq!(stdout, "forc-deploy 0.2.0\n");
-        stdout = cfg.exec("forc-deploy", &["--version"]).stdout;
-        assert_eq!(stdout, "forc-deploy 0.2.0\n");
+        stdout = cfg.forc(&["wallet", "--version"]).stdout;
+        assert_eq!(stdout, "forc-wallet 0.2.0\n");
+        stdout = cfg.exec("forc-wallet", &["--version"]).stdout;
+        assert_eq!(stdout, "forc-wallet 0.2.0\n");
     })?;
 
     Ok(())

--- a/tests/override.rs
+++ b/tests/override.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use std::str::FromStr;
+
+pub mod testcfg;
+use fuelup::{
+    constants::FUEL_TOOLCHAIN_TOML_FILE,
+    toolchain_override::{self, OverrideCfg, ToolchainCfg, ToolchainOverride},
+};
+use testcfg::FuelupState;
+
+#[test]
+fn check_correct_forc_deploy_called() -> Result<()> {
+    testcfg::setup(FuelupState::AllInstalled, &|cfg| {
+        let mut stdout = cfg.forc(&["deploy", "--version"]).stdout;
+        assert_eq!(stdout, "forc-deploy 0.1.0\n");
+        stdout = cfg.exec("forc-deploy", &["--version"]).stdout;
+        assert_eq!(stdout, "forc-deploy 0.1.0\n");
+
+        let toolchain_override = ToolchainOverride {
+            cfg: OverrideCfg::new(
+                ToolchainCfg {
+                    channel: toolchain_override::Channel::from_str("nightly-2022-08-30").unwrap(),
+                },
+                None,
+            ),
+            path: cfg.home.join(FUEL_TOOLCHAIN_TOML_FILE),
+        };
+        testcfg::setup_override_file(toolchain_override).unwrap();
+
+        stdout = cfg.forc(&["deploy", "--version"]).stdout;
+        assert_eq!(stdout, "forc-deploy 0.2.0\n");
+        stdout = cfg.exec("forc-deploy", &["--version"]).stdout;
+        assert_eq!(stdout, "forc-deploy 0.2.0\n");
+    })?;
+
+    Ok(())
+}

--- a/tests/override.rs
+++ b/tests/override.rs
@@ -10,6 +10,11 @@ use testcfg::FuelupState;
 
 #[test]
 fn check_correct_forc_plugin_called() -> Result<()> {
+    // We execute both 'forc wallet' and 'forc-wallet' in this test
+    // to ensure both work as intended.
+    //
+    // The test environment is set up similarly to a real fuelup environment,
+    // complete with links.
     testcfg::setup(FuelupState::AllInstalled, &|cfg| {
         let mut stdout = cfg.forc(&["wallet", "--version"]).stdout;
         assert_eq!(stdout, "forc-wallet 0.1.0\n");

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -111,12 +111,17 @@ impl TestCfg {
             .unwrap()
     }
 
+    /// A function for executing binaries within the fuelup test configuration.
+    ///
+    /// This invokes std::process::Command with some default environment variables
+    /// set up nicely for testing fuelup and its managed binaries.
     pub fn exec(&mut self, proc_name: &str, args: &[&str]) -> TestOutput {
         let path = self.fuelup_bin_dirpath.join(proc_name);
         let output = Command::new(path)
             .args(args)
             .current_dir(&self.home)
             .env("HOME", &self.home)
+            .env("CARGO_HOME", &self.home.join(".cargo"))
             .env(
                 "PATH",
                 format!(
@@ -138,34 +143,16 @@ impl TestCfg {
         }
     }
 
+    /// A convenience wrapper for executing 'forc' binaries within the fuelup test configuration.
+    /// This is just a testcfg::exec() call with "forc" as its first argument.
     pub fn forc(&mut self, args: &[&str]) -> TestOutput {
         self.exec("forc", args)
     }
 
+    /// A convenience wrapper for executing 'fuelup' within the fuelup test configuration.
+    /// This is just a testcfg::exec() call with "fuelup" as its first argument.
     pub fn fuelup(&mut self, args: &[&str]) -> TestOutput {
-        let output = Command::new(&self.fuelup_path)
-            .args(args)
-            .current_dir(&self.home)
-            .env("HOME", &self.home)
-            .env("CARGO_HOME", self.home.join(".cargo").to_str().unwrap())
-            .env(
-                "PATH",
-                format!(
-                    "{}:{}",
-                    &self.home.join(".local/bin").display(),
-                    &self.home.join(".cargo/bin").display()
-                ),
-            )
-            .env("TERM", "dumb")
-            .output()
-            .expect("Failed to execute command");
-        let stdout = String::from_utf8(output.stdout).unwrap();
-        let stderr = String::from_utf8(output.stderr).unwrap();
-        TestOutput {
-            stdout,
-            stderr,
-            status: output.status,
-        }
+        self.exec("fuelup", args)
     }
 }
 


### PR DESCRIPTION
closes #422 

The entire bug was a result of a one-line mistake:

https://github.com/FuelLabs/fuelup/blob/784edcddd8dc28b7499b4410d5c3fc8802ebe281/src/proxy_cli.rs#L74

If you look at the source code you can see that `component_name` is used to derive the path of a binary if a version was specified in an override. In the case of forc, we require this `component_name` instead of using `proc_name` as seen in the function because forc plugins are packaged together with forc - which means if we want to find  the directory that contains `forc-deploy v0.35.5`, this would be found in `forc-0.35.5`, which means we would have to use `component_name` (forc) instead of `proc_name` (forc-deploy, for example)

The bug was caused by using the `component_name` to invoke the binary instead of using the `proc_name` in the case that an entire toolchain was overridden. In that scenario, since that specific version is already linked to the toolchain directory, we do not have to derive the path, we just have to call what's inside the toolchain bin directory, i.e. `~/.fuelup/toolchains/beta-3.../bin/forc-deploy`.

I also added a simple test in this PR to emulate the scenario with a custom injected override file so we can hopefully prevent any regressions on this behavior.