### PR TITLE
Use buildjet cache for faster runs

### DIFF
--- a/.github/workflows/test-toolchain-compatibility.yml
+++ b/.github/workflows/test-toolchain-compatibility.yml
@@ -49,7 +49,15 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       
-      - uses: Swatinem/rust-cache@v2
+      - uses: buildjet/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Forc
         run: cd sway && cargo install --locked --debug --path ./forc


### PR DESCRIPTION
Apparently using github's cache with a buildjet image actually makes runs slower over time. This uses the [buildjet cache](https://buildjet.com/for-github-actions/docs/guides/migrating-to-buildjet-cache#rust) instead.