### PR TITLE
feat: make the latest channel point to beta-4

### DIFF
--- a/docs/src/concepts/channels.md
+++ b/docs/src/concepts/channels.md
@@ -55,7 +55,7 @@ The `latest` channel is pointing to our latest beta network. This toolchain shou
 
 > **Note**
 >
-> The `latest` channel used to point latest compatible versions of `forc` and `fuel-core`, after version v0.20.0 latest is changed to point latest network. This is a breaking change and should be taken into account for existing workflows.
+> The `latest` channel used to point latest compatible versions of `forc` and `fuel-core`, after version v0.20.0 latest is changed to point to the latest network. This is a breaking change and should be taken into account for existing workflows.
 
 ## Developer Guide
 

--- a/docs/src/concepts/channels.md
+++ b/docs/src/concepts/channels.md
@@ -98,4 +98,3 @@ You may also use [nektos/act](https://github.com/nektos/act) to run the workflow
 [beta-4-rc]: #the-beta-4-rc-channel
 [beta-4-rc2]: #the-beta-4-rc2-channel
 [beta-4]: #the-beta-4-channel
-[gh-pages]: https://github.com/FuelLabs/fuelup/tree/gh-pages

--- a/docs/src/concepts/channels.md
+++ b/docs/src/concepts/channels.md
@@ -6,9 +6,9 @@
 
 | Channel       | Source          | Integration Tested   | Update Frequency         | Available |
 | ------------- | --------------- | -------------------- | ------------------------ | --------- |
-| **[latest]**  | published bins  | ✔️                    | checked every 30 minutes  | ✔️         |
-| **[nightly]** | `master` branch | ➖                   | nightly (1:00 AM UTC)     | ✔️         |
-| **[beta-3]**  | published bins  | ➖                   | only when necessary       | ✔️         |
+| **[latest]**  | published bins  | ✔️                    | only when necessary      | ✔️         |
+| **[nightly]** | `master` branch | ➖                   | nightly (1:00 AM UTC)    | ✔️         |
+| **[beta-3]**  | published bins  | ➖                   | only when necessary      | ✔️         |
 | **[beta-4-rc]**  | published bins  | ➖                   | only when necessary       | ✔️         |
 | **[beta-4-rc2]**  | published bins  | ➖                   | only when necessary       | ✔️         |
 | **[beta-4]**  | published bins  | ➖                   | only when necessary       | ✔️         |
@@ -50,17 +50,12 @@ Keep in mind that compatibility between `forc` and `fuel-core` is not guaranteed
 
 <!-- This section should give an overview of the latest channel -->
 <!-- latest:example:start -->
-The `latest` channel is updated by a scheduled GitHub workflow that **runs every 30 minutes** and checks for new, compatible releases of `forc` and `fuel-core`.
-
-The `latest` channel is `fuelup`'s default channel. It provides access to the latest compatible, published releases of `forc` and `fuel-core`.
+The `latest` channel is pointing to our latest beta network. This toolchain should be used to interact with and build on the latest testnet. This is also the default channel for `fuelup`.
 <!-- latest:example:end -->
 
-When installing the `latest` channel, fuelup will refer to the `channel-fuel-latest.toml` file published within the fuelup repository in the [gh-pages] branch to determine the set of `forc` and `fuel-core` versions to retrieve. The versions in this file are updated by a scheduled GitHub workflow that runs once every 30 minutes and performs the following steps:
-
-1. Checks for newly published versions of forc and fuel-core.
-2. Tests compatibility of new versions against a set of integration tests.
-3. Selects the latest set of versions that successfully pass the tests.
-4. Publishes the selected versions to the channel-fuel-latest.toml manifest.
+> **Note**
+>
+> The `latest` channel used to point latest compatible versions of `forc` and `fuel-core`, after version v0.20.0 latest is changed to point latest network. This is a breaking change and should be taken into account for existing workflows.
 
 ## Developer Guide
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,7 +5,7 @@ pub const FUEL_TOOLCHAIN_TOML_FILE: &str = "fuel-toolchain.toml";
 pub const FUELS_VERSION_FILE: &str = "fuels_version";
 
 pub const CHANNEL_LATEST_URL: &str =
-    "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-latest.toml";
+    "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-4.toml";
 pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-beta-4.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
 pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,7 +6,7 @@ pub const FUELS_VERSION_FILE: &str = "fuels_version";
 
 pub const CHANNEL_LATEST_URL: &str =
     "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-latest.toml";
-pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-latest.toml";
+pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-beta-4.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
 pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
 pub const CHANNEL_BETA_2_FILE_NAME: &str = "channel-fuel-beta-2.toml";


### PR DESCRIPTION
Changes latest channel to point beta-4 which is the latest network. We can later on create a new channel with a different name (maybe `latest-local`?) to offer current latest channel. One other alternative is to keep publishing latest as it is but default to beta-4. I can change the PR to that approach as well according to comments.