### PR TITLE
chore: Update github name and email for CI

### DIFF
--- a/.github/workflows/gh-pages-meta.yml
+++ b/.github/workflows/gh-pages-meta.yml
@@ -36,6 +36,8 @@ jobs:
           keep_files: true
           publish_dir: ${{ env.FUELUP_INIT_DIR }}
           destination_dir: ./
+          user_name: 'fuel-service-user'
+          user_email: 'fuel-service-user@users.noreply.github.com'
 
       - name: Get latest tag and copy into fuelup-version
         run: |
@@ -53,3 +55,5 @@ jobs:
           keep_files: true
           publish_dir: ${{ env.FUELUP_VERSION_DIR }}
           destination_dir: ./
+          user_name: 'fuel-service-user'
+          user_email: 'fuel-service-user@users.noreply.github.com'

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,6 +27,8 @@ jobs:
           publish_dir: ./docs/book
           destination_dir: master
           cname: install.fuel.network
+          user_name: 'fuel-service-user'
+          user_email: 'fuel-service-user@users.noreply.github.com'
         if: github.ref == 'refs/heads/master'
 
       - name: Get tag
@@ -42,6 +44,8 @@ jobs:
           publish_dir: ./docs/book
           destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}
           cname: install.fuel.network
+          user_name: 'fuel-service-user'
+          user_email: 'fuel-service-user@users.noreply.github.com'
         if: startsWith(github.ref, 'refs/tags')
 
       - name: Create latest HTML redirect file
@@ -62,4 +66,6 @@ jobs:
           publish_dir: ./latest/
           destination_dir: ./latest/
           cname: install.fuel.network
+          user_name: 'fuel-service-user'
+          user_email: 'fuel-service-user@users.noreply.github.com'
         if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/publish-nightly-channel.yml
+++ b/.github/workflows/publish-nightly-channel.yml
@@ -45,6 +45,8 @@ jobs:
           publish_dir: ${{ env.NIGHTLY_CHANNEL_DIR }}
           keep_files: true
           destination_dir: ./
+          user_name: 'fuel-service-user'
+          user_email: 'fuel-service-user@users.noreply.github.com'
 
       - name: Deploy nightly channel (archive)
         uses: peaceiris/actions-gh-pages@v3
@@ -53,6 +55,8 @@ jobs:
           publish_dir: ${{ env.NIGHTLY_CHANNEL_DIR }}
           keep_files: true
           destination_dir: ${{ steps.setup.outputs.archive_dir }}
+          user_name: 'fuel-service-user'
+          user_email: 'fuel-service-user@users.noreply.github.com'
 
       - name: Notify if Job Fails
         uses: ravsamhq/notify-slack-action@v1


### PR DESCRIPTION
After https://github.com/FuelLabs/fuelup/pull/615, the commit author is not showing correctly. It should now be the fuel-service-user.