### PR TITLE
fix: use forc to build sdk-harness tests in CI

### DIFF
--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -68,7 +68,7 @@ jobs:
         run: cd sway && cargo run --locked --release --bin test -- --target evm --locked
 
       - name: Build All Tests
-        run: cd sway/test/src/sdk-harness && bash build.sh --locked && cd ../../../../
+        run: cd sway && cargo run --locked -p forc -- build --locked --path ./test/src/sdk-harness 
 
       - name: Cargo Test sway-lib-std
         id: std-lib-tests


### PR DESCRIPTION
Sway repo uses forc workspaces to build sdk harness tests but fuelup CI was still trying to use outdated `buil.sh` which does not exist anymore. So the integration tests were failing, this should fix it but I am not sure how to test it.