### PR TITLE
fix: manually add missing forc-wallet entries

### DIFF
--- a/channel-fuel-latest.toml
+++ b/channel-fuel-latest.toml
@@ -1,4 +1,4 @@
-date = "2023-08-28"
+date = "2023-07-18"
 
 [pkg.forc]
 version = "0.44.1"
@@ -59,6 +59,22 @@ hash = "0323a546758202c3150643dd146099bed25c1d78c2a7c4c1ce4dac7675346cee"
 
 [pkg.forc-wallet]
 version = "0.3.0"
+
+[pkg.forc-wallet.target.aarch64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.3.0/forc-wallet-0.3.0-aarch64-unknown-linux-gnu.tar.gz"
+hash = "c6a0e5a8cc05748588278246ae9397c458ab25ce5575a7a04f8815f9c955851c"
+
+[pkg.forc-wallet.target.x86_64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.3.0/forc-wallet-0.3.0-x86_64-unknown-linux-gnu.tar.gz"
+hash = "5d733960fc022a25044bf67bf865eedb2d43ea3f859cd91e37ed7f603209c32c"
+
+[pkg.forc-wallet.target.aarch64-apple-darwin]
+url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.3.0/forc-wallet-0.3.0-aarch64-apple-darwin.tar.gz"
+hash = "f3dd5f2706b6c4b0f3eef44247deab9418eb9d856f613451bd615e7dd03fe51f"
+
+[pkg.forc-wallet.target.x86_64-apple-darwin]
+url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.3.0/forc-wallet-0.3.0-x86_64-apple-darwin.tar.gz"
+hash = "0c6b28a593dc3607055a5a8f51f1aacf1362243469abc6a43b681b8020fe67fe"
 
 [pkg.fuel-core]
 version = "0.20.4"


### PR DESCRIPTION
Due to a release error in forc-wallet's CI we had a faulty release which broke the latest channel. This fixes it by adding the new release manually to unblock the CI again