### PR TITLE
chore: bump version to 0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "ansiterm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Will merge after https://github.com/FuelLabs/fuelup/pull/577 and make a release.