### PR TITLE
add html redirect to install script

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <script>
+    window.location.href = './fuelup-init.sh';
+  </script>
+</head>
+<body>
+  <p>If you are not redirected, <a href="./fuelup-init.sh">click here to download the script</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
This PR introduces an index.html file at the root of the gh-pages branch to facilitate automatic redirection to the `fuelup-init.sh` script when the root URL (https://install.fuel.network/) is accessed. This change simplifies the process for users to download and install `fuelup` by allowing a direct curl command from the root URL.

The motivation is to change the install command from 

```
curl -sSf https://install.fuel.network/fuelup-init.sh | sh
```

to this

```
curl -sSf https://fuel.network/install | sh
```