### PR TITLE
feat: add beta-5 support

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,8 +1,8 @@
 use crate::{
     constants::{
         CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_BETA_3_FILE_NAME,
-        CHANNEL_BETA_4_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
-        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES, CHANNEL_BETA_5_FILE_NAME,
+        CHANNEL_BETA_4_FILE_NAME, CHANNEL_BETA_5_FILE_NAME, CHANNEL_LATEST_FILE_NAME,
+        CHANNEL_NIGHTLY_FILE_NAME, DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -76,7 +76,7 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
         DistToolchainName::Beta2 => url.push_str(CHANNEL_BETA_2_FILE_NAME),
         DistToolchainName::Beta3 => url.push_str(CHANNEL_BETA_3_FILE_NAME),
         DistToolchainName::Beta4 => url.push_str(CHANNEL_BETA_4_FILE_NAME),
-        DistToolchainName::Beta5 => url.push_str(CHANNEL_BETA_5_FILE_NAME)
+        DistToolchainName::Beta5 => url.push_str(CHANNEL_BETA_5_FILE_NAME),
     };
 
     Ok(url)

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -2,7 +2,7 @@ use crate::{
     constants::{
         CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_BETA_3_FILE_NAME,
         CHANNEL_BETA_4_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
-        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
+        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES, CHANNEL_BETA_5_FILE_NAME,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -22,6 +22,7 @@ pub const BETA_1: &str = "beta-1";
 pub const BETA_2: &str = "beta-2";
 pub const BETA_3: &str = "beta-3";
 pub const BETA_4: &str = "beta-4";
+pub const BETA_5: &str = "beta-5";
 pub const NIGHTLY: &str = "nightly";
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -43,7 +44,7 @@ pub struct Package {
 }
 
 pub fn is_beta_toolchain(name: &str) -> bool {
-    name == BETA_1 || name == BETA_2 || name == BETA_3 || name == BETA_4
+    name == BETA_1 || name == BETA_2 || name == BETA_3 || name == BETA_4 || name == BETA_5
 }
 
 fn format_nightly_url(date: &Date) -> Result<String> {
@@ -75,6 +76,7 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
         DistToolchainName::Beta2 => url.push_str(CHANNEL_BETA_2_FILE_NAME),
         DistToolchainName::Beta3 => url.push_str(CHANNEL_BETA_3_FILE_NAME),
         DistToolchainName::Beta4 => url.push_str(CHANNEL_BETA_4_FILE_NAME),
+        DistToolchainName::Beta5 => url.push_str(CHANNEL_BETA_5_FILE_NAME)
     };
 
     Ok(url)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,8 +6,7 @@ pub const FUELS_VERSION_FILE: &str = "fuels_version";
 
 pub const CHANNEL_LATEST_URL: &str =
     "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-4.toml";
-// TODO: Make this point to beta-5.
-pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-beta-4.toml";
+pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-beta-5.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
 pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
 pub const CHANNEL_BETA_2_FILE_NAME: &str = "channel-fuel-beta-2.toml";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,12 +6,14 @@ pub const FUELS_VERSION_FILE: &str = "fuels_version";
 
 pub const CHANNEL_LATEST_URL: &str =
     "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-beta-4.toml";
+// TODO: Make this point to beta-5.
 pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-beta-4.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
 pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
 pub const CHANNEL_BETA_2_FILE_NAME: &str = "channel-fuel-beta-2.toml";
 pub const CHANNEL_BETA_3_FILE_NAME: &str = "channel-fuel-beta-3.toml";
 pub const CHANNEL_BETA_4_FILE_NAME: &str = "channel-fuel-beta-4.toml";
+pub const CHANNEL_BETA_5_FILE_NAME: &str = "channel-fuel-beta-5.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -27,6 +27,7 @@ pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::BETA_2,
     channel::BETA_3,
     channel::BETA_4,
+    channel::BETA_5,
     channel::NIGHTLY,
     channel::STABLE,
 ];
@@ -37,6 +38,7 @@ pub enum DistToolchainName {
     Beta2,
     Beta3,
     Beta4,
+    Beta5,
     Latest,
     Nightly,
 }
@@ -50,6 +52,7 @@ impl fmt::Display for DistToolchainName {
             DistToolchainName::Beta2 => write!(f, "{}", channel::BETA_2),
             DistToolchainName::Beta3 => write!(f, "{}", channel::BETA_3),
             DistToolchainName::Beta4 => write!(f, "{}", channel::BETA_4),
+            DistToolchainName::Beta5 => write!(f, "{}", channel::BETA_5),
         }
     }
 }
@@ -64,6 +67,7 @@ impl FromStr for DistToolchainName {
             channel::BETA_2 => Ok(Self::Beta2),
             channel::BETA_3 => Ok(Self::Beta3),
             channel::BETA_4 => Ok(Self::Beta4),
+            channel::BETA_5 => Ok(Self::Beta5),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }


### PR DESCRIPTION
Adds beta-5 support to fuelup, once we have the toolchain toml merged as well we should make sure to point latest to it. I kept it like it so that tests would pass.