### PR TITLE
feat: add upgrade command to auto update fuelup, switch to latest and update installed channels

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,3 +6,4 @@ pub mod fuelup;
 pub mod show;
 pub mod toolchain;
 pub mod update;
+pub mod upgrade;

--- a/src/commands/upgrade.rs
+++ b/src/commands/upgrade.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use clap::Parser;
+
+use crate::ops::fuelup_upgrade;
+
+#[derive(Debug, Parser)]
+pub struct UpgradeCommand {
+    #[clap(long, short)]
+    pub force: bool,
+}
+
+pub fn exec(force: bool) -> Result<()> {
+    fuelup_upgrade::upgrade(force)?;
+
+    Ok(())
+}

--- a/src/fuelup_cli.rs
+++ b/src/fuelup_cli.rs
@@ -43,7 +43,7 @@ enum Commands {
     Show(ShowCommand),
     /// Updates the distributable toolchains, if already installed
     Update(UpdateCommand),
-    /// Update fuelup itself to latest, switches to latest channel and checks for updates for the components.
+    /// Updates fuelup itself, switches to the `latest` channel and updates components in all channels.
     Upgrade(UpgradeCommand),
 }
 

--- a/src/fuelup_cli.rs
+++ b/src/fuelup_cli.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::commands::show::ShowCommand;
-use crate::commands::{check, completions, component, default, fuelup, show, toolchain, update};
+use crate::commands::{
+    check, completions, component, default, fuelup, show, toolchain, update, upgrade,
+};
 
 use crate::commands::check::CheckCommand;
 use crate::commands::completions::CompletionsCommand;
@@ -11,6 +13,7 @@ use crate::commands::default::DefaultCommand;
 use crate::commands::fuelup::FuelupCommand;
 use crate::commands::toolchain::ToolchainCommand;
 use crate::commands::update::UpdateCommand;
+use crate::commands::upgrade::UpgradeCommand;
 
 #[derive(Debug, Parser)]
 #[clap(name = "fuelup", about = "Fuel Toolchain Manager", version)]
@@ -40,6 +43,8 @@ enum Commands {
     Show(ShowCommand),
     /// Updates the distributable toolchains, if already installed
     Update(UpdateCommand),
+    /// Update fuelup itself to latest, switches to latest channel and checks for updates for the components.
+    Upgrade(UpgradeCommand),
 }
 
 pub fn fuelup_cli() -> Result<()> {
@@ -57,5 +62,6 @@ pub fn fuelup_cli() -> Result<()> {
         Commands::Show(_command) => show::exec(),
         Commands::Toolchain(command) => toolchain::exec(command),
         Commands::Update(_command) => update::exec(),
+        Commands::Upgrade(command) => upgrade::exec(command.force),
     }
 }

--- a/src/ops/fuelup_upgrade.rs
+++ b/src/ops/fuelup_upgrade.rs
@@ -7,7 +7,7 @@ pub fn upgrade(force: bool) -> Result<()> {
     fuelup_self::self_update(force)?;
     // switch to 'latest' channel.
     fuelup_default::default(Some(LATEST.to_owned()))?;
-    // update channel
+    // update channels
     fuelup_update::update()?;
     Ok(())
 }

--- a/src/ops/fuelup_upgrade.rs
+++ b/src/ops/fuelup_upgrade.rs
@@ -1,0 +1,13 @@
+use super::{fuelup_default, fuelup_self, fuelup_update};
+use crate::channel::LATEST;
+use anyhow::Result;
+
+pub fn upgrade(force: bool) -> Result<()> {
+    // self update
+    fuelup_self::self_update(force)?;
+    // switch to 'latest' channel.
+    fuelup_default::default(Some(LATEST.to_owned()))?;
+    // update channel
+    fuelup_update::update()?;
+    Ok(())
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -6,3 +6,4 @@ pub mod fuelup_self;
 pub mod fuelup_show;
 pub mod fuelup_toolchain;
 pub mod fuelup_update;
+pub mod fuelup_upgrade;

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+use testcfg::FuelupState;
+
+pub mod testcfg;
+
+#[test]
+fn fuelup_upgrade() -> Result<()> {
+    testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
+        let output = cfg.fuelup(&["upgrade"]);
+        let expected_stdout_starts_with = "Already up to date";
+        assert!(output.stdout.contains(expected_stdout_starts_with));
+    })?;
+
+    Ok(())
+}


### PR DESCRIPTION
Adds `fuelup upgrade` command which executes:

1. Updates fuelup itself (`fuelup self update`)
2. Switches to latest channel (`fuelup default latest`)
3. Updates fuelup channels (`fuelup update`)