### PR TITLE
ci: use bigger image to run check-versions ci workflow

### DIFF
--- a/.github/workflows/index-versions.yml
+++ b/.github/workflows/index-versions.yml
@@ -14,7 +14,7 @@ jobs:
   # test-toolchain-compatibility job to run integration tests.
   compare-versions:
     name: Check versions
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204 
     outputs:
       should-run: ${{ steps.set-version-matrix.outputs.should-run }}
       version-matrix: ${{ steps.set-version-matrix.outputs.version-matrix }}
@@ -99,7 +99,7 @@ jobs:
   check-other-components-latest:
     name: Check other components for their latest versions
     needs: compare-versions
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204 
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Our CI runs are failing, possible due to lack of memory/storage on ci runner. 

This fix is also applied to sway repo ci: https://github.com/FuelLabs/sway/commit/e75f14b03636bc96751a6760304a1a6d3eb5937d