### PR TITLE
chore: bump fuel-core version to 0.22.1 in beta-5

### DIFF
--- a/channel-fuel-beta-5.toml
+++ b/channel-fuel-beta-5.toml
@@ -1,4 +1,4 @@
-date = "2023-02-16"
+date = "2023-02-28"
 
 [pkg.forc]
 version = "0.49.2"
@@ -58,39 +58,39 @@ url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.4.3/forc-wal
 hash = "944dbd922999ea4dbf1f8a9828c72200ec088e3c05b86e5dcf2b88633275b922"
 
 [pkg.fuel-core]
-version = "0.22.0"
+version = "0.22.1"
 
 [pkg.fuel-core.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.0/fuel-core-0.22.0-aarch64-unknown-linux-gnu.tar.gz"
-hash = "48dfa260b737b6e8bb5a7a259bff3e39c689eaeabc9016e48628724a4f32c5ed"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-aarch64-unknown-linux-gnu.tar.gz"
+hash = "3edb985f71e0a0e937fbb985902eb8cb10a32a71d2c9f9e359fd2ffcebd24ffb"
 
 [pkg.fuel-core.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.0/fuel-core-0.22.0-x86_64-unknown-linux-gnu.tar.gz"
-hash = "8c6e982d0e656fa1eae1d8fced99ef17837a301d9b6170d5cedf386782c96d3a"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-x86_64-unknown-linux-gnu.tar.gz"
+hash = "88254295557b4ec230265a983be5f8505209e94ac70f9a3e6b76d9963e583b2b"
 
 [pkg.fuel-core.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.0/fuel-core-0.22.0-aarch64-apple-darwin.tar.gz"
-hash = "92a1880a4abc3320f7876a32dc79ab37cd34806fad084eb3d391e534a6bbb164"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-aarch64-apple-darwin.tar.gz"
+hash = "a11c56c67514373f602045c28cec9710253d52f587da288f8b29dbcf634711e7"
 
 [pkg.fuel-core.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.0/fuel-core-0.22.0-x86_64-apple-darwin.tar.gz"
-hash = "efb0f6dfb81a308691c0178ba2bcaa6c1141935bb4e6c100e1f67fb94579740f"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-x86_64-apple-darwin.tar.gz"
+hash = "769805e4c75d7f20adba3910593eb0a4b6026c71c9ba4342cc5c478ab6685070"
 
 [pkg.fuel-core-keygen]
-version = "0.22.0"
+version = "0.22.1"
 
 [pkg.fuel-core-keygen.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.0/fuel-core-0.22.0-aarch64-unknown-linux-gnu.tar.gz"
-hash = "48dfa260b737b6e8bb5a7a259bff3e39c689eaeabc9016e48628724a4f32c5ed"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-aarch64-unknown-linux-gnu.tar.gz"
+hash = "3edb985f71e0a0e937fbb985902eb8cb10a32a71d2c9f9e359fd2ffcebd24ffb"
 
 [pkg.fuel-core-keygen.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.0/fuel-core-0.22.0-x86_64-unknown-linux-gnu.tar.gz"
-hash = "8c6e982d0e656fa1eae1d8fced99ef17837a301d9b6170d5cedf386782c96d3a"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-x86_64-unknown-linux-gnu.tar.gz"
+hash = "88254295557b4ec230265a983be5f8505209e94ac70f9a3e6b76d9963e583b2b"
 
 [pkg.fuel-core-keygen.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.0/fuel-core-0.22.0-aarch64-apple-darwin.tar.gz"
-hash = "92a1880a4abc3320f7876a32dc79ab37cd34806fad084eb3d391e534a6bbb164"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-aarch64-apple-darwin.tar.gz"
+hash = "a11c56c67514373f602045c28cec9710253d52f587da288f8b29dbcf634711e7"
 
 [pkg.fuel-core-keygen.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.0/fuel-core-0.22.0-x86_64-apple-darwin.tar.gz"
-hash = "efb0f6dfb81a308691c0178ba2bcaa6c1141935bb4e6c100e1f67fb94579740f"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-x86_64-apple-darwin.tar.gz"
+hash = "769805e4c75d7f20adba3910593eb0a4b6026c71c9ba4342cc5c478ab6685070"


### PR DESCRIPTION
Bumps fuel-core version to 0.22.1 in beta-5 channel (from 0.22.0)