### PR TITLE
Use larger image in test-toolchain-compatibility.yml

### DIFF
--- a/.github/workflows/index-versions.yml
+++ b/.github/workflows/index-versions.yml
@@ -1,9 +1,10 @@
 name: Check Versions
 
 on:
+  workflow_dispatch:
   schedule:
-    # Run at minute 0 every hour
-    - cron: '0 * * * *'
+    # Run at minute 0 every 6 hours
+    - cron: '0 */6 * * *'
 env:
   LATEST_CHANNEL_DIR: ./channel-fuel-latest.toml.d/
 

--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   test-toolchain-compatibility:
     name: Test forc-${{ matrix.job.forc-version }} against fuel-core-${{ matrix.job.fuel-core-version }}
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     # Init parallelized jobs running tests for toolchain version sets in a matrix.
     # `fail-fast` is set to false so that we run the tests to completion even if a single version set fails.
     # We use the fromJSON expression to have an easier time setting up a matrix with dynamic inputs.


### PR DESCRIPTION
This is the reusable workflow where the tests are actually run. I think that's why https://github.com/FuelLabs/fuelup/pull/488 didn't work.

Also adds a manual trigger for this job, and changes the cron to run every 6 hours.