### PR TITLE
chore: bump to v0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "ansi_term",
  "ansiterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
waiting on #647

major version as #644 was breaking. 