### PR TITLE
ci: use rust 1.71 in ci

### DIFF
--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  RUST_VERSION: 1.68.2
+  RUST_VERSION: 1.71.0
   NIGHTLY_RUST_VERSION: nightly-2023-02-08
   INCOMPATIBLE_DIR: ./incompatible-versions
   LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/

--- a/ci/compare-versions/src/main.rs
+++ b/ci/compare-versions/src/main.rs
@@ -180,7 +180,7 @@ fn compare_rest() -> Result<()> {
 
     for component in components
         .iter()
-        .filter(|c| !["forc", "fuel-core"].contains(&c.name.as_str()))
+        .filter(|c| !["forc", "fuel-core", "fuel-core-keygen"].contains(&c.name.as_str()))
     {
         let latest_actual_version = get_latest_version(&component.repository_name)?;
         let latest_indexed_version = parse_latest_indexed_version(&channel_doc, &component.name);

--- a/ci/compare-versions/src/main.rs
+++ b/ci/compare-versions/src/main.rs
@@ -180,7 +180,7 @@ fn compare_rest() -> Result<()> {
 
     for component in components
         .iter()
-        .filter(|c| !["forc", "fuel-core", "fuel-core-keygen"].contains(&c.name.as_str()))
+        .filter(|c| !["forc", "fuel-core"].contains(&c.name.as_str()))
     {
         let latest_actual_version = get_latest_version(&component.repository_name)?;
         let latest_indexed_version = parse_latest_indexed_version(&channel_doc, &component.name);


### PR DESCRIPTION
Check versions failed https://github.com/FuelLabs/fuelup/actions/runs/5883810160/job/15957285050 because we need rust version 1.70.0 or higher in CI. 