### PR TITLE
feat: add `beta-4-rc-2` dist channel support

### DIFF
--- a/docs/src/concepts/channels.md
+++ b/docs/src/concepts/channels.md
@@ -20,9 +20,9 @@ The `beta-3` channel is a published TOML file describing the toolchain that is c
 
 The `beta-4-rc` channel offers developers an early opportunity to test out new features and improvements, including enhancements and bug fixes made since the beta-3 version. If maintaining compatibility with the beta-3 testnet is required for your project, we recommend you continue using the beta-3 toolchain. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-4-rc.toml).
 
-## The `beta-4-rc-2` channel
+## The `beta-4-rc.2` channel
 
-The `beta-4-rc-2` channel offers developers an early opportunity to test out new features and improvements, including enhancements and bug fixes made since the beta-4-rc version. If maintaining compatibility with the beta-3 testnet is required for your project, we recommend you continue using the beta-3 toolchain. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-4-rc-2.toml).
+The `beta-4-rc.2` channel offers developers an early opportunity to test out new features and improvements, including enhancements and bug fixes made since the beta-4-rc version. If maintaining compatibility with the beta-3 testnet is required for your project, we recommend you continue using the beta-3 toolchain. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-4-rc-2.toml).
 
 ## The `nightly` channel
 

--- a/docs/src/concepts/channels.md
+++ b/docs/src/concepts/channels.md
@@ -20,6 +20,10 @@ The `beta-3` channel is a published TOML file describing the toolchain that is c
 
 The `beta-4-rc` channel offers developers an early opportunity to test out new features and improvements, including enhancements and bug fixes made since the beta-3 version. If maintaining compatibility with the beta-3 testnet is required for your project, we recommend you continue using the beta-3 toolchain. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-4-rc.toml).
 
+## The `beta-4-rc-2` channel
+
+The `beta-4-rc-2` channel offers developers an early opportunity to test out new features and improvements, including enhancements and bug fixes made since the beta-4-rc version. If maintaining compatibility with the beta-3 testnet is required for your project, we recommend you continue using the beta-3 toolchain. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-4-rc-2.toml).
+
 ## The `nightly` channel
 
 <!-- This section should give an overview of the nightly channel -->

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -22,7 +22,7 @@ pub const BETA_1: &str = "beta-1";
 pub const BETA_2: &str = "beta-2";
 pub const BETA_3: &str = "beta-3";
 pub const BETA_4_RC: &str = "beta-4-rc";
-pub const BETA_4_RC_2: &str = "beta-4-rc2";
+pub const BETA_4_RC_2: &str = "beta-4-rc.2";
 pub const NIGHTLY: &str = "nightly";
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,8 +1,8 @@
 use crate::{
     constants::{
         CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_BETA_3_FILE_NAME,
-        CHANNEL_BETA_4_RC_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
-        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
+        CHANNEL_BETA_4_RC_2_FILE_NAME, CHANNEL_BETA_4_RC_FILE_NAME, CHANNEL_LATEST_FILE_NAME,
+        CHANNEL_NIGHTLY_FILE_NAME, DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -22,6 +22,7 @@ pub const BETA_1: &str = "beta-1";
 pub const BETA_2: &str = "beta-2";
 pub const BETA_3: &str = "beta-3";
 pub const BETA_4_RC: &str = "beta-4-rc";
+pub const BETA_4_RC_2: &str = "beta-4-rc2";
 pub const NIGHTLY: &str = "nightly";
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -43,7 +44,7 @@ pub struct Package {
 }
 
 pub fn is_beta_toolchain(name: &str) -> bool {
-    name == BETA_1 || name == BETA_2 || name == BETA_3 || name == BETA_4_RC
+    name == BETA_1 || name == BETA_2 || name == BETA_3 || name == BETA_4_RC || name == BETA_4_RC_2
 }
 
 fn format_nightly_url(date: &Date) -> Result<String> {
@@ -75,6 +76,7 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
         DistToolchainName::Beta2 => url.push_str(CHANNEL_BETA_2_FILE_NAME),
         DistToolchainName::Beta3 => url.push_str(CHANNEL_BETA_3_FILE_NAME),
         DistToolchainName::Beta4Rc => url.push_str(CHANNEL_BETA_4_RC_FILE_NAME),
+        DistToolchainName::Beta4Rc2 => url.push_str(CHANNEL_BETA_4_RC_2_FILE_NAME),
     };
 
     Ok(url)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,6 +12,7 @@ pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
 pub const CHANNEL_BETA_2_FILE_NAME: &str = "channel-fuel-beta-2.toml";
 pub const CHANNEL_BETA_3_FILE_NAME: &str = "channel-fuel-beta-3.toml";
 pub const CHANNEL_BETA_4_RC_FILE_NAME: &str = "channel-fuel-beta-4-rc.toml";
+pub const CHANNEL_BETA_4_RC_2_FILE_NAME: &str = "channel-fuel-beta-4-rc-2.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -27,6 +27,7 @@ pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::BETA_2,
     channel::BETA_3,
     channel::BETA_4_RC,
+    channel::BETA_4_RC_2,
     channel::NIGHTLY,
     channel::STABLE,
 ];
@@ -37,6 +38,7 @@ pub enum DistToolchainName {
     Beta2,
     Beta3,
     Beta4Rc,
+    Beta4Rc2,
     Latest,
     Nightly,
 }
@@ -50,6 +52,7 @@ impl fmt::Display for DistToolchainName {
             DistToolchainName::Beta2 => write!(f, "{}", channel::BETA_2),
             DistToolchainName::Beta3 => write!(f, "{}", channel::BETA_3),
             DistToolchainName::Beta4Rc => write!(f, "{}", channel::BETA_4_RC),
+            DistToolchainName::Beta4Rc2 => write!(f, "{}", channel::BETA_4_RC_2),
         }
     }
 }
@@ -64,6 +67,7 @@ impl FromStr for DistToolchainName {
             channel::BETA_2 => Ok(Self::Beta2),
             channel::BETA_3 => Ok(Self::Beta3),
             channel::BETA_4_RC => Ok(Self::Beta4Rc),
+            channel::BETA_4_RC_2 => Ok(Self::Beta4Rc2),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }


### PR DESCRIPTION
Adds beta-4-rc2 support to fuelup so that people can install it via:

```console
fuelup toolchain install beta-4-rc.2
```

Unfortunately due to how fuelup parses toolchain metadata it is not straightforward to make it possible to use:

```console
fuelup toolchain install beta-4-rc-2
```

We can support it later on and change the name if necessary as this is more towards to our internal testing, I feel like timing is has a little priority rn, but happy to mark this as draft and handle that if it seems like blocker.