### PR TITLE
fix: fuelup self update should not update if current bin version is higher

### DIFF
--- a/src/ops/fuelup_self.rs
+++ b/src/ops/fuelup_self.rs
@@ -113,8 +113,9 @@ pub fn self_update(force: bool) -> Result<()> {
     )?;
 
     let fuelup_bin = fuelup_bin();
+    let fuelup_version = get_bin_version(&fuelup_bin).ok();
 
-    if !force && get_bin_version(&fuelup_bin).ok() == Some(download_cfg.version.clone()) {
+    if !force && fuelup_version >= Some(download_cfg.version.clone()) {
         info!(
             "Already up to date (fuelup v{})",
             download_cfg.version.to_string()


### PR DESCRIPTION
Currently fuelup self update does only check for equality between the latest released version and current bin version for omitting updates. But this breaks release procedure because once fuelup version is bumped, fuelup self update tries to downgrade itself as latest released version and current version is not equal. This blocks #603 