### PR TITLE
chore: bump to v0.19.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "anyhow",
  "clap 4.2.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.19.4"
+version = "0.19.5"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Waiting for:

1. https://github.com/FuelLabs/fuelup/pull/480