### PR TITLE
bump testnet to use fuel-core v0.31.0

### DIFF
--- a/channel-fuel-testnet.toml
+++ b/channel-fuel-testnet.toml
@@ -1,4 +1,4 @@
-date = "2024-07-04"
+date = "2024-07-08"
 
 [pkg.forc]
 version = "0.61.2"
@@ -39,39 +39,39 @@ url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.8.1/forc-wal
 hash = "5f6e0de39fe684bf08fb666a18322a5927de823efed02b36707b7368c67626c2"
 
 [pkg.fuel-core]
-version = "0.30.0"
+version = "0.31.0"
 
 [pkg.fuel-core.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.30.0/fuel-core-0.30.0-aarch64-unknown-linux-gnu.tar.gz"
-hash = "5b3b324a10a839c0ffc88ebd150b797dcbb426f6d698086f86a62f6d72a61b45"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.31.0/fuel-core-0.31.0-aarch64-unknown-linux-gnu.tar.gz"
+hash = "3ab362150b52d0db144cd8acddde4f375215a6863c1d61b02c54973899d382a5"
 
 [pkg.fuel-core.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.30.0/fuel-core-0.30.0-x86_64-unknown-linux-gnu.tar.gz"
-hash = "f36eb2cc69500bd98df0911cfeda02364d9483b20d9d1559161171a5602a8534"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.31.0/fuel-core-0.31.0-x86_64-unknown-linux-gnu.tar.gz"
+hash = "d75d1b5ebd3327bae6fea373fbd2d9c4b75027cbaea888430fbfdac43fbbe1b1"
 
 [pkg.fuel-core.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.30.0/fuel-core-0.30.0-aarch64-apple-darwin.tar.gz"
-hash = "48b6bb90dc62bee968e13f1deb32daad90a9f787aea39acfe020c9ff260466e7"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.31.0/fuel-core-0.31.0-aarch64-apple-darwin.tar.gz"
+hash = "e1cc9fdfaf07efdfb54790132deeb5fba356de4c8512061edc1e9c681ec3b838"
 
 [pkg.fuel-core.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.30.0/fuel-core-0.30.0-x86_64-apple-darwin.tar.gz"
-hash = "8d709a6128f2e6ab25d9f9d62fe97183640428586a4539b9aa2a4c0c1a259eba"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.31.0/fuel-core-0.31.0-x86_64-apple-darwin.tar.gz"
+hash = "ea8c2dd45b216005751cb4030ace2da37a81044d732f3b07402a242c072f4417"
 
 [pkg.fuel-core-keygen]
-version = "0.30.0"
+version = "0.31.0"
 
 [pkg.fuel-core-keygen.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.30.0/fuel-core-0.30.0-aarch64-unknown-linux-gnu.tar.gz"
-hash = "5b3b324a10a839c0ffc88ebd150b797dcbb426f6d698086f86a62f6d72a61b45"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.31.0/fuel-core-0.31.0-aarch64-unknown-linux-gnu.tar.gz"
+hash = "3ab362150b52d0db144cd8acddde4f375215a6863c1d61b02c54973899d382a5"
 
 [pkg.fuel-core-keygen.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.30.0/fuel-core-0.30.0-x86_64-unknown-linux-gnu.tar.gz"
-hash = "f36eb2cc69500bd98df0911cfeda02364d9483b20d9d1559161171a5602a8534"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.31.0/fuel-core-0.31.0-x86_64-unknown-linux-gnu.tar.gz"
+hash = "d75d1b5ebd3327bae6fea373fbd2d9c4b75027cbaea888430fbfdac43fbbe1b1"
 
 [pkg.fuel-core-keygen.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.30.0/fuel-core-0.30.0-aarch64-apple-darwin.tar.gz"
-hash = "48b6bb90dc62bee968e13f1deb32daad90a9f787aea39acfe020c9ff260466e7"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.31.0/fuel-core-0.31.0-aarch64-apple-darwin.tar.gz"
+hash = "e1cc9fdfaf07efdfb54790132deeb5fba356de4c8512061edc1e9c681ec3b838"
 
 [pkg.fuel-core-keygen.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.30.0/fuel-core-0.30.0-x86_64-apple-darwin.tar.gz"
-hash = "8d709a6128f2e6ab25d9f9d62fe97183640428586a4539b9aa2a4c0c1a259eba"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.31.0/fuel-core-0.31.0-x86_64-apple-darwin.tar.gz"
+hash = "ea8c2dd45b216005751cb4030ace2da37a81044d732f3b07402a242c072f4417"


### PR DESCRIPTION
follows on from the 0.30 patch @kayagokalp did in #646 
