### PR TITLE
doc: add fuelup http proxy setting document

### DIFF
--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -36,9 +36,17 @@ fuelup self update
 
 ## Using Http Proxy
 
-To configure `fuelup` to use your proxy setting you can change `http_proxy` environment value. The value format is in [libcurl format](https://everything.curl.dev/libcurl/proxies#proxy-types) as in `[protocol://]host[:port]`.
+To configure `fuelup` to use your proxy setting you can change `http_proxy`(***other optional enviroments see below***) environment value. The value format is in [libcurl format](https://everything.curl.dev/usingcurl/proxies/type.html) as in `[protocol://]host[:port]`.
 
-***Warning: don't leave `http_proxy` environment with empty string or other invalid format***
+### Supported proxy enviroment variables
+- http_proxy
+- HTTP_PROXY
+- https_proxy
+- HTTPS_PROXY
+- all_proxy
+- ALL_PROXY
+
+***Warning: don't leave all proxy environment with empty string or other invalid format***
 
 ## Help system
 

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -39,6 +39,7 @@ fuelup self update
 To configure `fuelup` to use your proxy setting you can change `http_proxy`(***other optional enviroments see below***) environment value. The value format is in [libcurl format](https://everything.curl.dev/usingcurl/proxies/type.html) as in `[protocol://]host[:port]`.
 
 ### Supported proxy enviroment variables
+
 - http_proxy
 - HTTP_PROXY
 - https_proxy

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -38,6 +38,8 @@ fuelup self update
 
 To configure `fuelup` to use your proxy setting you can change `http_proxy` environment value. The value format is in [libcurl format](https://everything.curl.dev/libcurl/proxies#proxy-types) as in `[protocol://]host[:port]`.
 
+***Warning: don't leave `http_proxy` environment with empty string or other invalid format***
+
 ## Help system
 
 The `fuelup` command-line is built with [clap], which serves a nice, built-in help system

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -34,6 +34,10 @@ fuelup self update
 ```
 <!-- update_fuelup:example:end -->
 
+## Using Http Proxy
+
+To configure `fuelup` to use your proxy setting you can change `http_proxy` environment value. The value format is in [libcurl format](https://everything.curl.dev/libcurl/proxies#proxy-types) as in `[protocol://]host[:port]`.
+
 ## Help system
 
 The `fuelup` command-line is built with [clap], which serves a nice, built-in help system

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -14,7 +14,7 @@ allowed in the installation step (explained below), which means you can run them
 
 Installation is done through the `fuelup-init` script found on our [repository], where you may find the source code.
 
-Run the following command:
+Run the following command (you may need to set a [http proxy](../basics.md#using-http-proxy) before running this command):
 
 <!-- This section should have the default command to install fuelup -->
 <!-- install:example:start -->


### PR DESCRIPTION
As I first run `fuelup toolchain install latest`, I failed because of network errors, and didn't find the instruction to set an http proxy to solve this problem. We should add this part IMO 😀