### PR TITLE
chore: bump indexer beta-4

### DIFF
--- a/channel-fuel-beta-4-rc-2.toml
+++ b/channel-fuel-beta-4-rc-2.toml
@@ -39,23 +39,23 @@ url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-
 hash = "9ef1d8af2c5a611d33f8966881197bd4958da05e4b325eb0dc847b84ea1eac96"
 
 [pkg.forc-index]
-version = "0.19.5"
+version = "0.20.5"
 
 [pkg.forc-index.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/forc-index-0.19.5-aarch64-unknown-linux-gnu.tar.gz"
-hash = "02c8befef0164409af621d48e8ce1b928855e406ff457a18221e534eccc8bd15"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-aarch64-unknown-linux-gnu.tar.gz"
+hash = "df2dee5a806117216963654f6ca9f7784180b197126b926db73f6ea2b426710d"
 
 [pkg.forc-index.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/forc-index-0.19.5-x86_64-unknown-linux-gnu.tar.gz"
-hash = "6346ee7c51ad20559fcf865ed3a0b7b718cc10bad759f3e3f2912742f95348a1"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-x86_64-unknown-linux-gnu.tar.gz"
+hash = "5091cce9c231c4e063445470b4facd39deb66f495f3c6458550bbeb3bdb2e9a7"
 
 [pkg.forc-index.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/forc-index-0.19.5-aarch64-apple-darwin.tar.gz"
-hash = "01739059f5192c34f78907fa7d9618a16685324c4eff2c2733ec305df1d04a0c"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-aarch64-apple-darwin.tar.gz"
+hash = "52a024a8a519d75af35c36ee4641ec447f57ca50b3f8444c128707bffd6b4846"
 
 [pkg.forc-index.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/forc-index-0.19.5-x86_64-apple-darwin.tar.gz"
-hash = "502fad37d189b858068763429d8eb1068d7a26f2ee70f9ba7b778c56d59720ff"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-x86_64-apple-darwin.tar.gz"
+hash = "0323a546758202c3150643dd146099bed25c1d78c2a7c4c1ce4dac7675346cee"
 
 [pkg.forc-wallet]
 version = "0.2.5"
@@ -96,20 +96,21 @@ url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core
 hash = "cb229ffad1106d14bb07db6bf7022af265ad6c0d5f0b017ccf98cb460905fcd5"
 
 [pkg.fuel-indexer]
-version = "0.19.5"
+version = "0.20.5"
 
 [pkg.fuel-indexer.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/fuel-indexer-0.19.5-aarch64-unknown-linux-gnu.tar.gz"
-hash = "5beb76deba0284244a8fecab154d4aa774590876eeb9405748f25fd62cd6cdef"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-aarch64-unknown-linux-gnu.tar.gz"
+hash = "547409870ae5ccb5b3f7a4bccdbf4d6a30a61ccb2f11cdb95e8e83b80aa6b2bd"
 
 [pkg.fuel-indexer.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/fuel-indexer-0.19.5-x86_64-unknown-linux-gnu.tar.gz"
-hash = "488ebbbb6b0df88b664033c09d5cd57d78f199cfb619b1afb3a660aa4485b149"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-x86_64-unknown-linux-gnu.tar.gz"
+hash = "a09c5dcbe3b6bf592eb0948f41c8f81314803b99edf0c46ae45a09ccade42652"
 
 [pkg.fuel-indexer.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/fuel-indexer-0.19.5-aarch64-apple-darwin.tar.gz"
-hash = "fc27862e4d8327e1745fca6c853e19a97630c911c87ae24ce19c61c2858a08d1"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-aarch64-apple-darwin.tar.gz"
+hash = "a56702555e305cc2b6963404b861c3a561c46088882d780fd3ec94d44cb9f6ec"
 
 [pkg.fuel-indexer.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/fuel-indexer-0.19.5-x86_64-apple-darwin.tar.gz"
-hash = "3cd279dfdc79ef61b4f71cfd75fe684ef0c65f68e4db3beac3cae926324a6674"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-x86_64-apple-darwin.tar.gz"
+hash = "623c179dd31c207b41cceda95b4d4fa9656ed486ee98e151b14e5b53aabe6528"
+

--- a/channel-fuel-beta-4-rc-2.toml
+++ b/channel-fuel-beta-4-rc-2.toml
@@ -39,23 +39,23 @@ url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-
 hash = "9ef1d8af2c5a611d33f8966881197bd4958da05e4b325eb0dc847b84ea1eac96"
 
 [pkg.forc-index]
-version = "0.20.5"
+version = "0.20.8"
 
 [pkg.forc-index.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-aarch64-unknown-linux-gnu.tar.gz"
-hash = "df2dee5a806117216963654f6ca9f7784180b197126b926db73f6ea2b426710d"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-aarch64-unknown-linux-gnu.tar.gz"
+hash = "94af6577baca4d708d92987d6cf66e5fdd4a0d85d87a841338b66bfcd885e3ba"
 
 [pkg.forc-index.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-x86_64-unknown-linux-gnu.tar.gz"
-hash = "5091cce9c231c4e063445470b4facd39deb66f495f3c6458550bbeb3bdb2e9a7"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-x86_64-unknown-linux-gnu.tar.gz"
+hash = "84f80ae44f8147077423d5f8bd65fc53c329600fec8ba78c66766bbf034624e4"
 
 [pkg.forc-index.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-aarch64-apple-darwin.tar.gz"
-hash = "52a024a8a519d75af35c36ee4641ec447f57ca50b3f8444c128707bffd6b4846"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-aarch64-apple-darwin.tar.gz"
+hash = "55044f8852c96a6b327be0be95c1546adc66262e8092fe945e7dc818c13a0633"
 
 [pkg.forc-index.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-x86_64-apple-darwin.tar.gz"
-hash = "0323a546758202c3150643dd146099bed25c1d78c2a7c4c1ce4dac7675346cee"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-x86_64-apple-darwin.tar.gz"
+hash = "dc1276fde5fd8f652a94122d1b658cdbeb921725eb9308588d98e021e5b3801f"
 
 [pkg.forc-wallet]
 version = "0.2.5"
@@ -96,21 +96,20 @@ url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core
 hash = "cb229ffad1106d14bb07db6bf7022af265ad6c0d5f0b017ccf98cb460905fcd5"
 
 [pkg.fuel-indexer]
-version = "0.20.5"
+version = "0.20.8"
 
 [pkg.fuel-indexer.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-aarch64-unknown-linux-gnu.tar.gz"
-hash = "547409870ae5ccb5b3f7a4bccdbf4d6a30a61ccb2f11cdb95e8e83b80aa6b2bd"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-aarch64-unknown-linux-gnu.tar.gz"
+hash = "58da5b79b581dc9ea1566768a6a5ec8f30f82a955a631d733ea54edfb321ef8b"
 
 [pkg.fuel-indexer.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-x86_64-unknown-linux-gnu.tar.gz"
-hash = "a09c5dcbe3b6bf592eb0948f41c8f81314803b99edf0c46ae45a09ccade42652"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-x86_64-unknown-linux-gnu.tar.gz"
+hash = "a0e44c9b78eedae00d46def0e1cad5b92f627482480ce932ede2e671592f7eeb"
 
 [pkg.fuel-indexer.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-aarch64-apple-darwin.tar.gz"
-hash = "a56702555e305cc2b6963404b861c3a561c46088882d780fd3ec94d44cb9f6ec"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-aarch64-apple-darwin.tar.gz"
+hash = "475171a8e239cf7cec6c28b2288ab442c99607406717d38cde9cf5291bf88111"
 
 [pkg.fuel-indexer.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-x86_64-apple-darwin.tar.gz"
-hash = "623c179dd31c207b41cceda95b4d4fa9656ed486ee98e151b14e5b53aabe6528"
-
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-x86_64-apple-darwin.tar.gz"
+hash = "7ec1e80c810a8dc5e1a7541d67967c3bc7bbaca28f8e5f500e884e43c8fec0b0"

--- a/channel-fuel-beta-4-rc-2.toml
+++ b/channel-fuel-beta-4-rc-2.toml
@@ -39,23 +39,23 @@ url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-
 hash = "9ef1d8af2c5a611d33f8966881197bd4958da05e4b325eb0dc847b84ea1eac96"
 
 [pkg.forc-index]
-version = "0.20.8"
+version = "0.19.5"
 
 [pkg.forc-index.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-aarch64-unknown-linux-gnu.tar.gz"
-hash = "94af6577baca4d708d92987d6cf66e5fdd4a0d85d87a841338b66bfcd885e3ba"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/forc-index-0.19.5-aarch64-unknown-linux-gnu.tar.gz"
+hash = "02c8befef0164409af621d48e8ce1b928855e406ff457a18221e534eccc8bd15"
 
 [pkg.forc-index.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-x86_64-unknown-linux-gnu.tar.gz"
-hash = "84f80ae44f8147077423d5f8bd65fc53c329600fec8ba78c66766bbf034624e4"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/forc-index-0.19.5-x86_64-unknown-linux-gnu.tar.gz"
+hash = "6346ee7c51ad20559fcf865ed3a0b7b718cc10bad759f3e3f2912742f95348a1"
 
 [pkg.forc-index.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-aarch64-apple-darwin.tar.gz"
-hash = "55044f8852c96a6b327be0be95c1546adc66262e8092fe945e7dc818c13a0633"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/forc-index-0.19.5-aarch64-apple-darwin.tar.gz"
+hash = "01739059f5192c34f78907fa7d9618a16685324c4eff2c2733ec305df1d04a0c"
 
 [pkg.forc-index.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-x86_64-apple-darwin.tar.gz"
-hash = "dc1276fde5fd8f652a94122d1b658cdbeb921725eb9308588d98e021e5b3801f"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/forc-index-0.19.5-x86_64-apple-darwin.tar.gz"
+hash = "502fad37d189b858068763429d8eb1068d7a26f2ee70f9ba7b778c56d59720ff"
 
 [pkg.forc-wallet]
 version = "0.2.5"
@@ -96,20 +96,20 @@ url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core
 hash = "cb229ffad1106d14bb07db6bf7022af265ad6c0d5f0b017ccf98cb460905fcd5"
 
 [pkg.fuel-indexer]
-version = "0.20.8"
+version = "0.19.5"
 
 [pkg.fuel-indexer.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-aarch64-unknown-linux-gnu.tar.gz"
-hash = "58da5b79b581dc9ea1566768a6a5ec8f30f82a955a631d733ea54edfb321ef8b"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/fuel-indexer-0.19.5-aarch64-unknown-linux-gnu.tar.gz"
+hash = "5beb76deba0284244a8fecab154d4aa774590876eeb9405748f25fd62cd6cdef"
 
 [pkg.fuel-indexer.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-x86_64-unknown-linux-gnu.tar.gz"
-hash = "a0e44c9b78eedae00d46def0e1cad5b92f627482480ce932ede2e671592f7eeb"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/fuel-indexer-0.19.5-x86_64-unknown-linux-gnu.tar.gz"
+hash = "488ebbbb6b0df88b664033c09d5cd57d78f199cfb619b1afb3a660aa4485b149"
 
 [pkg.fuel-indexer.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-aarch64-apple-darwin.tar.gz"
-hash = "475171a8e239cf7cec6c28b2288ab442c99607406717d38cde9cf5291bf88111"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/fuel-indexer-0.19.5-aarch64-apple-darwin.tar.gz"
+hash = "fc27862e4d8327e1745fca6c853e19a97630c911c87ae24ce19c61c2858a08d1"
 
 [pkg.fuel-indexer.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-x86_64-apple-darwin.tar.gz"
-hash = "7ec1e80c810a8dc5e1a7541d67967c3bc7bbaca28f8e5f500e884e43c8fec0b0"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.19.5/fuel-indexer-0.19.5-x86_64-apple-darwin.tar.gz"
+hash = "3cd279dfdc79ef61b4f71cfd75fe684ef0c65f68e4db3beac3cae926324a6674"

--- a/channel-fuel-beta-4-rc.toml
+++ b/channel-fuel-beta-4-rc.toml
@@ -39,23 +39,23 @@ url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-
 hash = "9ef1d8af2c5a611d33f8966881197bd4958da05e4b325eb0dc847b84ea1eac96"
 
 [pkg.forc-index]
-version = "0.17.3"
+version = "0.20.5"
 
 [pkg.forc-index.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-aarch64-unknown-linux-gnu.tar.gz"
-hash = "e2afb58ba7618b98fd750918f5fc9645b4c78f5558ea9c992768f53fce367e84"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-aarch64-unknown-linux-gnu.tar.gz"
+hash = "df2dee5a806117216963654f6ca9f7784180b197126b926db73f6ea2b426710d"
 
 [pkg.forc-index.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-x86_64-unknown-linux-gnu.tar.gz"
-hash = "09d63a4830152aba2745a56813979b9374cd405a0d2270a39dfda71102209025"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-x86_64-unknown-linux-gnu.tar.gz"
+hash = "5091cce9c231c4e063445470b4facd39deb66f495f3c6458550bbeb3bdb2e9a7"
 
 [pkg.forc-index.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-aarch64-apple-darwin.tar.gz"
-hash = "353d0c2e59dcc54a00e16f809a0391af081226d820bd7fcc6516346d49465a03"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-aarch64-apple-darwin.tar.gz"
+hash = "52a024a8a519d75af35c36ee4641ec447f57ca50b3f8444c128707bffd6b4846"
 
 [pkg.forc-index.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-x86_64-apple-darwin.tar.gz"
-hash = "99735d2b0f255320435aa1663253916ae18d43da38c6c083b2c2bd7f9129c26a"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-x86_64-apple-darwin.tar.gz"
+hash = "0323a546758202c3150643dd146099bed25c1d78c2a7c4c1ce4dac7675346cee"
 
 [pkg.forc-wallet]
 version = "0.2.3"
@@ -96,20 +96,21 @@ url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.18.2/fuel-core
 hash = "f8b3223233518671b494e071788c696a4814216f172a0d4c57bbf9fff05ff73a"
 
 [pkg.fuel-indexer]
-version = "0.17.3"
+version = "0.20.5"
 
 [pkg.fuel-indexer.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-aarch64-unknown-linux-gnu.tar.gz"
-hash = "de559d9f254d92858643fd2d04efe825a1481adc4a5eabb59ff1100d6d060fa4"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-aarch64-unknown-linux-gnu.tar.gz"
+hash = "547409870ae5ccb5b3f7a4bccdbf4d6a30a61ccb2f11cdb95e8e83b80aa6b2bd"
 
 [pkg.fuel-indexer.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-x86_64-unknown-linux-gnu.tar.gz"
-hash = "9d4ce324bd69737dfd29a6b356035d15d3d70c94469bd5205c71a990a6c39d59"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-x86_64-unknown-linux-gnu.tar.gz"
+hash = "a09c5dcbe3b6bf592eb0948f41c8f81314803b99edf0c46ae45a09ccade42652"
 
 [pkg.fuel-indexer.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-aarch64-apple-darwin.tar.gz"
-hash = "7ee477dffb7ebe418fa87383899ab972755d2b9ca16407f235a0e78c2bb5951d"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-aarch64-apple-darwin.tar.gz"
+hash = "a56702555e305cc2b6963404b861c3a561c46088882d780fd3ec94d44cb9f6ec"
 
 [pkg.fuel-indexer.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-x86_64-apple-darwin.tar.gz"
-hash = "d5f106728d939a1b8462c92eccca01b733f64d2f92cba23dee0fe80ea95375be"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-x86_64-apple-darwin.tar.gz"
+hash = "623c179dd31c207b41cceda95b4d4fa9656ed486ee98e151b14e5b53aabe6528"
+

--- a/channel-fuel-beta-4-rc.toml
+++ b/channel-fuel-beta-4-rc.toml
@@ -39,23 +39,23 @@ url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-
 hash = "9ef1d8af2c5a611d33f8966881197bd4958da05e4b325eb0dc847b84ea1eac96"
 
 [pkg.forc-index]
-version = "0.20.5"
+version = "0.17.3"
 
 [pkg.forc-index.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-aarch64-unknown-linux-gnu.tar.gz"
-hash = "df2dee5a806117216963654f6ca9f7784180b197126b926db73f6ea2b426710d"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-aarch64-unknown-linux-gnu.tar.gz"
+hash = "e2afb58ba7618b98fd750918f5fc9645b4c78f5558ea9c992768f53fce367e84"
 
 [pkg.forc-index.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-x86_64-unknown-linux-gnu.tar.gz"
-hash = "5091cce9c231c4e063445470b4facd39deb66f495f3c6458550bbeb3bdb2e9a7"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-x86_64-unknown-linux-gnu.tar.gz"
+hash = "09d63a4830152aba2745a56813979b9374cd405a0d2270a39dfda71102209025"
 
 [pkg.forc-index.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-aarch64-apple-darwin.tar.gz"
-hash = "52a024a8a519d75af35c36ee4641ec447f57ca50b3f8444c128707bffd6b4846"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-aarch64-apple-darwin.tar.gz"
+hash = "353d0c2e59dcc54a00e16f809a0391af081226d820bd7fcc6516346d49465a03"
 
 [pkg.forc-index.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/forc-index-0.20.5-x86_64-apple-darwin.tar.gz"
-hash = "0323a546758202c3150643dd146099bed25c1d78c2a7c4c1ce4dac7675346cee"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-x86_64-apple-darwin.tar.gz"
+hash = "99735d2b0f255320435aa1663253916ae18d43da38c6c083b2c2bd7f9129c26a"
 
 [pkg.forc-wallet]
 version = "0.2.3"
@@ -96,21 +96,20 @@ url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.18.2/fuel-core
 hash = "f8b3223233518671b494e071788c696a4814216f172a0d4c57bbf9fff05ff73a"
 
 [pkg.fuel-indexer]
-version = "0.20.5"
+version = "0.17.3"
 
 [pkg.fuel-indexer.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-aarch64-unknown-linux-gnu.tar.gz"
-hash = "547409870ae5ccb5b3f7a4bccdbf4d6a30a61ccb2f11cdb95e8e83b80aa6b2bd"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-aarch64-unknown-linux-gnu.tar.gz"
+hash = "de559d9f254d92858643fd2d04efe825a1481adc4a5eabb59ff1100d6d060fa4"
 
 [pkg.fuel-indexer.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-x86_64-unknown-linux-gnu.tar.gz"
-hash = "a09c5dcbe3b6bf592eb0948f41c8f81314803b99edf0c46ae45a09ccade42652"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-x86_64-unknown-linux-gnu.tar.gz"
+hash = "9d4ce324bd69737dfd29a6b356035d15d3d70c94469bd5205c71a990a6c39d59"
 
 [pkg.fuel-indexer.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-aarch64-apple-darwin.tar.gz"
-hash = "a56702555e305cc2b6963404b861c3a561c46088882d780fd3ec94d44cb9f6ec"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-aarch64-apple-darwin.tar.gz"
+hash = "7ee477dffb7ebe418fa87383899ab972755d2b9ca16407f235a0e78c2bb5951d"
 
 [pkg.fuel-indexer.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.5/fuel-indexer-0.20.5-x86_64-apple-darwin.tar.gz"
-hash = "623c179dd31c207b41cceda95b4d4fa9656ed486ee98e151b14e5b53aabe6528"
-
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-x86_64-apple-darwin.tar.gz"
+hash = "d5f106728d939a1b8462c92eccca01b733f64d2f92cba23dee0fe80ea95375be"

--- a/channel-fuel-beta-4-rc.toml
+++ b/channel-fuel-beta-4-rc.toml
@@ -39,23 +39,23 @@ url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-
 hash = "9ef1d8af2c5a611d33f8966881197bd4958da05e4b325eb0dc847b84ea1eac96"
 
 [pkg.forc-index]
-version = "0.17.3"
+version = "0.20.8"
 
 [pkg.forc-index.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-aarch64-unknown-linux-gnu.tar.gz"
-hash = "e2afb58ba7618b98fd750918f5fc9645b4c78f5558ea9c992768f53fce367e84"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-aarch64-unknown-linux-gnu.tar.gz"
+hash = "94af6577baca4d708d92987d6cf66e5fdd4a0d85d87a841338b66bfcd885e3ba"
 
 [pkg.forc-index.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-x86_64-unknown-linux-gnu.tar.gz"
-hash = "09d63a4830152aba2745a56813979b9374cd405a0d2270a39dfda71102209025"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-x86_64-unknown-linux-gnu.tar.gz"
+hash = "84f80ae44f8147077423d5f8bd65fc53c329600fec8ba78c66766bbf034624e4"
 
 [pkg.forc-index.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-aarch64-apple-darwin.tar.gz"
-hash = "353d0c2e59dcc54a00e16f809a0391af081226d820bd7fcc6516346d49465a03"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-aarch64-apple-darwin.tar.gz"
+hash = "55044f8852c96a6b327be0be95c1546adc66262e8092fe945e7dc818c13a0633"
 
 [pkg.forc-index.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/forc-index-0.17.3-x86_64-apple-darwin.tar.gz"
-hash = "99735d2b0f255320435aa1663253916ae18d43da38c6c083b2c2bd7f9129c26a"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/forc-index-0.20.8-x86_64-apple-darwin.tar.gz"
+hash = "dc1276fde5fd8f652a94122d1b658cdbeb921725eb9308588d98e021e5b3801f"
 
 [pkg.forc-wallet]
 version = "0.2.3"
@@ -96,20 +96,20 @@ url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.18.2/fuel-core
 hash = "f8b3223233518671b494e071788c696a4814216f172a0d4c57bbf9fff05ff73a"
 
 [pkg.fuel-indexer]
-version = "0.17.3"
+version = "0.20.8"
 
 [pkg.fuel-indexer.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-aarch64-unknown-linux-gnu.tar.gz"
-hash = "de559d9f254d92858643fd2d04efe825a1481adc4a5eabb59ff1100d6d060fa4"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-aarch64-unknown-linux-gnu.tar.gz"
+hash = "58da5b79b581dc9ea1566768a6a5ec8f30f82a955a631d733ea54edfb321ef8b"
 
 [pkg.fuel-indexer.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-x86_64-unknown-linux-gnu.tar.gz"
-hash = "9d4ce324bd69737dfd29a6b356035d15d3d70c94469bd5205c71a990a6c39d59"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-x86_64-unknown-linux-gnu.tar.gz"
+hash = "a0e44c9b78eedae00d46def0e1cad5b92f627482480ce932ede2e671592f7eeb"
 
 [pkg.fuel-indexer.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-aarch64-apple-darwin.tar.gz"
-hash = "7ee477dffb7ebe418fa87383899ab972755d2b9ca16407f235a0e78c2bb5951d"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-aarch64-apple-darwin.tar.gz"
+hash = "475171a8e239cf7cec6c28b2288ab442c99607406717d38cde9cf5291bf88111"
 
 [pkg.fuel-indexer.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.17.3/fuel-indexer-0.17.3-x86_64-apple-darwin.tar.gz"
-hash = "d5f106728d939a1b8462c92eccca01b733f64d2f92cba23dee0fe80ea95375be"
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.8/fuel-indexer-0.20.8-x86_64-apple-darwin.tar.gz"
+hash = "7ec1e80c810a8dc5e1a7541d67967c3bc7bbaca28f8e5f500e884e43c8fec0b0"


### PR DESCRIPTION
### Description

- PR simply bumps the indexer versions for the beta-4 toolchain