### PR TITLE
Write logs to filesystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,6 @@ dependencies = [
  "sha2",
  "tar",
  "tempfile",
- "termcolor",
  "time",
  "toml_edit 0.13.4",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansiterm"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab587f5395da16dd2e6939adf53dede583221b320cadfb94e02b5b7b9bf24cc"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +474,7 @@ dependencies = [
 name = "fuelup"
 version = "0.20.0"
 dependencies = [
+ "ansiterm",
  "anyhow",
  "clap 4.4.7",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strip-ansi-escapes",
  "tar",
  "tempfile",
  "time",
@@ -980,6 +981,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1317,26 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +481,7 @@ dependencies = [
  "time",
  "toml_edit 0.13.4",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "ureq",
 ]
@@ -1127,6 +1147,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -1170,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ termcolor = "1"
 time = { version = "0.3", features = ["macros", "parsing", "formatting", "serde-well-known"] }
 toml_edit = { version = "0.13", features = ["serde", "easy"] }
 tracing = "0.1"
+tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
 ureq = "2.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ name = "fuelup"
 path = "src/main.rs"
 
 [dependencies]
+ansiterm = "0.12.2"
 anyhow = "1"
 clap = { version = "4.2.4", features = ["cargo", "derive", "env"] }
 clap_complete = "4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ serde_json = "1.0"
 sha2 = "0.10"
 tar = "0.4"
 tempfile = "3"
-termcolor = "1"
 time = { version = "0.3", features = ["macros", "parsing", "formatting", "serde-well-known"] }
 toml_edit = { version = "0.13", features = ["serde", "easy"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ ureq = "2.4"
 
 [workspace]
 members = ["component", "ci/build-channel", "ci/compare-versions"]
+
+[dev-dependencies]
+strip-ansi-escapes = "0.2.0"

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,37 +1,23 @@
 use std::io::Write;
+use ansiterm::Style;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+use tracing::info;
 
 use crate::target_triple::TargetTriple;
 
-// In the below functions, we ignore the `Result`s of `set_color` and `reset` to allow `write`
-// to work even when those functions fail to set/reset colors, since `StandardStream::stdout` is
-// a wrapper over `std::io::stdout`.
-
-pub fn bold<F>(write: F)
-where
-    F: FnOnce(&mut StandardStream) -> std::io::Result<()>,
-{
-    let mut stdout = StandardStream::stdout(ColorChoice::Auto);
-    let _ = stdout.set_color(ColorSpec::new().set_bold(true));
-    write(&mut stdout).expect("Unexpected error writing to stdout");
-    let _ = stdout.reset();
+pub fn bold(text: &str) -> String {
+    let style = Style::new().bold();
+    format!("{}", style.paint(text))
 }
 
-pub fn colored_bold<F>(color: Color, write: F)
-where
-    F: FnOnce(&mut StandardStream) -> std::io::Result<()>,
-{
-    let mut stdout = StandardStream::stdout(ColorChoice::Auto);
-    let _ = stdout.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true));
-    write(&mut stdout).expect("Unexpected error writing to stdout");
-    let _ = stdout.reset();
+pub fn colored_bold(color: ansiterm::Color, text: &str) -> String {
+    format!("{}", color.bold().paint(text))
 }
 
 pub fn print_header(header: &str) {
-    let mut stdout = StandardStream::stdout(ColorChoice::Auto);
-    bold(|s| writeln!(s, "{header}"));
-    writeln!(stdout, "{}", "-".repeat(header.len())).expect("Unexpected error writing to stdout");
-    let _ = stdout.reset();
+    info!("");
+    info!("{}", bold(header));
+    info!("{}", "-".repeat(header.len()));
 }
 
 pub fn format_toolchain_with_target(toolchain: &str) -> String {

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,6 +1,4 @@
-use std::io::Write;
 use ansiterm::Style;
-use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use tracing::info;
 
 use crate::target_triple::TargetTriple;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod download;
 pub mod file;
 pub mod fmt;
 pub mod fuelup_cli;
+pub mod logging;
 pub mod ops;
 pub mod path;
 pub mod proxy_cli;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,7 +5,10 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
 
 pub fn log_command() {
-    debug!("Command: {}", env::args().collect::<Vec<String>>().join(" "));
+    debug!(
+        "Command: {}",
+        env::args().collect::<Vec<String>>().join(" ")
+    );
 }
 
 pub fn log_environment() {
@@ -18,7 +21,7 @@ pub fn log_environment() {
             debug!("PATH does not include {}", FUELUP_DIR);
         }
     }
-    if let Some(val) = env::var_os("FUELUP_HOME") {
+    if let Some(val) = env::var_os(FUELUP_HOME) {
         debug!("FUELUP_HOME: {}", val.to_string_lossy());
     } else {
         debug!("FUELUP_HOME is not set");
@@ -34,7 +37,8 @@ pub fn init_tracing() -> WorkerGuard {
             tracing_subscriber::fmt::Layer::default()
                 .with_writer(file_writer)
                 .log_internal_errors(false)
-                .with_target(false),
+                .with_target(false)
+                .with_filter(LevelFilter::DEBUG),
         )
         .with(
             tracing_subscriber::fmt::Layer::default()

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,50 @@
+use crate::path::{fuelup_log_dir, FUELUP_DIR, FUELUP_HOME};
+use std::env;
+use tracing::{debug, level_filters::LevelFilter};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
+
+pub fn log_command() {
+    debug!("Command: {}", env::args().collect::<Vec<String>>().join(" "));
+}
+
+pub fn log_environment() {
+    if let Some(val) = env::var_os("PATH") {
+        if let Some(fuelup_path) =
+            env::split_paths(&val).find(|p| p.to_string_lossy().contains(FUELUP_DIR))
+        {
+            debug!("PATH includes {}", fuelup_path.to_string_lossy());
+        } else {
+            debug!("PATH does not include {}", FUELUP_DIR);
+        }
+    }
+    if let Some(val) = env::var_os("FUELUP_HOME") {
+        debug!("FUELUP_HOME: {}", val.to_string_lossy());
+    } else {
+        debug!("FUELUP_HOME is not set");
+    }
+}
+
+pub fn init_tracing() -> WorkerGuard {
+    let file_appender = tracing_appender::rolling::hourly(fuelup_log_dir(), "fuelup.log");
+    let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
+
+    tracing_subscriber::Registry::default()
+        .with(
+            tracing_subscriber::fmt::Layer::default()
+                .with_writer(file_writer)
+                .log_internal_errors(false)
+                .with_target(false),
+        )
+        .with(
+            tracing_subscriber::fmt::Layer::default()
+                .with_writer(std::io::stdout)
+                .without_time()
+                .with_level(false)
+                .with_target(false)
+                .with_filter(LevelFilter::INFO),
+        )
+        .init();
+
+    guard
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use fuelup::{
     fuelup_cli,
     logging::{init_tracing, log_command, log_environment},
-    path::fuelup_log_dir,
     proxy_cli,
 };
 use std::{env, panic, path::PathBuf};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,17 @@
 use anyhow::Result;
-use fuelup::path::fuelup_log_dir;
-use fuelup::{fuelup_cli, proxy_cli};
-use std::panic;
-use std::path::PathBuf;
+use fuelup::{
+    fuelup_cli,
+    logging::{init_tracing, log_command, log_environment},
+    path::fuelup_log_dir,
+    proxy_cli,
+};
+use std::{env, panic, path::PathBuf};
 use tracing::error;
-use tracing::level_filters::LevelFilter;
-use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::Layer;
 
 fn run() -> Result<()> {
-    let arg0 = std::env::args().next().map(PathBuf::from);
+    log_command();
+    log_environment();
+    let arg0 = env::args().next().map(PathBuf::from);
 
     let process_name = arg0
         .as_ref()
@@ -33,29 +33,6 @@ fn run() -> Result<()> {
         None => panic!("fuelup does not understand this command"),
     }
     Ok(())
-}
-
-fn init_tracing() -> WorkerGuard {
-    let file_appender = tracing_appender::rolling::hourly(fuelup_log_dir(), "fuelup.log");
-    let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
-
-    tracing_subscriber::Registry::default()
-        .with(
-            tracing_subscriber::fmt::Layer::default()
-                .with_writer(file_writer)
-                .with_target(false),
-        )
-        .with(
-            tracing_subscriber::fmt::Layer::default()
-                .with_writer(std::io::stdout)
-                .without_time()
-                .with_level(false)
-                .with_target(false)
-                .with_filter(LevelFilter::INFO),
-        )
-        .init();
-
-    guard
 }
 
 fn main() {

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -11,7 +11,6 @@ use ansiterm::Color;
 use anyhow::Result;
 use component::{self, Components};
 use semver::Version;
-use std::io::Write;
 use std::str::FromStr;
 use std::{
     cmp::Ordering::{Equal, Greater, Less},
@@ -38,16 +37,12 @@ fn format_version_comparison(current_version: &Version, latest_version: &Version
                 "{} : {current_version} -> {latest_version}",
                 colored_bold(Color::Yellow, "Update available")
             )
-            // colored_bold(Color::Yellow, |s| write!(s, "Update available"));
-            // println!(" : {current_version} -> {latest_version}");
         }
         Equal => {
             format!(
                 "{} : {current_version}",
                 colored_bold(Color::Green, "Up to date")
             )
-            // colored_bold(Color::Green, |s| write!(s, "Up to date"));
-            // println!(" : {current_version}");
         }
         Greater => {
             format!(
@@ -57,11 +52,6 @@ fn format_version_comparison(current_version: &Version, latest_version: &Version
                 latest_version,
                 colored_bold(Color::Green, "(recommended)")
             )
-
-            // print!(" : {current_version}");
-            // colored_bold(Color::Yellow, |s| write!(s, " (unstable)"));
-            // print!(" -> {latest_version}");
-            // colored_bold(Color::Green, |s| writeln!(s, " (recommended)"));
         }
     }
 }
@@ -87,11 +77,12 @@ fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version
                 }
             };
         }
-        Err(e) => { // TODO: use e
+        Err(e) => {
+            // TODO: use e
             let error_text = if plugin_executable.exists() {
-                "execution error - {e}"
+                format!("execution error - {e}")
             } else {
-                "not found"
+                "not found".into()
             };
             info!("    - {} - {}", bold(plugin), error_text);
         }

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -17,7 +17,6 @@ use std::{
     path::Path,
 };
 use std::{collections::HashMap, process::Command};
-// use termcolor::Color;
 use tracing::{error, info};
 
 fn collect_package_versions(channel: Channel) -> HashMap<String, Version> {
@@ -78,7 +77,6 @@ fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version
             };
         }
         Err(e) => {
-            // TODO: use e
             let error_text = if plugin_executable.exists() {
                 format!("execution error - {e}")
             } else {

--- a/src/ops/fuelup_component/list.rs
+++ b/src/ops/fuelup_component/list.rs
@@ -1,10 +1,10 @@
 use crate::{
-    commands::component::ListCommand, download::get_latest_version, fmt::{bold}, toolchain::Toolchain,
+    commands::component::ListCommand, download::get_latest_version, fmt::bold, toolchain::Toolchain,
 };
 use anyhow::Result;
 use component::Components;
 use semver::Version;
-use std::io::Write;
+use std::fmt::Write;
 use tracing::info;
 
 fn format_installed_component_info(
@@ -24,17 +24,13 @@ fn format_installable_component_info(name: &str, latest_version: &str) -> String
 }
 
 fn format_forc_default_plugins(plugin_executables: Vec<String>) -> String {
-    use std::fmt::Write;
-    format!(
-        "{}",
-        plugin_executables
-            .iter()
-            .filter(|c| *c != component::FORC)
-            .fold(String::new(), |mut output, b| {
-                let _ = write!(output, "    - {b}\n");
-                output
-            })
-    )
+    plugin_executables
+        .iter()
+        .filter(|c| *c != component::FORC)
+        .fold(String::new(), |mut output, b| {
+            let _ = writeln!(output, "    - {b}");
+            output
+        })
 }
 
 pub fn list(_command: ListCommand) -> Result<()> {

--- a/src/ops/fuelup_component/list.rs
+++ b/src/ops/fuelup_component/list.rs
@@ -1,5 +1,5 @@
 use crate::{
-    commands::component::ListCommand, download::get_latest_version, fmt::bold, toolchain::Toolchain,
+    commands::component::ListCommand, download::get_latest_version, fmt::{bold}, toolchain::Toolchain,
 };
 use anyhow::Result;
 use component::Components;
@@ -26,12 +26,12 @@ fn format_installable_component_info(name: &str, latest_version: &str) -> String
 fn format_forc_default_plugins(plugin_executables: Vec<String>) -> String {
     use std::fmt::Write;
     format!(
-        "    - {}\n",
+        "{}",
         plugin_executables
             .iter()
             .filter(|c| *c != component::FORC)
             .fold(String::new(), |mut output, b| {
-                let _ = write!(output, "{b}");
+                let _ = write!(output, "    - {b}\n");
                 output
             })
     )
@@ -39,10 +39,6 @@ fn format_forc_default_plugins(plugin_executables: Vec<String>) -> String {
 
 pub fn list(_command: ListCommand) -> Result<()> {
     let toolchain = Toolchain::from_settings()?;
-
-    // use write! instead of writeln! here to prevent this from printing first.
-    bold(|s| write!(s, "{}", toolchain.name));
-
     let mut installed_components_summary = String::from("\nInstalled:\n");
     let mut available_components_summary = String::from("Installable:\n");
 
@@ -95,6 +91,7 @@ pub fn list(_command: ListCommand) -> Result<()> {
             }
         }
     }
+    info!("{}", bold(&toolchain.name));
     info!(
         "{}\n{}",
         installed_components_summary, available_components_summary

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -2,15 +2,15 @@ use anyhow::{bail, Result};
 use component::{self, Components};
 use semver::Version;
 use std::collections::HashMap;
+use std::path::Path;
 use std::str::FromStr;
-use std::{io::Write, path::Path};
-use tracing::{error, info};
+use tracing::info;
 
 use crate::fmt::bold;
 use crate::store::Store;
 use crate::{
     config::Config,
-    fmt::{ print_header},
+    fmt::print_header,
     path::fuelup_dir,
     target_triple::TargetTriple,
     toolchain::{DistToolchainDescription, Toolchain},
@@ -27,12 +27,12 @@ fn exec_version(component_executable: &Path) -> Result<Version> {
             match output.split_whitespace().last() {
                 Some(v) => {
                     let version = Version::parse(v)?;
-                    return Ok(version);
+                    Ok(version)
                 }
                 None => {
                     bail!("Error getting version string");
                 }
-            };
+            }
         }
         Err(e) => {
             if component_executable.exists() {
@@ -45,11 +45,7 @@ fn exec_version(component_executable: &Path) -> Result<Version> {
 }
 
 pub fn show() -> Result<()> {
-    info!(
-        "{}: {}",
-        bold("Default host"),
-        TargetTriple::from_host()?
-    );
+    info!("{}: {}", bold("Default host"), TargetTriple::from_host()?);
     info!("{}: {}", bold("fuelup home"), fuelup_dir().display());
 
     print_header("installed toolchains");
@@ -133,7 +129,7 @@ pub fn show() -> Result<()> {
                                 format!("{}", e)
                             }
                         };
-                        info!("      - {} : {}", bold(&executable), version_text);
+                        info!("      - {} : {}", bold(executable), version_text);
                     }
                 } else {
                     let plugin_executable = active_toolchain.bin_path.join(&plugin.name);

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -6,17 +6,18 @@ use std::str::FromStr;
 use std::{io::Write, path::Path};
 use tracing::{error, info};
 
+use crate::fmt::bold;
 use crate::store::Store;
 use crate::{
     config::Config,
-    fmt::{bold, print_header},
+    fmt::{ print_header},
     path::fuelup_dir,
     target_triple::TargetTriple,
     toolchain::{DistToolchainDescription, Toolchain},
     toolchain_override::ToolchainOverride,
 };
 
-fn exec_show_version(component_executable: &Path) -> Result<Version> {
+fn exec_version(component_executable: &Path) -> Result<Version> {
     match std::process::Command::new(component_executable)
         .arg("--version")
         .output()
@@ -26,33 +27,30 @@ fn exec_show_version(component_executable: &Path) -> Result<Version> {
             match output.split_whitespace().last() {
                 Some(v) => {
                     let version = Version::parse(v)?;
-                    info!(" : {}", version);
                     return Ok(version);
                 }
                 None => {
-                    error!(" : Error getting version string");
+                    bail!("Error getting version string");
                 }
             };
         }
         Err(e) => {
-            print!(" - ");
             if component_executable.exists() {
-                error!("execution error - {}", e);
+                bail!("execution error - {}", e);
             } else {
-                error!("not found");
+                bail!("not found");
             }
         }
     }
-
-    bail!("could not show version: {}", component_executable.display());
 }
 
 pub fn show() -> Result<()> {
-    bold(|s| write!(s, "Default host: "));
-    info!("{}", TargetTriple::from_host()?);
-
-    bold(|s| write!(s, "fuelup home: "));
-    info!("{}\n", fuelup_dir().display());
+    info!(
+        "{}: {}",
+        bold("Default host"),
+        TargetTriple::from_host()?
+    );
+    info!("{}: {}", bold("fuelup home"), fuelup_dir().display());
 
     print_header("installed toolchains");
     let cfg = Config::from_env()?;
@@ -102,34 +100,51 @@ pub fn show() -> Result<()> {
         active_toolchain_message.push_str(&format!("{} (default)", active_toolchain.name));
     };
 
-    print_header("\nactive toolchain");
+    print_header("active toolchain");
     info!("{}", active_toolchain_message);
 
     let mut version_map: HashMap<String, Version> = HashMap::new();
     for component in Components::collect_exclude_plugins()? {
-        bold(|s| write!(s, "  {}", &component.name));
         let component_executable = active_toolchain.bin_path.join(&component.name);
-        if let Ok(version) = exec_show_version(component_executable.as_path()) {
-            version_map.insert(component.name.clone(), version);
+        let version_text: String = match exec_version(component_executable.as_path()) {
+            Ok(version) => {
+                version_map.insert(component.name.clone(), version.clone());
+                format!("{}", version)
+            }
+            Err(e) => format!("{}", e),
         };
+
+        info!("  {} : {}", bold(&component.name), version_text);
 
         if component.name == component::FORC {
             for plugin in Components::collect_plugins()? {
-                bold(|s| write!(s, "    - {}", &plugin.name));
                 if !plugin.is_main_executable() {
-                    info!("");
+                    info!("    - {}", bold(&plugin.name));
+
                     for executable in plugin.executables.iter() {
-                        bold(|s| write!(s, "      - {}", &executable));
                         let plugin_executable = active_toolchain.bin_path.join(executable);
-                        if let Ok(version) = exec_show_version(plugin_executable.as_path()) {
-                            version_map.insert(executable.clone(), version);
+                        let version_text = match exec_version(plugin_executable.as_path()) {
+                            Ok(version) => {
+                                version_map.insert(executable.clone(), version.clone());
+
+                                format!("{}", version)
+                            }
+                            Err(e) => {
+                                format!("{}", e)
+                            }
                         };
+                        info!("      - {} : {}", bold(&executable), version_text);
                     }
                 } else {
                     let plugin_executable = active_toolchain.bin_path.join(&plugin.name);
-                    if let Ok(version) = exec_show_version(plugin_executable.as_path()) {
-                        version_map.insert(plugin.name.clone(), version);
+                    let version_text = match exec_version(plugin_executable.as_path()) {
+                        Ok(version) => {
+                            version_map.insert(plugin.name.clone(), version.clone());
+                            format!("{}", version)
+                        }
+                        Err(e) => format!("{}", e),
                     };
+                    info!("    - {} : {}", bold(&plugin.name), version_text);
                 }
             }
         }
@@ -143,12 +158,10 @@ pub fn show() -> Result<()> {
             if let Ok(fuels_version) = store.get_cached_fuels_version(&component.name, version) {
                 // Only print the header if we find an Ok fuels_version to show.
                 if !fuels_version_header_shown {
-                    print_header("\nfuels versions");
+                    print_header("fuels versions");
                     fuels_version_header_shown = true;
                 }
-
-                bold(|s| write!(s, "{}", &component.name));
-                info!(" : {}", fuels_version);
+                info!("{} : {}", bold(&component.name), fuels_version);
             };
         }
     }

--- a/src/ops/fuelup_update.rs
+++ b/src/ops/fuelup_update.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use ansiterm::Color;
 use anyhow::{bail, Result};
-use std::io::Write;
 use std::str::FromStr;
 use tracing::info;
 
@@ -72,7 +71,7 @@ pub fn update() -> Result<()> {
             .collect::<String>()
             .is_empty()
         {
-            info!("{}",colored_bold(Color::Green, &toolchain_info));
+            info!("{}", colored_bold(Color::Green, &toolchain_info));
         } else {
             info!("{}", bold(&toolchain_info));
         }

--- a/src/ops/fuelup_update.rs
+++ b/src/ops/fuelup_update.rs
@@ -5,10 +5,10 @@ use crate::{
     path::warn_existing_fuel_executables,
     toolchain::{DistToolchainDescription, Toolchain},
 };
+use ansiterm::Color;
 use anyhow::{bail, Result};
 use std::io::Write;
 use std::str::FromStr;
-use termcolor::Color;
 use tracing::info;
 
 const UPDATED: &str = "updated";
@@ -60,7 +60,7 @@ pub fn update() -> Result<()> {
         };
 
         summary.push((
-            format!("{toolchain} {status}\n"),
+            format!("{toolchain} {status}"),
             format!("{installed_bins}{errored_bins}"),
         ));
     }
@@ -72,9 +72,9 @@ pub fn update() -> Result<()> {
             .collect::<String>()
             .is_empty()
         {
-            colored_bold(Color::Green, |s| write!(s, "{toolchain_info}"));
+            info!("{}",colored_bold(Color::Green, &toolchain_info));
         } else {
-            bold(|s| write!(s, "{toolchain_info}"));
+            info!("{}", bold(&toolchain_info));
         }
         info!("{}", components_info);
     }

--- a/src/path.rs
+++ b/src/path.rs
@@ -12,6 +12,7 @@ use dirs;
 use crate::constants::FUEL_TOOLCHAIN_TOML_FILE;
 
 pub const FUELUP_DIR: &str = ".fuelup";
+pub const FUELUP_HOME: &str = "FUELUP_HOME";
 
 pub fn fuelup_dir() -> PathBuf {
     dirs::home_dir().unwrap().join(FUELUP_DIR)

--- a/src/path.rs
+++ b/src/path.rs
@@ -25,6 +25,10 @@ pub fn fuelup_bin() -> PathBuf {
     fuelup_bin_dir().join("fuelup")
 }
 
+pub fn fuelup_log_dir() -> PathBuf {
+    fuelup_dir().join("log")
+}
+
 pub fn settings_file() -> PathBuf {
     fuelup_dir().join("settings.toml")
 }

--- a/tests/check.rs
+++ b/tests/check.rs
@@ -7,35 +7,41 @@ use testcfg::FuelupState;
 
 #[test]
 fn fuelup_check() -> Result<()> {
-    let latest = format!("latest-{}\n", TargetTriple::from_host().unwrap());
-    let beta_1 = format!("beta-1-{}\n", TargetTriple::from_host().unwrap());
+    let latest = format!("latest-{}", TargetTriple::from_host().unwrap());
+    let beta_1 = format!("beta-1-{}", TargetTriple::from_host().unwrap());
     let forc = "forc -";
     let fuel_core = "fuel-core -";
     let fuel_indexer = "fuel-indexer -";
     testcfg::setup(FuelupState::Empty, &|cfg| {
         let output = cfg.fuelup(&["check"]);
-        assert!(!output.stdout.contains(&latest));
-        assert!(!output.stdout.contains(forc));
-        assert!(!output.stdout.contains(fuel_core));
-        assert!(!output.stdout.contains(fuel_indexer));
+        let stripped = strip_ansi_escapes::strip(output.stdout);
+        let stdout = String::from_utf8_lossy(&stripped);
+        assert!(!stdout.contains(&latest));
+        assert!(!stdout.contains(forc));
+        assert!(!stdout.contains(fuel_core));
+        assert!(!stdout.contains(fuel_indexer));
     })?;
 
     // Test that only the 'latest' toolchain shows.
     testcfg::setup(FuelupState::LatestAndCustomInstalled, &|cfg| {
         let output = cfg.fuelup(&["check"]);
-        assert!(output.stdout.contains(&latest));
-        assert!(output.stdout.contains(forc));
-        assert!(output.stdout.contains(fuel_core));
-        assert!(output.stdout.contains(fuel_indexer));
+        let stripped = strip_ansi_escapes::strip(output.stdout);
+        let stdout = String::from_utf8_lossy(&stripped);
+        assert!(stdout.contains(&latest));
+        assert!(stdout.contains(forc));
+        assert!(stdout.contains(fuel_core));
+        assert!(stdout.contains(fuel_indexer));
     })?;
 
     // Test that toolchain names with '-' inside are parsed correctly.
     testcfg::setup(FuelupState::Beta1Installed, &|cfg| {
         let output = cfg.fuelup(&["check"]);
-        assert!(output.stdout.contains(&beta_1));
-        assert!(output.stdout.contains(forc));
-        assert!(output.stdout.contains(fuel_core));
-        assert!(!output.stdout.contains(fuel_indexer));
+        let stripped = strip_ansi_escapes::strip(output.stdout);
+        let stdout = String::from_utf8_lossy(&stripped);
+        assert!(stdout.contains(&beta_1));
+        assert!(stdout.contains(forc));
+        assert!(stdout.contains(fuel_core));
+        assert!(!stdout.contains(fuel_indexer));
     })?;
 
     Ok(())

--- a/tests/default.rs
+++ b/tests/default.rs
@@ -84,20 +84,24 @@ fn fuelup_default_nightly() -> Result<()> {
 #[test]
 fn fuelup_default_nightly_and_nightly_date() -> Result<()> {
     testcfg::setup(FuelupState::NightlyAndNightlyDateInstalled, &|cfg| {
-        let output = cfg.fuelup(&["default", "nightly"]);
+        let stripped = strip_ansi_escapes::strip(cfg.fuelup(&["default", "nightly"]).stdout);
+        let stdout = String::from_utf8_lossy(&stripped);
+
         let expected_stdout = format!(
             "default toolchain set to 'nightly-{}'\n",
             TargetTriple::from_host().unwrap()
         );
-        assert_eq!(output.stdout, expected_stdout);
+        assert_eq!(stdout, expected_stdout);
 
-        let output = cfg.fuelup(&["default", &format!("nightly-{DATE}")]);
+        let stripped =
+            strip_ansi_escapes::strip(cfg.fuelup(&["default", &format!("nightly-{DATE}")]).stdout);
+        let stdout = String::from_utf8_lossy(&stripped);
         let expected_stdout = format!(
             "default toolchain set to 'nightly-{}-{}'\n",
             DATE,
             TargetTriple::from_host().unwrap()
         );
-        assert_eq!(output.stdout, expected_stdout);
+        assert_eq!(stdout, expected_stdout);
     })?;
 
     Ok(())

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -13,7 +13,8 @@ use testcfg::FuelupState;
 fn fuelup_show_latest() -> Result<()> {
     testcfg::setup(FuelupState::AllInstalled, &|cfg| {
         cfg.fuelup(&["show"]);
-        let stdout = cfg.fuelup(&["show"]).stdout;
+        let stripped = strip_ansi_escapes::strip(cfg.fuelup(&["show"]).stdout);
+        let stdout = String::from_utf8_lossy(&stripped);
         let target = TargetTriple::from_host().unwrap();
 
         let mut lines = stdout.lines();
@@ -29,7 +30,7 @@ nightly-{target}
 nightly-2022-08-30-{target}
 
 active toolchain
------------------
+----------------
 latest-{target} (default)
   forc : 0.1.0
     - forc-client
@@ -43,7 +44,7 @@ latest-{target} (default)
     - forc-tx : 0.1.0
     - forc-wallet : 0.1.0
   fuel-core : 0.1.0
-  fuel-core-keygen - not found
+  fuel-core-keygen : not found
   fuel-indexer : 0.1.0
 "#
         );
@@ -57,7 +58,8 @@ latest-{target} (default)
 fn fuelup_show_and_switch() -> Result<()> {
     testcfg::setup(FuelupState::AllInstalled, &|cfg| {
         cfg.fuelup(&["show"]);
-        let mut stdout = cfg.fuelup(&["show"]).stdout;
+        let mut stripped = strip_ansi_escapes::strip(cfg.fuelup(&["show"]).stdout);
+        let mut stdout = String::from_utf8_lossy(&stripped);
         let mut target = TargetTriple::from_host().unwrap();
 
         let mut lines = stdout.lines();
@@ -73,7 +75,7 @@ nightly-{target}
 nightly-2022-08-30-{target}
 
 active toolchain
------------------
+----------------
 latest-{target} (default)
   forc : 0.1.0
     - forc-client
@@ -87,7 +89,7 @@ latest-{target} (default)
     - forc-tx : 0.1.0
     - forc-wallet : 0.1.0
   fuel-core : 0.1.0
-  fuel-core-keygen - not found
+  fuel-core-keygen : not found
   fuel-indexer : 0.1.0
 "#
         );
@@ -95,7 +97,8 @@ latest-{target} (default)
         assert!(!stdout.contains("fuels versions"));
 
         cfg.fuelup(&["default", "nightly"]);
-        stdout = cfg.fuelup(&["show"]).stdout;
+        stripped = strip_ansi_escapes::strip(cfg.fuelup(&["show"]).stdout);
+        stdout = String::from_utf8_lossy(&stripped);
         target = TargetTriple::from_host().unwrap();
 
         let expected_stdout = &format!(
@@ -107,7 +110,7 @@ nightly-{target} (default)
 nightly-2022-08-30-{target}
 
 active toolchain
------------------
+----------------
 nightly-{target} (default)
   forc : 0.2.0
     - forc-client
@@ -121,7 +124,7 @@ nightly-{target} (default)
     - forc-tx : 0.2.0
     - forc-wallet : 0.2.0
   fuel-core : 0.2.0
-  fuel-core-keygen - not found
+  fuel-core-keygen : not found
   fuel-indexer : 0.2.0
 "#
         );
@@ -136,7 +139,8 @@ nightly-{target} (default)
 fn fuelup_show_custom() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
         cfg.fuelup(&["toolchain", "new", "my_toolchain"]);
-        let stdout = cfg.fuelup(&["show"]).stdout;
+        let stripped = strip_ansi_escapes::strip(cfg.fuelup(&["show"]).stdout);
+        let stdout = String::from_utf8_lossy(&stripped);
 
         let mut lines = stdout.lines();
         assert_eq!(
@@ -151,23 +155,24 @@ installed toolchains
 my_toolchain (default)
 
 active toolchain
------------------
+----------------
 my_toolchain (default)
-  forc - not found
+  forc : not found
     - forc-client
-      - forc-deploy - not found
-      - forc-run - not found
-    - forc-doc - not found
-    - forc-explore - not found
-    - forc-fmt - not found
-    - forc-index - not found
-    - forc-lsp - not found
-    - forc-tx - not found
-    - forc-wallet - not found
-  fuel-core - not found
-  fuel-core-keygen - not found
-  fuel-indexer - not found
+      - forc-deploy : not found
+      - forc-run : not found
+    - forc-doc : not found
+    - forc-explore : not found
+    - forc-fmt : not found
+    - forc-index : not found
+    - forc-lsp : not found
+    - forc-tx : not found
+    - forc-wallet : not found
+  fuel-core : not found
+  fuel-core-keygen : not found
+  fuel-indexer : not found
 "#;
+
         assert!(stdout.contains(expected_stdout));
         assert!(!stdout.contains("fuels versions"));
     })?;
@@ -177,7 +182,8 @@ my_toolchain (default)
 #[test]
 fn fuelup_show_override() -> Result<()> {
     testcfg::setup(FuelupState::LatestWithBetaOverride, &|cfg| {
-        let stdout = cfg.fuelup(&["show"]).stdout;
+        let stripped = strip_ansi_escapes::strip(cfg.fuelup(&["show"]).stdout);
+        let stdout = String::from_utf8_lossy(&stripped);
 
         let mut lines = stdout.lines();
         assert_eq!(
@@ -194,22 +200,22 @@ installed toolchains
 latest-{target} (default)
 
 active toolchain
------------------
+----------------
 beta-1-{target} (override), path: {}
-  forc - not found
+  forc : not found
     - forc-client
-      - forc-deploy - not found
-      - forc-run - not found
-    - forc-doc - not found
-    - forc-explore - not found
-    - forc-fmt - not found
-    - forc-index - not found
-    - forc-lsp - not found
-    - forc-tx - not found
-    - forc-wallet - not found
-  fuel-core - not found
-  fuel-core-keygen - not found
-  fuel-indexer - not found
+      - forc-deploy : not found
+      - forc-run : not found
+    - forc-doc : not found
+    - forc-explore : not found
+    - forc-fmt : not found
+    - forc-index : not found
+    - forc-lsp : not found
+    - forc-tx : not found
+    - forc-wallet : not found
+  fuel-core : not found
+  fuel-core-keygen : not found
+  fuel-indexer : not found
 "#,
             cfg.home.join(FUEL_TOOLCHAIN_TOML_FILE).display()
         );
@@ -222,7 +228,8 @@ beta-1-{target} (override), path: {}
 #[test]
 fn fuelup_show_latest_then_override() -> Result<()> {
     testcfg::setup(FuelupState::AllInstalled, &|cfg| {
-        let mut stdout = cfg.fuelup(&["show"]).stdout;
+        let mut stripped = strip_ansi_escapes::strip(cfg.fuelup(&["show"]).stdout);
+        let mut stdout = String::from_utf8_lossy(&stripped);
 
         let mut lines = stdout.lines();
         assert_eq!(
@@ -240,7 +247,7 @@ nightly-{target}
 nightly-2022-08-30-{target}
 
 active toolchain
------------------
+----------------
 latest-{target} (default)
   forc : 0.1.0
     - forc-client
@@ -254,7 +261,7 @@ latest-{target} (default)
     - forc-tx : 0.1.0
     - forc-wallet : 0.1.0
   fuel-core : 0.1.0
-  fuel-core-keygen - not found
+  fuel-core-keygen : not found
   fuel-indexer : 0.1.0
 "#,
         );
@@ -274,7 +281,8 @@ latest-{target} (default)
         std::fs::write(toolchain_override.path, document.to_string())
             .unwrap_or_else(|_| panic!("Failed to write {FUEL_TOOLCHAIN_TOML_FILE}"));
 
-        stdout = cfg.fuelup(&["show"]).stdout;
+        stripped = strip_ansi_escapes::strip(cfg.fuelup(&["show"]).stdout);
+        stdout = String::from_utf8_lossy(&stripped);
 
         let mut lines = stdout.lines();
         while let Some(line) = lines.next() {
@@ -302,7 +310,7 @@ latest-{target} (default)
     - forc-tx : 0.2.0
     - forc-wallet : 0.2.0
   fuel-core : 0.2.0
-  fuel-core-keygen - not found
+  fuel-core-keygen : not found
   fuel-indexer : 0.2.0
 "#;
         assert!(stdout.contains(expected_stdout));


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuelup/issues/519

This writes logs to `~/.fuelup/log` rolling over every hour. For example `~/.fuelup/log/fuelup.log.2023-11-22-00`

Since `tracing` is used for showing output to the user as well, I added a filter so that`debug` logs will only be logged to the filesystem, not shown to the user.

The PR also includes:
- Cleans up existing logs: the output shown to the user is a combination of tracing and plain `writeln`s. In order for the log file to capture everything the user is shown, we should output everything through tracing macros.
- Adds useful `debug` logs about the environment and the command that was called. It doesn't log the full PATH, because that could contain sensitive information, rather it logs whether or not the `.fuelup` directory is part of the path.

Example of the current log output after `fuelup show`:

### User sees

```
$ fuelup show
Default host: x86_64-apple-darwin
fuelup home: /Users/sophiedankel/.fuelup

installed toolchains
--------------------
beta-3-x86_64-apple-darwin
beta-4-aarch64-apple-darwin (default)
latest-aarch64-apple-darwin

active toolchain
-----------------
beta-4-aarch64-apple-darwin (default)
  forc : 0.46.1
    - forc-client
      - forc-deploy - not found
      - forc-run - not found
    - forc-doc - not found
    - forc-explore - not found
    - forc-fmt - not found
    - forc-index - not found
    - forc-lsp - not found
    - forc-tx - not found
    - forc-wallet - not found
  fuel-core : 0.20.5
  fuel-core-keygen : Error getting version string
  fuel-indexer : 0.23.0

fuels versions
---------------
forc : 0.45
```

### Logged to file
```
$ cat ~/.fuelup/log/fuelup.log.2023-11-27-02 
2023-11-27T02:51:30.172198Z DEBUG Command: fuelup show
2023-11-27T02:51:30.172325Z DEBUG PATH includes /Users/sophiedankel/.fuelup/bin
2023-11-27T02:51:30.172330Z DEBUG FUELUP_HOME is not set
2023-11-27T02:51:30.173654Z  INFO Default host: x86_64-apple-darwin
2023-11-27T02:51:30.173717Z  INFO fuelup home: /Users/sophiedankel/.fuelup
2023-11-27T02:51:30.173722Z  INFO 
2023-11-27T02:51:30.173725Z  INFO installed toolchains
2023-11-27T02:51:30.173728Z  INFO --------------------
2023-11-27T02:51:30.177851Z  INFO beta-3-x86_64-apple-darwin
2023-11-27T02:51:30.177868Z  INFO beta-4-aarch64-apple-darwin (default)
2023-11-27T02:51:30.177872Z  INFO latest-aarch64-apple-darwin
2023-11-27T02:51:30.177877Z  INFO 
2023-11-27T02:51:30.177882Z  INFO active toolchain
2023-11-27T02:51:30.177884Z  INFO ----------------
2023-11-27T02:51:30.177888Z  INFO beta-4-aarch64-apple-darwin (default)
2023-11-27T02:51:30.192053Z  INFO   forc : 0.46.1
2023-11-27T02:51:30.192401Z  INFO     - forc-client
2023-11-27T02:51:30.192606Z  INFO       - forc-deploy : not found
2023-11-27T02:51:30.192757Z  INFO       - forc-run : not found
2023-11-27T02:51:30.192848Z  INFO     - forc-doc : not found
2023-11-27T02:51:30.193018Z  INFO     - forc-explore : not found
2023-11-27T02:51:30.193096Z  INFO     - forc-fmt : not found
2023-11-27T02:51:30.193174Z  INFO     - forc-index : not found
2023-11-27T02:51:30.193256Z  INFO     - forc-lsp : not found
2023-11-27T02:51:30.193331Z  INFO     - forc-tx : not found
2023-11-27T02:51:30.193423Z  INFO     - forc-wallet : not found
2023-11-27T02:51:30.217404Z  INFO   fuel-core : 0.20.5
2023-11-27T02:51:30.221223Z  INFO   fuel-core-keygen : Error getting version string
2023-11-27T02:51:30.247717Z  INFO   fuel-indexer : 0.23.0
2023-11-27T02:51:30.248265Z  INFO 
2023-11-27T02:51:30.248275Z  INFO fuels versions
2023-11-27T02:51:30.248277Z  INFO --------------
2023-11-27T02:51:30.248281Z  INFO forc : 0.45
```