### PR TITLE
feat: using rust's built-in alignment to place spaces we want

### DIFF
--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -66,13 +66,14 @@ fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version
                 Some(v) => {
                     let version = Version::parse(v)?;
                     info!(
-                        "    - {} - {}",
+                        "{:>4}- {} - {}",
+                        "",
                         bold(plugin),
                         format_version_comparison(&version, latest_version)
                     );
                 }
                 None => {
-                    info!("    - {} - Error getting version string", plugin);
+                    info!("{:>4}- {} - Error getting version string", "", plugin);
                 }
             };
         }
@@ -82,7 +83,7 @@ fn check_plugin(plugin_executable: &Path, plugin: &str, latest_version: &Version
             } else {
                 "not found".into()
             };
-            info!("    - {} - {}", bold(plugin), error_text);
+            info!("{:>4}- {} - {}", "", bold(plugin), error_text);
         }
     }
     Ok(())
@@ -128,23 +129,32 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                         Some(v) => {
                             let version = Version::parse(v)?;
                             info!(
-                                "  {} - {}",
+                                "{:>2}{} - {}",
+                                "",
                                 bold(&component.name),
                                 format_version_comparison(&version, latest_version)
                             );
                         }
                         None => {
-                            error!("  {} - Error getting version string", bold(&component.name));
+                            error!(
+                                "{:>2}{} - Error getting version string",
+                                "",
+                                bold(&component.name)
+                            );
                         }
                     }
                 }
-                Err(_) => error!("  {} - Error getting version string", bold(&component.name)),
+                Err(_) => error!(
+                    "{:>2}{} - Error getting version string",
+                    "",
+                    bold(&component.name)
+                ),
             };
 
             if verbose && component.name == component::FORC {
                 for plugin in component::Components::collect_plugins()? {
                     if !plugin.is_main_executable() {
-                        info!("    - {}", bold(&plugin.name));
+                        info!("{:>4}- {}", "", bold(&plugin.name));
                     }
 
                     for (index, executable) in plugin.executables.iter().enumerate() {
@@ -153,7 +163,7 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
                         let mut plugin_name = &plugin.name;
 
                         if !plugin.is_main_executable() {
-                            print!("  ");
+                            print!("{:>2}", "");
                             plugin_name = &plugin.executables[index];
                         }
 

--- a/src/ops/fuelup_component/list.rs
+++ b/src/ops/fuelup_component/list.rs
@@ -13,14 +13,14 @@ fn format_installed_component_info(
     version_info: &str,
 ) -> String {
     if let Some(v) = version {
-        format!("  {name} {v} ({version_info})\n")
+        format!("{:>2}{name} {v} ({version_info})\n", "")
     } else {
-        format!("  {name} : failed getting current version\n")
+        format!("{:>2}{name} : failed getting current version\n", "")
     }
 }
 
 fn format_installable_component_info(name: &str, latest_version: &str) -> String {
-    format!("  {name} (latest: {latest_version})\n")
+    format!("{:>2}{name} (latest: {latest_version})\n", "")
 }
 
 fn format_forc_default_plugins(plugin_executables: Vec<String>) -> String {
@@ -28,7 +28,7 @@ fn format_forc_default_plugins(plugin_executables: Vec<String>) -> String {
         .iter()
         .filter(|c| *c != component::FORC)
         .fold(String::new(), |mut output, b| {
-            let _ = writeln!(output, "    - {b}");
+            let _ = writeln!(output, "{:>4}- {}", "", b);
             output
         })
 }

--- a/src/ops/fuelup_show.rs
+++ b/src/ops/fuelup_show.rs
@@ -110,12 +110,12 @@ pub fn show() -> Result<()> {
             Err(e) => format!("{}", e),
         };
 
-        info!("  {} : {}", bold(&component.name), version_text);
+        info!("{:>2}{} : {}", "", bold(&component.name), version_text);
 
         if component.name == component::FORC {
             for plugin in Components::collect_plugins()? {
                 if !plugin.is_main_executable() {
-                    info!("    - {}", bold(&plugin.name));
+                    info!("{:>4}- {}", "", bold(&plugin.name));
 
                     for executable in plugin.executables.iter() {
                         let plugin_executable = active_toolchain.bin_path.join(executable);
@@ -129,7 +129,7 @@ pub fn show() -> Result<()> {
                                 format!("{}", e)
                             }
                         };
-                        info!("      - {} : {}", bold(executable), version_text);
+                        info!("{:>6}- {} : {}", "", bold(executable), version_text);
                     }
                 } else {
                     let plugin_executable = active_toolchain.bin_path.join(&plugin.name);
@@ -140,7 +140,7 @@ pub fn show() -> Result<()> {
                         }
                         Err(e) => format!("{}", e),
                     };
-                    info!("    - {} : {}", bold(&plugin.name), version_text);
+                    info!("{:>4}- {} : {}", "", bold(&plugin.name), version_text);
                 }
             }
         }

--- a/src/ops/fuelup_update.rs
+++ b/src/ops/fuelup_update.rs
@@ -50,12 +50,12 @@ pub fn update() -> Result<()> {
         let mut status = String::new();
         if !installed_bins.is_empty() {
             status = UPDATED.to_string();
-            installed_bins = format!("  updated components:\n{installed_bins}");
+            installed_bins = format!("{:>2}updated components:\n{}", "", installed_bins);
         }
 
         if !errored_bins.is_empty() {
             status = PARTIALLY_UPDATED.to_string();
-            errored_bins = format!("  failed to update:\n{errored_bins}");
+            errored_bins = format!("{:>2}failed to update:\n{}", "", errored_bins);
         };
 
         summary.push((


### PR DESCRIPTION
close [#182](https://github.com/FuelLabs/fuelup/issues/182)

This PR added a function `pad_spaces(num: usize) -> String` to conveniently input the number of spaces we want.