### PR TITLE
chore: bump to v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "ansi_term",
  "ansiterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Bumps fuelup to 0.23.0. This is a major, as #609 is breaking.