### PR TITLE
feat: add beta-4-rc reserved channel

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,8 +1,8 @@
 use crate::{
     constants::{
         CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_BETA_3_FILE_NAME,
-        CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME, DATE_FORMAT_URL_FRIENDLY,
-        FUELUP_GH_PAGES,
+        CHANNEL_BETA_4_RC_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
+        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -21,6 +21,7 @@ pub const STABLE: &str = "stable";
 pub const BETA_1: &str = "beta-1";
 pub const BETA_2: &str = "beta-2";
 pub const BETA_3: &str = "beta-3";
+pub const BETA_4_RC: &str = "beta-4-rc";
 pub const NIGHTLY: &str = "nightly";
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -42,7 +43,7 @@ pub struct Package {
 }
 
 pub fn is_beta_toolchain(name: &str) -> bool {
-    name == BETA_1 || name == BETA_2 || name == BETA_3
+    name == BETA_1 || name == BETA_2 || name == BETA_3 || name == BETA_4_RC
 }
 
 fn format_nightly_url(date: &Date) -> Result<String> {
@@ -73,6 +74,7 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
         DistToolchainName::Beta1 => url.push_str(CHANNEL_BETA_1_FILE_NAME),
         DistToolchainName::Beta2 => url.push_str(CHANNEL_BETA_2_FILE_NAME),
         DistToolchainName::Beta3 => url.push_str(CHANNEL_BETA_3_FILE_NAME),
+        DistToolchainName::Beta4Rc => url.push_str(CHANNEL_BETA_4_RC_FILE_NAME),
     };
 
     Ok(url)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,6 +11,7 @@ pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
 pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
 pub const CHANNEL_BETA_2_FILE_NAME: &str = "channel-fuel-beta-2.toml";
 pub const CHANNEL_BETA_3_FILE_NAME: &str = "channel-fuel-beta-3.toml";
+pub const CHANNEL_BETA_4_RC_FILE_NAME: &str = "channel-fuel-beta-4-rc.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -26,6 +26,7 @@ pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::BETA_1,
     channel::BETA_2,
     channel::BETA_3,
+    channel::BETA_4_RC,
     channel::NIGHTLY,
     channel::STABLE,
 ];
@@ -35,6 +36,7 @@ pub enum DistToolchainName {
     Beta1,
     Beta2,
     Beta3,
+    Beta4Rc,
     Latest,
     Nightly,
 }
@@ -47,6 +49,7 @@ impl fmt::Display for DistToolchainName {
             DistToolchainName::Beta1 => write!(f, "{}", channel::BETA_1),
             DistToolchainName::Beta2 => write!(f, "{}", channel::BETA_2),
             DistToolchainName::Beta3 => write!(f, "{}", channel::BETA_3),
+            DistToolchainName::Beta4Rc => write!(f, "{}", channel::BETA_4_RC),
         }
     }
 }
@@ -60,6 +63,7 @@ impl FromStr for DistToolchainName {
             channel::BETA_1 => Ok(Self::Beta1),
             channel::BETA_2 => Ok(Self::Beta2),
             channel::BETA_3 => Ok(Self::Beta3),
+            channel::BETA_4_RC => Ok(Self::Beta4Rc),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }


### PR DESCRIPTION
This PR adds beta-4-rc reserved channel to fuelup. So that users can get the beta-4-rc channel with

```console
fuelup toolchain install beta-4-rc
```