### PR TITLE
feat: add preview reserved channel

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -2,7 +2,8 @@ use crate::{
     constants::{
         CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_BETA_3_FILE_NAME,
         CHANNEL_BETA_4_FILE_NAME, CHANNEL_BETA_5_FILE_NAME, CHANNEL_LATEST_FILE_NAME,
-        CHANNEL_NIGHTLY_FILE_NAME, DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
+        CHANNEL_NIGHTLY_FILE_NAME, CHANNEL_PREVIEW_FILE_NAME, DATE_FORMAT_URL_FRIENDLY,
+        FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -23,8 +24,11 @@ pub const BETA_2: &str = "beta-2";
 pub const BETA_3: &str = "beta-3";
 pub const BETA_4: &str = "beta-4";
 pub const BETA_5: &str = "beta-5";
+pub const PREVIEW: &str = "preview";
 pub const NIGHTLY: &str = "nightly";
-pub const CHANNELS: [&str; 7] = [LATEST, NIGHTLY, BETA_1, BETA_2, BETA_3, BETA_4, BETA_5];
+pub const CHANNELS: [&str; 8] = [
+    LATEST, NIGHTLY, BETA_1, BETA_2, BETA_3, BETA_4, BETA_5, PREVIEW,
+];
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HashedBinary {
@@ -45,7 +49,12 @@ pub struct Package {
 }
 
 pub fn is_beta_toolchain(name: &str) -> bool {
-    name == BETA_1 || name == BETA_2 || name == BETA_3 || name == BETA_4 || name == BETA_5
+    name == BETA_1
+        || name == BETA_2
+        || name == BETA_3
+        || name == BETA_4
+        || name == BETA_5
+        || name == PREVIEW
 }
 
 fn format_nightly_url(date: &Date) -> Result<String> {
@@ -78,6 +87,7 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
         DistToolchainName::Beta3 => url.push_str(CHANNEL_BETA_3_FILE_NAME),
         DistToolchainName::Beta4 => url.push_str(CHANNEL_BETA_4_FILE_NAME),
         DistToolchainName::Beta5 => url.push_str(CHANNEL_BETA_5_FILE_NAME),
+        DistToolchainName::Preview => url.push_str(CHANNEL_PREVIEW_FILE_NAME),
     };
 
     Ok(url)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,6 +13,7 @@ pub const CHANNEL_BETA_2_FILE_NAME: &str = "channel-fuel-beta-2.toml";
 pub const CHANNEL_BETA_3_FILE_NAME: &str = "channel-fuel-beta-3.toml";
 pub const CHANNEL_BETA_4_FILE_NAME: &str = "channel-fuel-beta-4.toml";
 pub const CHANNEL_BETA_5_FILE_NAME: &str = "channel-fuel-beta-5.toml";
+pub const CHANNEL_PREVIEW_FILE_NAME: &str = "channel-fuel-preview.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -28,6 +28,7 @@ pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::BETA_4,
     channel::BETA_5,
     channel::NIGHTLY,
+    channel::PREVIEW,
     // Stable is reserved, although currently unused.
     channel::STABLE,
 ];
@@ -41,6 +42,7 @@ pub enum DistToolchainName {
     Beta5,
     Latest,
     Nightly,
+    Preview,
 }
 
 impl fmt::Display for DistToolchainName {
@@ -53,6 +55,7 @@ impl fmt::Display for DistToolchainName {
             DistToolchainName::Beta3 => write!(f, "{}", channel::BETA_3),
             DistToolchainName::Beta4 => write!(f, "{}", channel::BETA_4),
             DistToolchainName::Beta5 => write!(f, "{}", channel::BETA_5),
+            DistToolchainName::Preview => write!(f, "{}", channel::PREVIEW),
         }
     }
 }
@@ -68,6 +71,7 @@ impl FromStr for DistToolchainName {
             channel::BETA_3 => Ok(Self::Beta3),
             channel::BETA_4 => Ok(Self::Beta4),
             channel::BETA_5 => Ok(Self::Beta5),
+            channel::PREVIEW => Ok(Self::Preview),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }


### PR DESCRIPTION
adds a `preview` channel for distributing internal channels.