### PR TITLE
fix: build-channel usage within CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,8 @@ jobs:
             FORC_VERSION=$(grep -A1 '\[pkg.forc\]' ./gh-pages/channel-fuel-latest.toml | cut -d "\"" -f2)
             FUEL_CORE_VERSION=$(grep -A1 '\[pkg.fuel-core\]' ./gh-pages/channel-fuel-latest.toml | cut -d "\"" -f2)
 
-            build-channel latest $CHANNEL_TOML $GITHUB_RUN_ID forc=$FORC_VERSION fuel-core=$FUEL_CORE_VERSION
+            PUBLISHED_DATE=$(date +'%Y-%m-%d')
+            build-channel $CHANNEL_TOML $PUBLISHED_DATE --github-run-id $GITHUB_RUN_ID forc=$FORC_VERSION fuel-core=$FUEL_CORE_VERSION
 
             cp $CHANNEL_TOML ${{ env.LATEST_CHANNEL_DIR }}
 


### PR DESCRIPTION
The build-channel program was changed in #392 but this part of the CI was not updated to match the new usage method.