### PR TITLE
chore: apply new clippy lints with rust v1.77.0

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -50,7 +50,7 @@ impl Component {
             .component
             .get(name)
             .ok_or_else(|| anyhow!("component with name '{}' does not exist", name))
-            .map(|c| c.clone())
+            .cloned()
     }
 
     pub fn is_default_forc_plugin(name: &str) -> bool {

--- a/src/download.rs
+++ b/src/download.rs
@@ -204,7 +204,11 @@ pub fn download_file(url: &str, path: &PathBuf) -> Result<()> {
 
     let handle = build_agent()?;
 
-    let mut file = OpenOptions::new().write(true).create(true).open(path)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
 
     for _ in 1..RETRY_ATTEMPTS {
         match handle.get(url).call() {

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -171,6 +171,7 @@ fn create_fuel_executable(exe_name: &str, path: &Path, version: &Version) -> std
 
     let mut exe = fs::OpenOptions::new()
         .create(true)
+        .truncate(true)
         .write(true)
         .mode(0o770)
         .open(path)?;


### PR DESCRIPTION
Applies rust v1.77.0 clippy lints to the repo.