### PR TITLE
fix: remove incorrect incompatabile versions flagged by fuelup

### DIFF
--- a/incompatible-versions/forc-0.44.1@fuel-core-0.18.3
+++ b/incompatible-versions/forc-0.44.1@fuel-core-0.18.3
@@ -1,1 +1,0 @@
-published_by=https://github.com/FuelLabs/fuelup/actions/runs/5883810160

--- a/incompatible-versions/forc-0.44.1@fuel-core-0.19.2
+++ b/incompatible-versions/forc-0.44.1@fuel-core-0.19.2
@@ -1,1 +1,0 @@
-published_by=https://github.com/FuelLabs/fuelup/actions/runs/5883810160

--- a/incompatible-versions/forc-0.44.1@fuel-core-0.20.3
+++ b/incompatible-versions/forc-0.44.1@fuel-core-0.20.3
@@ -1,1 +1,0 @@
-published_by=https://github.com/FuelLabs/fuelup/actions/runs/5883810160

--- a/incompatible-versions/forc-0.44.1@fuel-core-0.20.4
+++ b/incompatible-versions/forc-0.44.1@fuel-core-0.20.4
@@ -1,1 +1,0 @@
-published_by=https://github.com/FuelLabs/fuelup/actions/runs/5883810160


### PR DESCRIPTION
CI failed again and we need to wait for the next check versions run. This one removes the invalid incompatible versions so that fuelup tries again.