### PR TITLE
chore: bump beta-5 fuel-core to 0.22.4

### DIFF
--- a/channel-fuel-beta-5.toml
+++ b/channel-fuel-beta-5.toml
@@ -1,4 +1,4 @@
-date = "2024-03-08"
+date = "2024-04-04"
 
 [pkg.forc]
 version = "0.49.3"
@@ -58,39 +58,39 @@ url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.4.3/forc-wal
 hash = "944dbd922999ea4dbf1f8a9828c72200ec088e3c05b86e5dcf2b88633275b922"
 
 [pkg.fuel-core]
-version = "0.22.1"
+version = "0.22.4"
 
 [pkg.fuel-core.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-aarch64-unknown-linux-gnu.tar.gz"
-hash = "3edb985f71e0a0e937fbb985902eb8cb10a32a71d2c9f9e359fd2ffcebd24ffb"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.4/fuel-core-0.22.4-aarch64-unknown-linux-gnu.tar.gz"
+hash = "747f35ff3f6d87c4795c534fefde2d31c7b62010b576f77486a4b0b004255674"
 
 [pkg.fuel-core.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-x86_64-unknown-linux-gnu.tar.gz"
-hash = "88254295557b4ec230265a983be5f8505209e94ac70f9a3e6b76d9963e583b2b"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.4/fuel-core-0.22.4-x86_64-unknown-linux-gnu.tar.gz"
+hash = "ab38a4a023bcedb05f9ccd1a6d3d7d9d2a48e96e19dd1549d3a4447c7f88866d"
 
 [pkg.fuel-core.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-aarch64-apple-darwin.tar.gz"
-hash = "a11c56c67514373f602045c28cec9710253d52f587da288f8b29dbcf634711e7"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.4/fuel-core-0.22.4-aarch64-apple-darwin.tar.gz"
+hash = "1aa643f0ec7c90fc9df881f87e76dbca9c066d5d61584dc1c376f44082bd4fa6"
 
 [pkg.fuel-core.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-x86_64-apple-darwin.tar.gz"
-hash = "769805e4c75d7f20adba3910593eb0a4b6026c71c9ba4342cc5c478ab6685070"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.4/fuel-core-0.22.4-x86_64-apple-darwin.tar.gz"
+hash = "aa6d4cd8147a075b3b274ca38c6818c5d83185481323eb1671247838f66f4d7f"
 
 [pkg.fuel-core-keygen]
-version = "0.22.1"
+version = "0.22.4"
 
 [pkg.fuel-core-keygen.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-aarch64-unknown-linux-gnu.tar.gz"
-hash = "3edb985f71e0a0e937fbb985902eb8cb10a32a71d2c9f9e359fd2ffcebd24ffb"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.4/fuel-core-0.22.4-aarch64-unknown-linux-gnu.tar.gz"
+hash = "747f35ff3f6d87c4795c534fefde2d31c7b62010b576f77486a4b0b004255674"
 
 [pkg.fuel-core-keygen.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-x86_64-unknown-linux-gnu.tar.gz"
-hash = "88254295557b4ec230265a983be5f8505209e94ac70f9a3e6b76d9963e583b2b"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.4/fuel-core-0.22.4-x86_64-unknown-linux-gnu.tar.gz"
+hash = "ab38a4a023bcedb05f9ccd1a6d3d7d9d2a48e96e19dd1549d3a4447c7f88866d"
 
 [pkg.fuel-core-keygen.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-aarch64-apple-darwin.tar.gz"
-hash = "a11c56c67514373f602045c28cec9710253d52f587da288f8b29dbcf634711e7"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.4/fuel-core-0.22.4-aarch64-apple-darwin.tar.gz"
+hash = "1aa643f0ec7c90fc9df881f87e76dbca9c066d5d61584dc1c376f44082bd4fa6"
 
 [pkg.fuel-core-keygen.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.1/fuel-core-0.22.1-x86_64-apple-darwin.tar.gz"
-hash = "769805e4c75d7f20adba3910593eb0a4b6026c71c9ba4342cc5c478ab6685070"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.22.4/fuel-core-0.22.4-x86_64-apple-darwin.tar.gz"
+hash = "aa6d4cd8147a075b3b274ca38c6818c5d83185481323eb1671247838f66f4d7f"


### PR DESCRIPTION
bumps fuel-core version to 0.22.4 for beta-5 channel.