### PR TITLE
Support installing from a shorter URL

### DIFF
--- a/.github/workflows/gh-pages-meta.yml
+++ b/.github/workflows/gh-pages-meta.yml
@@ -28,6 +28,10 @@ jobs:
           mkdir -p ${{ env.FUELUP_INIT_DIR }}
           cp fuelup-init.sh ${{ env.FUELUP_INIT_DIR }}
 
+      # This lets us install the script directly from https://install.fuel.network/
+      - name: Copy fuelup_init.sh to index.html
+        run: cp fuelup_init.sh ${{ env.FUELUP_INIT_DIR }}/index.html
+
       - name: Deploy latest fuelup init
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
           mdbook-version: "0.4.8"
                   
       - run: mdbook build docs
-        
+
       - name: Deploy master
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,10 +19,6 @@ jobs:
           mdbook-version: "0.4.8"
                   
       - run: mdbook build docs
-
-      # This lets us install the script directly from https://install.fuel.network/
-      - name: Copy fuelup_init.sh to index.html
-        run: cp fuelup_init.sh docs/book/index.html
         
       - name: Deploy master
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,6 +20,10 @@ jobs:
                   
       - run: mdbook build docs
 
+      # This lets us install the script directly from https://install.fuel.network/
+      - name: Copy fuelup_init.sh to index.html
+        run: cp fuelup_init.sh docs/book/index.html
+        
       - name: Deploy master
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently, this script supports Linux/macOS systems only. For other systems, ple
 Installation is simple: all you need is `fuelup-init.sh`, which downloads the core Fuel binaries needed to get you started on development.
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh
+curl -fsSL https://install.fuel.network/ | sh
 ```
 
 This will automatically install `forc`, its accompanying plugins, `fuel-core` and other key components in `~/.fuelup/bin`. Please read the [Components chapter](https://fuellabs.github.io/fuelup/master/concepts/components.html) for more info on the components installed.
@@ -29,13 +29,13 @@ The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
 Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh -s -- --no-modify-path
+curl -fsSL https://install.fuel.network/ | sh -s -- --no-modify-path
 ```
 
 If you just want `fuelup` without automatically installing the `latest` toolchain, you can pass the `--skip-toolchain-installation` option:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh -s -- --skip-toolchain-installation
+curl -fsSL https://install.fuel.network/ | sh -s -- --skip-toolchain-installation
 ```
 
 ## License

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -19,7 +19,7 @@ Run the following command:
 <!-- This section should have the default command to install fuelup -->
 <!-- install:example:start -->
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh
+curl -fsSL https://install.fuel.network/ | sh
 ```
 <!-- install:example:end -->
 
@@ -28,7 +28,7 @@ This will install `forc`, `forc-client`, `forc-fmt`, `forc-crypto`, `forc-lsp`, 
 Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -sSf https://install.fuel.network/fuelup-init.sh | sh -s -- --no-modify-path
+curl -fsSL https://install.fuel.network/ | sh -s -- --no-modify-path
 ```
 
 Ensure that all components are downloaded and works:


### PR DESCRIPTION
Credit to @luizstacio for the idea!

Taking advantage of the fact that there was previously no index.html on this website (the page was a 404), we simply copy the installation script into `index.html`.

This change allows users to install from [https://install.fuel.network](https://install.fuel.network). I pushed the change to the gh-pages branch directly so you can test it already with:
```
curl -fsSL https://install.fuel.network/ | sh
```

I’ll make a release after this is merged to verify the gh action. Version bump: https://github.com/FuelLabs/fuelup/pull/578