### PR TITLE
chore: Add indexing_slicing lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,6 @@ members = ["component", "ci/build-channel", "ci/compare-versions"]
 [dev-dependencies]
 chrono = "0.4.33"
 strip-ansi-escapes = "0.2.0"
+
+[lints.clippy]
+indexing_slicing = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, allow(clippy::indexing_slicing))]
+
 pub mod channel;
 pub mod commands;
 pub mod config;

--- a/src/ops/fuelup_check.rs
+++ b/src/ops/fuelup_check.rs
@@ -9,7 +9,7 @@ use crate::{
     toolchain::{DistToolchainDescription, Toolchain},
 };
 use ansiterm::Color;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use component::{self, Components};
 use semver::Version;
 use std::collections::HashMap;
@@ -114,7 +114,10 @@ fn check_toolchain(toolchain: &str, verbose: bool) -> Result<()> {
 
                         if !plugin.is_main_executable() {
                             print!("{:>2}", "");
-                            plugin_name = &plugin.executables[index];
+                            plugin_name = plugin
+                                .executables
+                                .get(index)
+                                .ok_or_else(|| anyhow!("Plugin name not found"))?;
                         }
 
                         let maybe_latest_version = plugin.publish.map_or_else(

--- a/src/proxy_cli.rs
+++ b/src/proxy_cli.rs
@@ -18,10 +18,10 @@ pub fn proxy_run(arg0: &str) -> Result<ExitCode> {
     let cmd_args: Vec<_> = env::args_os().skip(1).collect();
     let toolchain = Toolchain::from_settings()?;
 
-    if !cmd_args.is_empty() {
-        let plugin = format!("{}-{}", arg0, &cmd_args[0].to_string_lossy());
+    if let Some(first_arg) = cmd_args.first() {
+        let plugin = format!("{}-{}", arg0, first_arg.to_string_lossy());
         if Components::collect_plugin_executables()?.contains(&plugin) {
-            direct_proxy(&plugin, &cmd_args[1..], &toolchain)?;
+            direct_proxy(&plugin, cmd_args.get(1..).unwrap_or_default(), &toolchain)?;
         }
     }
 

--- a/src/toolchain_override.rs
+++ b/src/toolchain_override.rs
@@ -118,6 +118,7 @@ impl ToolchainOverride {
         Ok(Self { cfg, path })
     }
 
+    #[allow(clippy::indexing_slicing)]
     pub fn to_toml(&self) -> Document {
         let mut document = toml_edit::Document::new();
 


### PR DESCRIPTION
Closes https://github.com/FuelLabs/fuelup/issues/636

Adds `clippy::indexing_slicing`, updates the code to remove instances of index slicing, and adds some unit tests for the functions that were significantly refactored.