### PR TITLE
chore: remove beta-4-rc* channels

### DIFF
--- a/docs/src/concepts/channels.md
+++ b/docs/src/concepts/channels.md
@@ -9,22 +9,12 @@
 | **[latest]**  | published bins  | ✔️                    | only when necessary      | ✔️         |
 | **[nightly]** | `master` branch | ➖                   | nightly (1:00 AM UTC)    | ✔️         |
 | **[beta-3]**  | published bins  | ➖                   | only when necessary      | ✔️         |
-| **[beta-4-rc]**  | published bins  | ➖                   | only when necessary       | ✔️         |
-| **[beta-4-rc2]**  | published bins  | ➖                   | only when necessary       | ✔️         |
 | **[beta-4]**  | published bins  | ➖                   | only when necessary       | ✔️         |
 <!-- channels:example:end -->
 
 ## The `beta-3` channel
 
 The `beta-3` channel is a published TOML file describing the toolchain that is compatible with our [beta-3 testnet](https://fuel-labs.ghost.io/announcing-beta-3-testnet/). This toolchain should be used to interact with and build on the testnet. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-3.toml).
-
-## The `beta-4-rc` channel
-
-The `beta-4-rc` channel offers developers an early opportunity to test out new features and improvements, including enhancements and bug fixes made since the beta-3 version. If maintaining compatibility with the beta-3 testnet is required for your project, we recommend you continue using the beta-3 toolchain. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-4-rc.toml).
-
-## The `beta-4-rc.2` channel
-
-The `beta-4-rc.2` channel offers developers an early opportunity to test out new features and improvements, including enhancements and bug fixes made since the beta-4-rc version. If maintaining compatibility with the beta-3 testnet is required for your project, we recommend you continue using the beta-3 toolchain. The components to be installed can be found [here](https://github.com/FuelLabs/fuelup/blob/gh-pages/channel-fuel-beta-4-rc-2.toml).
 
 ## The `beta-4` channel
 
@@ -95,6 +85,4 @@ You may also use [nektos/act](https://github.com/nektos/act) to run the workflow
 [latest]: #the-latest-channel
 [nightly]: #the-nightly-channel
 [beta-3]: #the-beta-3-channel
-[beta-4-rc]: #the-beta-4-rc-channel
-[beta-4-rc2]: #the-beta-4-rc2-channel
 [beta-4]: #the-beta-4-channel

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,9 +1,8 @@
 use crate::{
     constants::{
         CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_BETA_3_FILE_NAME,
-        CHANNEL_BETA_4_FILE_NAME, CHANNEL_BETA_4_RC_2_FILE_NAME, CHANNEL_BETA_4_RC_FILE_NAME,
-        CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME, DATE_FORMAT_URL_FRIENDLY,
-        FUELUP_GH_PAGES,
+        CHANNEL_BETA_4_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
+        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -22,8 +21,6 @@ pub const STABLE: &str = "stable";
 pub const BETA_1: &str = "beta-1";
 pub const BETA_2: &str = "beta-2";
 pub const BETA_3: &str = "beta-3";
-pub const BETA_4_RC: &str = "beta-4-rc";
-pub const BETA_4_RC_2: &str = "beta-4-rc.2";
 pub const BETA_4: &str = "beta-4";
 pub const NIGHTLY: &str = "nightly";
 
@@ -46,12 +43,7 @@ pub struct Package {
 }
 
 pub fn is_beta_toolchain(name: &str) -> bool {
-    name == BETA_1
-        || name == BETA_2
-        || name == BETA_3
-        || name == BETA_4_RC
-        || name == BETA_4_RC_2
-        || name == BETA_4
+    name == BETA_1 || name == BETA_2 || name == BETA_3 || name == BETA_4
 }
 
 fn format_nightly_url(date: &Date) -> Result<String> {
@@ -82,8 +74,6 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
         DistToolchainName::Beta1 => url.push_str(CHANNEL_BETA_1_FILE_NAME),
         DistToolchainName::Beta2 => url.push_str(CHANNEL_BETA_2_FILE_NAME),
         DistToolchainName::Beta3 => url.push_str(CHANNEL_BETA_3_FILE_NAME),
-        DistToolchainName::Beta4Rc => url.push_str(CHANNEL_BETA_4_RC_FILE_NAME),
-        DistToolchainName::Beta4Rc2 => url.push_str(CHANNEL_BETA_4_RC_2_FILE_NAME),
         DistToolchainName::Beta4 => url.push_str(CHANNEL_BETA_4_FILE_NAME),
     };
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,8 +11,6 @@ pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
 pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
 pub const CHANNEL_BETA_2_FILE_NAME: &str = "channel-fuel-beta-2.toml";
 pub const CHANNEL_BETA_3_FILE_NAME: &str = "channel-fuel-beta-3.toml";
-pub const CHANNEL_BETA_4_RC_FILE_NAME: &str = "channel-fuel-beta-4-rc.toml";
-pub const CHANNEL_BETA_4_RC_2_FILE_NAME: &str = "channel-fuel-beta-4-rc-2.toml";
 pub const CHANNEL_BETA_4_FILE_NAME: &str = "channel-fuel-beta-4.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -26,8 +26,7 @@ pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::BETA_1,
     channel::BETA_2,
     channel::BETA_3,
-    channel::BETA_4_RC,
-    channel::BETA_4_RC_2,
+    channel::BETA_4,
     channel::NIGHTLY,
     channel::STABLE,
 ];
@@ -37,8 +36,6 @@ pub enum DistToolchainName {
     Beta1,
     Beta2,
     Beta3,
-    Beta4Rc,
-    Beta4Rc2,
     Beta4,
     Latest,
     Nightly,
@@ -52,8 +49,6 @@ impl fmt::Display for DistToolchainName {
             DistToolchainName::Beta1 => write!(f, "{}", channel::BETA_1),
             DistToolchainName::Beta2 => write!(f, "{}", channel::BETA_2),
             DistToolchainName::Beta3 => write!(f, "{}", channel::BETA_3),
-            DistToolchainName::Beta4Rc => write!(f, "{}", channel::BETA_4_RC),
-            DistToolchainName::Beta4Rc2 => write!(f, "{}", channel::BETA_4_RC_2),
             DistToolchainName::Beta4 => write!(f, "{}", channel::BETA_4),
         }
     }
@@ -68,8 +63,6 @@ impl FromStr for DistToolchainName {
             channel::BETA_1 => Ok(Self::Beta1),
             channel::BETA_2 => Ok(Self::Beta2),
             channel::BETA_3 => Ok(Self::Beta3),
-            channel::BETA_4_RC => Ok(Self::Beta4Rc),
-            channel::BETA_4_RC_2 => Ok(Self::Beta4Rc2),
             channel::BETA_4 => Ok(Self::Beta4),
             _ => bail!("Unknown name for toolchain: {}", s),
         }


### PR DESCRIPTION
closes #502.

# Description

Removes beta-4-rc and beta-4-rc2 channels from fuelup. This is a breaking change.