### PR TITLE
chore: apply `clippy` lints for rust v1.73.0

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -127,7 +127,8 @@ impl Components {
                     .get(c)
                     .expect("Failed to parse components.toml")
             })
-            .filter_map(|c| c.is_plugin.is_none().then(|| c.clone()))
+            .filter(|&c| c.is_plugin.is_none())
+            .cloned()
             .collect();
 
         main_components.sort_by_key(|c| c.name.clone());

--- a/src/ops/fuelup_component/list.rs
+++ b/src/ops/fuelup_component/list.rs
@@ -24,13 +24,16 @@ fn format_installable_component_info(name: &str, latest_version: &str) -> String
 }
 
 fn format_forc_default_plugins(plugin_executables: Vec<String>) -> String {
+    use std::fmt::Write;
     format!(
         "    - {}\n",
         plugin_executables
             .iter()
             .filter(|c| *c != component::FORC)
-            .map(|s| format!("{s} "))
-            .collect::<String>(),
+            .fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{b}");
+                output
+            })
     )
 }
 


### PR DESCRIPTION
Applies various clippy lints to unblock CI after rust version 1.73 release.