### PR TITLE
chore: bump fuel-indexer to 0.18.4 for beta-3 network

### DIFF
--- a/channel-fuel-beta-3.toml
+++ b/channel-fuel-beta-3.toml
@@ -1,4 +1,4 @@
-date = "2023-05-26"
+date = "2023-07-18"
 
 [pkg.forc]
 version = "0.37.3"
@@ -39,23 +39,23 @@ url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-
 hash = "9ef1d8af2c5a611d33f8966881197bd4958da05e4b325eb0dc847b84ea1eac96"
 
 [pkg.forc-index]
-version = "0.15.0"
+version = "0.18.4"
 
 [pkg.forc-index.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.15.0/forc-index-0.15.0-aarch64-unknown-linux-gnu.tar.gz"
-hash = "fb5b1eda3ae19168cf12776a7be3cee81aba7150a04532c94ab90080dd64342d"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.18.4/forc-index-0.18.4-aarch64-unknown-linux-gnu.tar.gz"
+hash = "df8fdb088f5e51dc48b3addb1cddef434356356fb8a9294ffca606ed7014f7cf"
 
 [pkg.forc-index.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.15.0/forc-index-0.15.0-x86_64-unknown-linux-gnu.tar.gz"
-hash = "a1e31dc3c1d62be6ee54eaccde6d88c33fa1e40c2f7ab401fb99f5827d55452c"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.18.4/forc-index-0.18.4-x86_64-unknown-linux-gnu.tar.gz"
+hash = "7d5254011a15596fcec5c88070271cafd1c9beaa3d238e7794be3cd1d9c1df06"
 
 [pkg.forc-index.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.15.0/forc-index-0.15.0-aarch64-apple-darwin.tar.gz"
-hash = "04a54b237158fe1f5a9694fc759d420731f6d6abe32a283bb706667c832a042e"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.18.4/forc-index-0.18.4-aarch64-apple-darwin.tar.gz"
+hash = "dda5f51d01aa5e1b30b8d600b9712d549c382ae874759af01e2774db71886fe1"
 
 [pkg.forc-index.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.15.0/forc-index-0.15.0-x86_64-apple-darwin.tar.gz"
-hash = "1bbad7a631362885c9234bf88dfad9b8a1fa1fddc45d31273517410548e5a726"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.18.4/forc-index-0.18.4-x86_64-apple-darwin.tar.gz"
+hash = "83e788d2890cd3115e850237d326ef9f0ef5e4800cb970bc2760796d16d42714"
 
 [pkg.forc-wallet]
 version = "0.2.2"
@@ -96,20 +96,20 @@ url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.17.11/fuel-cor
 hash = "ec63e5a25450aec7f0e5f007f39b3efa50d882a85af0a118c866c122da6daa16"
 
 [pkg.fuel-indexer]
-version = "0.15.0"
+version = "0.18.4"
 
 [pkg.fuel-indexer.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.15.0/fuel-indexer-0.15.0-aarch64-unknown-linux-gnu.tar.gz"
-hash = "4754226d444162b0ec542b3f17fba58d5965729a4e7ebe3e4fe07843efd16d26"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.18.4/fuel-indexer-0.18.4-aarch64-unknown-linux-gnu.tar.gz"
+hash = "a271818a40156929c540ba2b8994e7703a832a2697337404c3c13badcfff890c"
 
 [pkg.fuel-indexer.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.15.0/fuel-indexer-0.15.0-x86_64-unknown-linux-gnu.tar.gz"
-hash = "48824ea98d7c0dc903e2c8ec95036dfb9baeae7a387a4eeea4a4299968e820f9"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.18.4/fuel-indexer-0.18.4-x86_64-unknown-linux-gnu.tar.gz"
+hash = "a7be918e4eeb91f2cb30994d6634299d19659af349079efbbe187dd6818ba496"
 
 [pkg.fuel-indexer.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.15.0/fuel-indexer-0.15.0-aarch64-apple-darwin.tar.gz"
-hash = "1dad9b9f6860a2ba65984076cc6e4a43b1b7c9c3c44979dd2ff684a9c318acd2"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.18.4/fuel-indexer-0.18.4-aarch64-apple-darwin.tar.gz"
+hash = "301e95333130f00a919b54c87deae93aaf8e819ea1c7a86bfc41804c60e4a822"
 
 [pkg.fuel-indexer.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.15.0/fuel-indexer-0.15.0-x86_64-apple-darwin.tar.gz"
-hash = "423de92c1d9b13e43d1b8a6af90115f800713b55a966d503597c0a013951569c"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.18.4/fuel-indexer-0.18.4-x86_64-apple-darwin.tar.gz"
+hash = "f227ad1b3b9690f2c32443867c90c0c49821ba4d39afde4d16d0f35dc1518883"


### PR DESCRIPTION
bumps indexer version to 0.18.4 for beta-3 network