### PR TITLE
chore: bump to v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "ansi_term",
  "ansiterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Releases v0.24.0 to get #612 released.