### PR TITLE
remove forc explore

### DIFF
--- a/components.toml
+++ b/components.toml
@@ -55,15 +55,6 @@ executables = ["forc-deploy", "forc-run"]
 repository_name = "sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 
-[component.forc-explore]
-name = "forc-explore"
-tarball_prefix = "forc-explore"
-is_plugin = true
-executables = ["forc-explore"]
-repository_name = "forc-explorer"
-targets = [ "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "aarch64-apple-darwin", "x86_64-apple-darwin" ]
-publish = true
-
 [component.forc-tx]
 name = "forc-tx"
 tarball_prefix = "forc-binaries"

--- a/docs/src/concepts/components.md
+++ b/docs/src/concepts/components.md
@@ -23,7 +23,6 @@ The following is an overview of components installable through `fuelup`:
 - [`forc`] — The Fuel Orchestrator, a suite of tools to work with the Fuel ecosystem. This comes
 with some built-in plugin executables, including but not limited to: [`forc-client`], [`forc-fmt`] and [`forc-lsp`].
 - [`fuel-core`] — Full node implementation of the Fuel v2 protocol, written in Rust.
-- [`forc-explore`] — A Forc plugin for running the Fuel Block Explorer.
 - [`forc-crypto`] — A Forc plugin for hashing arbitrary data.
 - [`forc-debug`] — A Forc plugin for debugging via CLI and IDE.
 - [`forc-wallet`] - A Forc plugin for managing Fuel wallets.
@@ -33,7 +32,6 @@ with some built-in plugin executables, including but not limited to: [`forc-clie
 [toolchain]: toolchains.md
 [`forc`]: https://fuellabs.github.io/sway/master/book/forc/index.html
 [`fuel-core`]: https://github.com/FuelLabs/fuel-core
-[`forc-explore`]: https://fuellabs.github.io/sway/master/book/forc/plugins/forc_explore.html
 [`forc-fmt`]: https://fuellabs.github.io/sway/master/book/forc/plugins/forc_fmt.html
 [`forc-crypto`]: https://fuellabs.github.io/sway/master/book/forc/plugins/forc_crypto.html
 [`forc-debug`]: https://fuellabs.github.io/sway/master/book/forc/plugins/forc_debug.html

--- a/fuelup-init.sh
+++ b/fuelup-init.sh
@@ -13,7 +13,6 @@ main() {
 
     check_cargo_bin forc
     check_cargo_bin forc-fmt
-    check_cargo_bin forc-explore
     check_cargo_bin forc-lsp
     check_cargo_bin fuel-core
 

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -39,7 +39,6 @@ fn fuelup_show_latest() -> Result<()> {
                 - forc-crypto : 0.1.0
                 - forc-debug : 0.1.0
                 - forc-doc : 0.1.0
-                - forc-explore : 0.1.0
                 - forc-fmt : 0.1.0
                 - forc-lsp : 0.1.0
                 - forc-tx : 0.1.0
@@ -82,7 +81,6 @@ fn fuelup_show_and_switch() -> Result<()> {
                 - forc-crypto : 0.1.0
                 - forc-debug : 0.1.0
                 - forc-doc : 0.1.0
-                - forc-explore : 0.1.0
                 - forc-fmt : 0.1.0
                 - forc-lsp : 0.1.0
                 - forc-tx : 0.1.0
@@ -118,7 +116,6 @@ fn fuelup_show_and_switch() -> Result<()> {
                 - forc-crypto : 0.2.0
                 - forc-debug : 0.2.0
                 - forc-doc : 0.2.0
-                - forc-explore : 0.2.0
                 - forc-fmt : 0.2.0
                 - forc-lsp : 0.2.0
                 - forc-tx : 0.2.0
@@ -160,7 +157,6 @@ fn fuelup_show_custom() -> Result<()> {
                 - forc-crypto : not found
                 - forc-debug : not found
                 - forc-doc : not found
-                - forc-explore : not found
                 - forc-fmt : not found
                 - forc-lsp : not found
                 - forc-tx : not found
@@ -200,7 +196,6 @@ fn fuelup_show_override() -> Result<()> {
                 - forc-crypto : not found
                 - forc-debug : not found
                 - forc-doc : not found
-                - forc-explore : not found
                 - forc-fmt : not found
                 - forc-lsp : not found
                 - forc-tx : not found
@@ -243,7 +238,6 @@ fn fuelup_show_latest_then_override() -> Result<()> {
                 - forc-crypto : 0.1.0
                 - forc-debug : 0.1.0
                 - forc-doc : 0.1.0
-                - forc-explore : 0.1.0
                 - forc-fmt : 0.1.0
                 - forc-lsp : 0.1.0
                 - forc-tx : 0.1.0
@@ -292,7 +286,6 @@ fn fuelup_show_latest_then_override() -> Result<()> {
                 - forc-crypto : 0.2.0
                 - forc-debug : 0.2.0
                 - forc-doc : 0.2.0
-                - forc-explore : 0.2.0
                 - forc-fmt : 0.2.0
                 - forc-lsp : 0.2.0
                 - forc-tx : 0.2.0

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -75,7 +75,6 @@ pub static ALL_BINS: &[&str] = &[
     "forc-debug",
     "forc-deploy",
     "forc-doc",
-    "forc-explore",
     "forc-fmt",
     "forc-index",
     "forc-lsp",
@@ -286,11 +285,6 @@ pub fn setup(state: FuelupState, f: &dyn Fn(&mut TestCfg)) -> Result<()> {
             )?;
             fs::create_dir_all(tmp_home.join(".cargo/bin"))?;
 
-            create_fuel_executable(
-                "forc-explore",
-                &tmp_home.join(".cargo/bin/forc-explore"),
-                VERSION,
-            )?;
             create_fuel_executable("fuel-core", &tmp_home.join(".cargo/bin/fuel-core"), VERSION)?;
 
             // Here we intentionally remove some of the 'binaries' that were linked in the

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -53,14 +53,6 @@ fn fuelup_update_conflict() -> Result<()> {
                 cfg.home.join(".fuelup/bin/forc-wallet").display(),
                 cfg.home.join(".local/bin/forc-wallet").display(),
             );
-        // 4) duplicate fuel executable found in PATH and in FUELUP_HOME and CARGO_HOME.
-        //    fuelup's version is overshadowed by the duplicate. `cargo uninstall` is a possible
-        //    action and therefore a suggestion by fuelup.
-        let has_duplicate_overshadow_cargo_uninstall_message = &format!("warning: 'forc-explore' found in PATH at {}. This will take precedence over 'forc-explore', already installed at {}. Consider uninstalling {}, or re-arranging your PATH to give fuelup priority. You may want to execute 'cargo uninstall forc-explore'.",
-                cfg.home.join(".cargo/bin/forc-explore").display(),
-                cfg.home.join(".fuelup/bin/forc-explore").display(),
-                cfg.home.join(".cargo/bin/forc-explore").display(),
-            );
 
         assert!(output.status.success());
         assert!(output.stdout.contains(has_duplicate_message));
@@ -68,9 +60,6 @@ fn fuelup_update_conflict() -> Result<()> {
             .stdout
             .contains(has_duplicate_cargo_uninstall_message));
         assert!(output.stdout.contains(has_duplicate_overshadow_message));
-        assert!(output
-            .stdout
-            .contains(has_duplicate_overshadow_cargo_uninstall_message));
     })?;
 
     Ok(())


### PR DESCRIPTION
[forc-explorer](https://github.com/FuelLabs/forc-explorer) has been archived so we are removing it from fuelup.