### PR TITLE
feat: add `testnet` reserved channel

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -2,8 +2,8 @@ use crate::{
     constants::{
         CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_BETA_3_FILE_NAME,
         CHANNEL_BETA_4_FILE_NAME, CHANNEL_BETA_5_FILE_NAME, CHANNEL_DEVNET_FILE_NAME,
-        CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME, DATE_FORMAT_URL_FRIENDLY,
-        FUELUP_GH_PAGES,
+        CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME, CHANNEL_TESTNET_FILE_NAME,
+        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -25,9 +25,11 @@ pub const BETA_3: &str = "beta-3";
 pub const BETA_4: &str = "beta-4";
 pub const BETA_5: &str = "beta-5";
 pub const DEVNET: &str = "devnet";
+pub const TESTNET: &str = "testnet";
 pub const NIGHTLY: &str = "nightly";
-pub const CHANNELS: [&str; 8] = [
-    LATEST, NIGHTLY, BETA_1, BETA_2, BETA_3, BETA_4, BETA_5, DEVNET,
+
+pub const CHANNELS: [&str; 9] = [
+    LATEST, NIGHTLY, BETA_1, BETA_2, BETA_3, BETA_4, BETA_5, DEVNET, TESTNET,
 ];
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -55,6 +57,7 @@ pub fn is_beta_toolchain(name: &str) -> bool {
         || name == BETA_4
         || name == BETA_5
         || name == DEVNET
+        || name == TESTNET
 }
 
 fn format_nightly_url(date: &Date) -> Result<String> {
@@ -88,6 +91,7 @@ fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
         DistToolchainName::Beta4 => url.push_str(CHANNEL_BETA_4_FILE_NAME),
         DistToolchainName::Beta5 => url.push_str(CHANNEL_BETA_5_FILE_NAME),
         DistToolchainName::Devnet => url.push_str(CHANNEL_DEVNET_FILE_NAME),
+        DistToolchainName::Testnet => url.push_str(CHANNEL_TESTNET_FILE_NAME),
     };
 
     Ok(url)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -14,6 +14,7 @@ pub const CHANNEL_BETA_3_FILE_NAME: &str = "channel-fuel-beta-3.toml";
 pub const CHANNEL_BETA_4_FILE_NAME: &str = "channel-fuel-beta-4.toml";
 pub const CHANNEL_BETA_5_FILE_NAME: &str = "channel-fuel-beta-5.toml";
 pub const CHANNEL_DEVNET_FILE_NAME: &str = "channel-fuel-devnet.toml";
+pub const CHANNEL_TESTNET_FILE_NAME: &str = "channel-fuel-testnet.toml";
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -43,6 +43,7 @@ pub enum DistToolchainName {
     Latest,
     Nightly,
     Devnet,
+    Testnet,
 }
 
 impl fmt::Display for DistToolchainName {
@@ -56,6 +57,7 @@ impl fmt::Display for DistToolchainName {
             DistToolchainName::Beta4 => write!(f, "{}", channel::BETA_4),
             DistToolchainName::Beta5 => write!(f, "{}", channel::BETA_5),
             DistToolchainName::Devnet => write!(f, "{}", channel::DEVNET),
+            DistToolchainName::Testnet => write!(f, "{}", channel::TESTNET),
         }
     }
 }
@@ -72,6 +74,7 @@ impl FromStr for DistToolchainName {
             channel::BETA_4 => Ok(Self::Beta4),
             channel::BETA_5 => Ok(Self::Beta5),
             channel::DEVNET => Ok(Self::Devnet),
+            channel::TESTNET => Ok(Self::Testnet),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }


### PR DESCRIPTION
Adds `testnet` reserved channel which points to `channel-fuel-testnet.toml` on gh-pages of this repo.