### PR TITLE
release: add beta-4 toolchain manifest

### DIFF
--- a/channel-fuel-beta-4.toml
+++ b/channel-fuel-beta-4.toml
@@ -1,0 +1,134 @@
+date = "2023-09-01"
+
+[pkg.forc]
+version = "0.45.0"
+
+[pkg.forc.target.linux_amd64]
+url = "https://github.com/FuelLabs/sway/releases/download/v0.45.0/forc-binaries-linux_amd64.tar.gz"
+hash = "433a2f90f8f816a2f93eae1bd94f429601d0965792cd3134f70cff297c26a261"
+
+[pkg.forc.target.linux_arm64]
+url = "https://github.com/FuelLabs/sway/releases/download/v0.45.0/forc-binaries-linux_arm64.tar.gz"
+hash = "a2f5821bac16fc62114e0c2dab4012ec4d5a28bd4f7f83ddc4441cf7c673b2ce"
+
+[pkg.forc.target.darwin_amd64]
+url = "https://github.com/FuelLabs/sway/releases/download/v0.45.0/forc-binaries-darwin_amd64.tar.gz"
+hash = "64a7e84371d1e524ace43f5cfa6384ad14203df7330341b69f84c726f97e88df"
+
+[pkg.forc.target.darwin_arm64]
+url = "https://github.com/FuelLabs/sway/releases/download/v0.45.0/forc-binaries-darwin_arm64.tar.gz"
+hash = "b7ab72e0dc65146dfe54c438eefa74ee3e604c295ff64060340be8ecbbc219a3"
+
+[pkg.forc-explore]
+version = "0.28.1"
+
+[pkg.forc-explore.target.aarch64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-explore-0.28.1-aarch64-unknown-linux-gnu.tar.gz"
+hash = "8f7ade34ff611eb8ffaea2ec0bd33f5bbf6de6b05aad2bcd39a3a62309ef3a41"
+
+[pkg.forc-explore.target.x86_64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-explore-0.28.1-x86_64-unknown-linux-gnu.tar.gz"
+hash = "b0bfe8ddb4b0a962bc2ce956385392c7dae3f19f3ca97a90aba88f8d5b5f183c"
+
+[pkg.forc-explore.target.aarch64-apple-darwin]
+url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-explore-0.28.1-aarch64-apple-darwin.tar.gz"
+hash = "4c437e84b4f95e55c97d32595a4d529b3dcb78ebec06f07babccde74e1827566"
+
+[pkg.forc-explore.target.x86_64-apple-darwin]
+url = "https://github.com/FuelLabs/forc-explorer/releases/download/v0.28.1/forc-explore-0.28.1-x86_64-apple-darwin.tar.gz"
+hash = "9ef1d8af2c5a611d33f8966881197bd4958da05e4b325eb0dc847b84ea1eac96"
+
+[pkg.forc-index]
+version = "0.20.7"
+
+[pkg.forc-index.target.aarch64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.7/forc-index-0.20.7-aarch64-unknown-linux-gnu.tar.gz"
+hash = "4a67080fa0f695d25d7e47a2808e0482558943b9dd2914e683a0e3d60f8119b7"
+
+[pkg.forc-index.target.x86_64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.7/forc-index-0.20.7-x86_64-unknown-linux-gnu.tar.gz"
+hash = "52efe1561ee9c6a234c5e18cc57d64a544331893da2d28f2330f32cdb51b92ab"
+
+[pkg.forc-index.target.aarch64-apple-darwin]
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.7/forc-index-0.20.7-aarch64-apple-darwin.tar.gz"
+hash = "0448c2360748fc5067b30d2fce290123bdbb8452b19815d3f42991feac0dbc54"
+
+[pkg.forc-index.target.x86_64-apple-darwin]
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.7/forc-index-0.20.7-x86_64-apple-darwin.tar.gz"
+hash = "79305281015f92c245f01d721a5d901f7d3f567747eacccfb82486cb74bcb146"
+
+[pkg.forc-wallet]
+version = "0.3.0"
+
+[pkg.forc-wallet.target.aarch64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.3.0/forc-wallet-0.3.0-aarch64-unknown-linux-gnu.tar.gz"
+hash = "c6a0e5a8cc05748588278246ae9397c458ab25ce5575a7a04f8815f9c955851c"
+
+[pkg.forc-wallet.target.x86_64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.3.0/forc-wallet-0.3.0-x86_64-unknown-linux-gnu.tar.gz"
+hash = "5d733960fc022a25044bf67bf865eedb2d43ea3f859cd91e37ed7f603209c32c"
+
+[pkg.forc-wallet.target.aarch64-apple-darwin]
+url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.3.0/forc-wallet-0.3.0-aarch64-apple-darwin.tar.gz"
+hash = "f3dd5f2706b6c4b0f3eef44247deab9418eb9d856f613451bd615e7dd03fe51f"
+
+[pkg.forc-wallet.target.x86_64-apple-darwin]
+url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.3.0/forc-wallet-0.3.0-x86_64-apple-darwin.tar.gz"
+hash = "0c6b28a593dc3607055a5a8f51f1aacf1362243469abc6a43b681b8020fe67fe"
+
+[pkg.fuel-core]
+version = "0.20.4"
+
+[pkg.fuel-core.target.aarch64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core-0.20.4-aarch64-unknown-linux-gnu.tar.gz"
+hash = "4900ab8bc5e7111d2ad2993e90559ceaa74c67b7d0b5bde9187a73da3d0eb4ee"
+
+[pkg.fuel-core.target.x86_64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core-0.20.4-x86_64-unknown-linux-gnu.tar.gz"
+hash = "7f94f9cef46b8d2f7a5584b847d521977d1067c27b3df7d03e65c156956936b8"
+
+[pkg.fuel-core.target.aarch64-apple-darwin]
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core-0.20.4-aarch64-apple-darwin.tar.gz"
+hash = "32c347d6f0685b0f16d7fef00fc2b32c078a3f9f2b9c1a581b83b60e0acd025f"
+
+[pkg.fuel-core.target.x86_64-apple-darwin]
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core-0.20.4-x86_64-apple-darwin.tar.gz"
+hash = "cb229ffad1106d14bb07db6bf7022af265ad6c0d5f0b017ccf98cb460905fcd5"
+
+[pkg.fuel-core-keygen]
+version = "0.20.4"
+
+[pkg.fuel-core-keygen.target.aarch64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core-0.20.4-aarch64-unknown-linux-gnu.tar.gz"
+hash = "4900ab8bc5e7111d2ad2993e90559ceaa74c67b7d0b5bde9187a73da3d0eb4ee"
+
+[pkg.fuel-core-keygen.target.x86_64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core-0.20.4-x86_64-unknown-linux-gnu.tar.gz"
+hash = "7f94f9cef46b8d2f7a5584b847d521977d1067c27b3df7d03e65c156956936b8"
+
+[pkg.fuel-core-keygen.target.aarch64-apple-darwin]
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core-0.20.4-aarch64-apple-darwin.tar.gz"
+hash = "32c347d6f0685b0f16d7fef00fc2b32c078a3f9f2b9c1a581b83b60e0acd025f"
+
+[pkg.fuel-core-keygen.target.x86_64-apple-darwin]
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.20.4/fuel-core-0.20.4-x86_64-apple-darwin.tar.gz"
+hash = "cb229ffad1106d14bb07db6bf7022af265ad6c0d5f0b017ccf98cb460905fcd5"
+
+[pkg.fuel-indexer]
+version = "0.20.7"
+
+[pkg.fuel-indexer.target.aarch64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.7/fuel-indexer-0.20.7-aarch64-unknown-linux-gnu.tar.gz"
+hash = "f0633c021c936c5218cee3218485e5fb4d72f131997f5ae94af4d7bf2b570861"
+
+[pkg.fuel-indexer.target.x86_64-unknown-linux-gnu]
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.7/fuel-indexer-0.20.7-x86_64-unknown-linux-gnu.tar.gz"
+hash = "7a3bbfeccab30b3acbe1327424905b231e9f8d0ca31c9eb8e908d6cfe0a86e37"
+
+[pkg.fuel-indexer.target.aarch64-apple-darwin]
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.7/fuel-indexer-0.20.7-aarch64-apple-darwin.tar.gz"
+hash = "56ce62025d4b87f874b3f07141d4ab5baaf89e76f4229e9c64f370f15daf92ae"
+
+[pkg.fuel-indexer.target.x86_64-apple-darwin]
+url = "https://github.com/FuelLabs/fuel-indexer/releases/download/v0.20.7/fuel-indexer-0.20.7-x86_64-apple-darwin.tar.gz"
+hash = "63038c75dca5749c3f939f0625f9973f8cd1745bacf87869138a775cdfc7c02c"


### PR DESCRIPTION
Adds beta-4 channel with following versions:

1. forc v0.45.0
2. fuel-core-* v0.20.4
3. indexder binaries v0.20.7
4. forc-explore 0.28.1
5. forc-wallet v0.3.0