### PR TITLE
chore: deprecate usage of hashes to check download duplication

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,55 +1,22 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use anyhow::{bail, Result};
-use std::io::{self, ErrorKind};
+use anyhow::Result;
+use std::io;
 
-use crate::file::write_file;
 use crate::fmt::format_toolchain_with_target;
-use crate::path::{ensure_dir_exists, hashes_dir, toolchains_dir};
-use crate::toolchain::{DistToolchainDescription, RESERVED_TOOLCHAIN_NAMES};
+use crate::path::toolchains_dir;
+use crate::toolchain::RESERVED_TOOLCHAIN_NAMES;
 
 pub struct Config {
     toolchains_dir: PathBuf,
-    hashes_dir: PathBuf,
 }
 
 impl Config {
     pub(crate) fn from_env() -> Result<Self> {
         Ok(Self {
             toolchains_dir: toolchains_dir(),
-            hashes_dir: hashes_dir(),
         })
-    }
-
-    pub(crate) fn hashes_dir(&self) -> &Path {
-        self.hashes_dir.as_path()
-    }
-
-    pub(crate) fn hash_matches(
-        &self,
-        description: &DistToolchainDescription,
-        hash: &str,
-    ) -> Result<bool> {
-        let hash_path = self.hashes_dir.join(description.to_string());
-
-        match fs::read_to_string(hash_path) {
-            Ok(h) => Ok(h == hash),
-            Err(e) => match e.kind() {
-                ErrorKind::NotFound => Ok(false),
-                _ => bail!("Failed to read hash from hash file"),
-            },
-        }
-    }
-
-    pub(crate) fn hash_exists(&self, description: &DistToolchainDescription) -> bool {
-        self.hashes_dir.join(description.to_string()).is_file()
-    }
-
-    pub(crate) fn save_hash(&self, toolchain: &str, hash: &str) -> Result<()> {
-        ensure_dir_exists(&self.hashes_dir)?;
-        write_file(&self.hashes_dir.join(toolchain), hash)?;
-        Ok(())
     }
 
     pub(crate) fn list_toolchains(&self) -> Result<Vec<String>> {

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -103,7 +103,7 @@ fn check_fuelup() -> Result<()> {
 fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
     let description = DistToolchainDescription::from_str(toolchain)?;
 
-    let (dist_channel, _) = Channel::from_dist_channel(&description)?;
+    let dist_channel = Channel::from_dist_channel(&description)?;
     let latest_package_versions = collect_package_versions(dist_channel);
 
     let toolchain = Toolchain::new(toolchain)?;

--- a/src/ops/fuelup_toolchain/uninstall.rs
+++ b/src/ops/fuelup_toolchain/uninstall.rs
@@ -1,5 +1,4 @@
 use anyhow::{bail, Result};
-use std::fs;
 use std::str::FromStr;
 use tracing::{error, info};
 
@@ -16,14 +15,7 @@ pub fn uninstall(command: UninstallCommand) -> Result<()> {
     let config = Config::from_env()?;
 
     let toolchain = match DistToolchainDescription::from_str(&name) {
-        Ok(desc) => {
-            if config.hash_exists(&desc) {
-                let hash_file = config.hashes_dir().join(desc.to_string());
-                fs::remove_file(hash_file)?;
-            };
-
-            Toolchain::from_path(&desc.to_string())
-        }
+        Ok(desc) => Toolchain::from_path(&desc.to_string()),
         Err(_) => Toolchain::from_path(&name),
     };
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -9,7 +9,6 @@ use time::Date;
 use tracing::{error, info};
 
 use crate::channel::{self, is_beta_toolchain, Channel};
-use crate::config::Config;
 use crate::constants::DATE_FORMAT;
 use crate::download::DownloadCfg;
 use crate::file::{hard_or_symlink_file, is_executable};
@@ -328,13 +327,9 @@ impl Toolchain {
     pub fn install_if_nonexistent(&self, description: &DistToolchainDescription) -> Result<()> {
         if !self.exists() {
             info!("toolchain '{}' does not exist; installing", description);
-            if let Ok((channel, hash)) = Channel::from_dist_channel(description) {
+            if let Ok(channel) = Channel::from_dist_channel(description) {
                 ensure_dir_exists(&self.bin_path)?;
                 let store = Store::from_env()?;
-                let config = Config::from_env()?;
-                if let Ok(true) = config.hash_matches(description, &hash) {
-                    info!("'{}' is already installed and up to date", self.name);
-                };
                 for cfg in channel.build_download_configs() {
                     if store.has_component(&cfg.name, &cfg.version) {
                         hard_or_symlink_file(


### PR DESCRIPTION
Closes #418 

Prior to the 'store' model that we now use, each binary was not cached in some local location. We used basic sha256 hashes stored within .fuelup/hashes directory as a way to tell fuelup that a toolchain already exists. This is important to ensure that users don't waste time re-downloading binaries that they have already downloaded once before.

With the store model, we no longer need this since it's much faster now to re-install toolchains with duplicate binaries since they are all cached in the store. We can now get rid of this hacky way of speeding up the download process, since it's built-in to the design.