### PR TITLE
Prompt user to install the override toolchain if its specified but not installed yet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "chrono",
  "clap 3.2.25",
  "component",
+ "fuelup",
  "once_cell",
  "semver",
  "serde",
@@ -313,6 +314,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "component",
+ "fuelup",
  "semver",
  "serde",
  "serde_json",

--- a/ci/build-channel/Cargo.toml
+++ b/ci/build-channel/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1"
 chrono = "0.4"
 clap = { version = "3.2", features = ["cargo", "derive", "env"] }
 component = { path = "../../component" }
+fuelup = { path = "../../" }
 once_cell = "1.17.0"
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/ci/build-channel/src/main.rs
+++ b/ci/build-channel/src/main.rs
@@ -33,6 +33,7 @@
 use anyhow::{bail, Result};
 use clap::Parser;
 use component::{Component, Components};
+use fuelup::constants::GITHUB_API_ORG_URL;
 use once_cell::sync::Lazy;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -113,8 +114,8 @@ fn get_version(component: &Component) -> Result<Version> {
     let mut data = Vec::new();
 
     let url = format!(
-        "https://api.github.com/repos/FuelLabs/{}/releases/latest",
-        component.repository_name
+        "{}{}/releases/latest",
+        GITHUB_API_ORG_URL, component.repository_name
     );
 
     let resp = handle.get(&url).call()?;
@@ -152,8 +153,8 @@ This could result in incompatibility between forc and fuel-core."
 fn write_nightly_document(document: &mut Document, components: Vec<Component>) -> Result<()> {
     let mut data = Vec::new();
     let nightly_release_url = format!(
-        "https://api.github.com/repos/FuelLabs/sway-nightly-binaries/releases/tags/nightly-{}",
-        *TODAY
+        "{}{}/releases/tags/nightly-{}",
+        GITHUB_API_ORG_URL, "sway-nightly-binaries", *TODAY
     );
 
     let resp = ureq::get(&nightly_release_url).call()?;

--- a/ci/compare-versions/Cargo.toml
+++ b/ci/compare-versions/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1" 
 component = { path = "../../component" }
+fuelup = { path = "../../" }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,9 +1,9 @@
 use crate::{
     constants::{
-        CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME, CHANNEL_BETA_3_FILE_NAME,
-        CHANNEL_BETA_4_FILE_NAME, CHANNEL_BETA_5_FILE_NAME, CHANNEL_DEVNET_FILE_NAME,
-        CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME, CHANNEL_TESTNET_FILE_NAME,
-        DATE_FORMAT_URL_FRIENDLY, FUELUP_GH_PAGES,
+        BETA_CHANNELS, CHANNEL_BETA_1_FILE_NAME, CHANNEL_BETA_2_FILE_NAME,
+        CHANNEL_BETA_3_FILE_NAME, CHANNEL_BETA_4_FILE_NAME, CHANNEL_BETA_5_FILE_NAME,
+        CHANNEL_DEVNET_FILE_NAME, CHANNEL_LATEST_FILE_NAME, CHANNEL_NIGHTLY_FILE_NAME,
+        CHANNEL_TESTNET_FILE_NAME, DATE_FORMAT_URL_FRIENDLY, GITHUB_USER_CONTENT_URL,
     },
     download::{download, DownloadCfg},
     toolchain::{DistToolchainDescription, DistToolchainName},
@@ -16,21 +16,6 @@ use std::{collections::BTreeMap, fmt::Debug};
 use time::Date;
 use toml_edit::de;
 use tracing::warn;
-
-pub const LATEST: &str = "latest";
-pub const STABLE: &str = "stable";
-pub const BETA_1: &str = "beta-1";
-pub const BETA_2: &str = "beta-2";
-pub const BETA_3: &str = "beta-3";
-pub const BETA_4: &str = "beta-4";
-pub const BETA_5: &str = "beta-5";
-pub const DEVNET: &str = "devnet";
-pub const TESTNET: &str = "testnet";
-pub const NIGHTLY: &str = "nightly";
-
-pub const CHANNELS: [&str; 9] = [
-    LATEST, NIGHTLY, BETA_1, BETA_2, BETA_3, BETA_4, BETA_5, DEVNET, TESTNET,
-];
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HashedBinary {
@@ -68,7 +53,7 @@ fn format_nightly_url(date: &Date) -> Result<String> {
 }
 
 fn construct_channel_url(desc: &DistToolchainDescription) -> Result<String> {
-    let mut url = FUELUP_GH_PAGES.to_owned();
+    let mut url = format!("{}{}/gh-pages/", GITHUB_USER_CONTENT_URL, "fuelup");
     match desc.name {
         DistToolchainName::Latest => {
             if let Some(date) = desc.date {
@@ -136,7 +121,7 @@ If this component should be downloadable, try running `fuelup self update` and r
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{download::DownloadCfg, file::read_file};
+    use crate::{constants::CHANNELS, download::DownloadCfg, file::read_file};
 
     #[test]
     fn channel_from_toml() {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -35,14 +35,11 @@ pub struct Package {
     pub fuels_version: Option<String>,
 }
 
-pub fn is_beta_toolchain(name: &str) -> bool {
-    name == BETA_1
-        || name == BETA_2
-        || name == BETA_3
-        || name == BETA_4
-        || name == BETA_5
-        || name == DEVNET
-        || name == TESTNET
+pub fn is_beta_toolchain(name: &str) -> Option<&str> {
+    BETA_CHANNELS
+        .iter()
+        .find(|&beta_channel| name.starts_with(beta_channel))
+        .copied()
 }
 
 fn format_nightly_url(date: &Date) -> Result<String> {
@@ -230,5 +227,15 @@ mod tests {
         assert_eq!(cfgs[0].version, Version::parse("0.17.0").unwrap());
         assert_eq!(cfgs[1].name, "fuel-core");
         assert_eq!(cfgs[1].version, Version::parse("0.9.4").unwrap());
+    }
+
+    #[test]
+    fn test_all_channels_for_beta() {
+        for channel in CHANNELS.iter() {
+            assert_eq!(
+                is_beta_toolchain(channel).is_some(),
+                BETA_CHANNELS.contains(channel)
+            );
+        }
     }
 }

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -1,6 +1,6 @@
+use crate::constants::CHANNELS;
 use crate::ops::fuelup_toolchain::{install::install, new::new, uninstall::uninstall};
 use crate::target_triple::TargetTriple;
-use crate::toolchain::RESERVED_TOOLCHAIN_NAMES;
 use anyhow::{bail, Result};
 use clap::Parser;
 
@@ -45,7 +45,7 @@ fn name_allowed(s: &str) -> Result<String> {
         None => s,
     };
 
-    if RESERVED_TOOLCHAIN_NAMES.contains(&name) {
+    if CHANNELS.contains(&name) {
         bail!(
             "Cannot use distributable toolchain name '{}' as a custom toolchain name",
             s

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
+use crate::constants::CHANNELS;
 use crate::fmt::format_toolchain_with_target;
 use crate::path::toolchains_dir;
-use crate::toolchain::RESERVED_TOOLCHAIN_NAMES;
 use anyhow::Result;
 use std::{fs, io, path::PathBuf};
 
@@ -25,7 +25,7 @@ impl Config {
                 .filter(|e| e.file_type().map(|f| f.is_dir()).unwrap_or(false))
             {
                 let toolchain = dir_entry.file_name().to_string_lossy().to_string();
-                if RESERVED_TOOLCHAIN_NAMES
+                if CHANNELS
                     .iter()
                     .any(|t| toolchain == format_toolchain_with_target(t))
                 {
@@ -54,7 +54,7 @@ impl Config {
                 .map(|e| e.file_name().into_string().ok().unwrap_or_default())
                 .collect();
 
-            for name in RESERVED_TOOLCHAIN_NAMES {
+            for name in CHANNELS {
                 let dist_toolchain = format_toolchain_with_target(name);
                 if installed_toolchains.contains(&dist_toolchain) {
                     dist_toolchains.push(name.to_string());

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,11 +1,62 @@
 use time::{format_description::FormatItem, macros::format_description};
 
-pub const FUELUP_GH_PAGES: &str = "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/";
+// Channels
+
+pub const LATEST: &str = "latest";
+pub const NIGHTLY: &str = "nightly";
+pub const BETA_1: &str = "beta-1";
+pub const BETA_2: &str = "beta-2";
+pub const BETA_3: &str = "beta-3";
+pub const BETA_4: &str = "beta-4";
+pub const BETA_5: &str = "beta-5";
+pub const DEVNET: &str = "devnet";
+pub const TESTNET: &str = "testnet";
+// Stable is reserved, although currently unused.
+pub const STABLE: &str = "stable";
+
+pub const BETA_CHANNELS: [&str; 7] = [BETA_1, BETA_2, BETA_3, BETA_4, BETA_5, DEVNET, TESTNET];
+
+#[allow(clippy::indexing_slicing)]
+pub const fn generate_all_channels<const N: usize>() -> [&'static str; N] {
+    let mut channels = [""; N];
+
+    channels[0] = LATEST;
+    channels[1] = NIGHTLY;
+
+    let mut i = 0;
+
+    while i < BETA_CHANNELS.len() {
+        channels[2 + i] = BETA_CHANNELS[i];
+        i += 1;
+    }
+
+    channels
+}
+
+pub const CHANNELS: [&str; 9] = generate_all_channels::<9>();
+
+// URLs
+
+pub const GITHUB_API_ORG_URL: &str = "https://api.github.com/repos/FuelLabs/";
+pub const GITHUB_USER_CONTENT_URL: &str = "https://raw.githubusercontent.com/FuelLabs/";
+
+// NOTE: Although this variable is named "LATEST", it needs to point to
+// "testnet" until mainnet has launched. Once launched, we can then merge this
+// variable with the `CHANNEL_LATEST_URL_ACTUAL` variable
+pub const CHANNEL_LATEST_URL: &str =
+    "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-testnet.toml";
+
+// We need to point to the latest URL but we can't use `CHANNEL_LATEST_URL`
+// until mainnet has launched (as `CHANNEL_LATEST_URL` currently points to
+// testnet). So we dupilcate here for now and we can cleanup sometime later
+pub const CHANNEL_LATEST_URL_ACTUAL: &str =
+    "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-latest.toml";
+
+// Filenames
+
 pub const FUEL_TOOLCHAIN_TOML_FILE: &str = "fuel-toolchain.toml";
 pub const FUELS_VERSION_FILE: &str = "fuels_version";
 
-pub const CHANNEL_LATEST_URL: &str =
-    "https://raw.githubusercontent.com/FuelLabs/fuelup/gh-pages/channel-fuel-testnet.toml";
 pub const CHANNEL_LATEST_FILE_NAME: &str = "channel-fuel-testnet.toml";
 pub const CHANNEL_NIGHTLY_FILE_NAME: &str = "channel-fuel-nightly.toml";
 pub const CHANNEL_BETA_1_FILE_NAME: &str = "channel-fuel-beta-1.toml";
@@ -15,6 +66,8 @@ pub const CHANNEL_BETA_4_FILE_NAME: &str = "channel-fuel-beta-4.toml";
 pub const CHANNEL_BETA_5_FILE_NAME: &str = "channel-fuel-beta-5.toml";
 pub const CHANNEL_DEVNET_FILE_NAME: &str = "channel-fuel-devnet.toml";
 pub const CHANNEL_TESTNET_FILE_NAME: &str = "channel-fuel-testnet.toml";
+
+// Misc
 
 pub const DATE_FORMAT: &[FormatItem] = format_description!("[year]-[month]-[day]");
 pub const DATE_FORMAT_URL_FRIENDLY: &[FormatItem] = format_description!("[year]/[month]/[day]");

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -57,4 +57,14 @@ pub fn ask_user_yes_no_question(question: &str) -> io::Result<bool> {
             return Ok(result);
         }
     }
+
+    // This is the dialoguer version of the prompter, but it's not testable
+    // as dialoguer requires an interactive terminal to work without failing.
+    //
+    // use dialoguer::{theme::ColorfulTheme, Confirm};
+    //
+    // Confirm::with_theme(&ColorfulTheme::default())
+    //     .with_prompt(question)
+    //     .interact()
+    //     .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))
 }

--- a/src/fuelup_cli.rs
+++ b/src/fuelup_cli.rs
@@ -7,9 +7,14 @@ use crate::commands::{
     toolchain::{self, ToolchainCommand},
     upgrade::{self, UpgradeCommand},
 };
-use crate::ops::{fuelup_show, fuelup_update};
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use clap::Parser;
+use crate::fmt::ask_user_yes_no_question;
+use crate::ops::{fuelup_show, fuelup_toolchain, fuelup_update};
+use crate::toolchain::{DistToolchainDescription, Toolchain};
+use crate::toolchain_override::ToolchainOverride;
+use std::str::FromStr;
+use tracing::info;
 
 #[derive(Debug, Parser)]
 #[clap(name = "fuelup", about = "Fuel Toolchain Manager", version)]
@@ -45,6 +50,41 @@ enum Commands {
 
 pub fn fuelup_cli() -> Result<()> {
     let cli = Cli::parse();
+
+    if let Some(toolchain_override) = ToolchainOverride::from_project_root() {
+        let override_path = toolchain_override.cfg.toolchain.channel.to_string();
+        let toolchain = match DistToolchainDescription::from_str(&override_path) {
+            Ok(desc) => Toolchain::from_path(&desc.to_string()),
+            Err(_) => Toolchain::from_path(&override_path),
+        };
+
+        info!("Using override toolchain '{}'", &toolchain.name);
+
+        if !toolchain.exists() {
+            match cli.command {
+                Commands::Toolchain(_) => {
+                    // User is managing their toolchains, so we fall through
+                }
+                _ => {
+                    let should_install = ask_user_yes_no_question(
+                        "Override toolchain is not installed. Do you want to install it now?",
+                    )
+                    .context("Console I/O")?;
+
+                    if should_install {
+                        fuelup_toolchain::install::install(toolchain::InstallCommand {
+                            name: toolchain.name,
+                        })?;
+                    } else {
+                        bail!(
+                            "Override toolchain is not installed. Please run: 'fuelup toolchain install {}'",
+                            &toolchain.name,
+                        )
+                    }
+                }
+            }
+        }
+    }
 
     match cli.command {
         Commands::Check(command) => check::exec(command),

--- a/src/ops/fuelup_upgrade.rs
+++ b/src/ops/fuelup_upgrade.rs
@@ -1,5 +1,5 @@
 use super::{fuelup_default, fuelup_self, fuelup_update};
-use crate::channel::LATEST;
+use crate::constants::LATEST;
 use anyhow::Result;
 
 pub fn upgrade(force: bool) -> Result<()> {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,6 +1,6 @@
 use crate::{
-    channel::{self, Channel},
-    constants::DATE_FORMAT,
+    channel::Channel,
+    constants::{self, CHANNELS, DATE_FORMAT},
     download::DownloadCfg,
     file::{get_bin_version, hard_or_symlink_file, is_executable},
     path::{
@@ -24,19 +24,6 @@ use std::{
 use time::Date;
 use tracing::{error, info};
 
-pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
-    channel::LATEST,
-    channel::BETA_1,
-    channel::BETA_2,
-    channel::BETA_3,
-    channel::BETA_4,
-    channel::BETA_5,
-    channel::NIGHTLY,
-    channel::DEVNET,
-    // Stable is reserved, although currently unused.
-    channel::STABLE,
-];
-
 #[derive(Debug, Eq, PartialEq)]
 pub enum DistToolchainName {
     Beta1,
@@ -53,15 +40,15 @@ pub enum DistToolchainName {
 impl fmt::Display for DistToolchainName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            DistToolchainName::Latest => write!(f, "{}", channel::LATEST),
-            DistToolchainName::Nightly => write!(f, "{}", channel::NIGHTLY),
-            DistToolchainName::Beta1 => write!(f, "{}", channel::BETA_1),
-            DistToolchainName::Beta2 => write!(f, "{}", channel::BETA_2),
-            DistToolchainName::Beta3 => write!(f, "{}", channel::BETA_3),
-            DistToolchainName::Beta4 => write!(f, "{}", channel::BETA_4),
-            DistToolchainName::Beta5 => write!(f, "{}", channel::BETA_5),
-            DistToolchainName::Devnet => write!(f, "{}", channel::DEVNET),
-            DistToolchainName::Testnet => write!(f, "{}", channel::TESTNET),
+            DistToolchainName::Latest => write!(f, "{}", constants::LATEST),
+            DistToolchainName::Nightly => write!(f, "{}", constants::NIGHTLY),
+            DistToolchainName::Beta1 => write!(f, "{}", constants::BETA_1),
+            DistToolchainName::Beta2 => write!(f, "{}", constants::BETA_2),
+            DistToolchainName::Beta3 => write!(f, "{}", constants::BETA_3),
+            DistToolchainName::Beta4 => write!(f, "{}", constants::BETA_4),
+            DistToolchainName::Beta5 => write!(f, "{}", constants::BETA_5),
+            DistToolchainName::Devnet => write!(f, "{}", constants::DEVNET),
+            DistToolchainName::Testnet => write!(f, "{}", constants::TESTNET),
         }
     }
 }
@@ -70,15 +57,15 @@ impl FromStr for DistToolchainName {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self> {
         match s {
-            channel::LATEST => Ok(Self::Latest),
-            channel::NIGHTLY => Ok(Self::Nightly),
-            channel::BETA_1 => Ok(Self::Beta1),
-            channel::BETA_2 => Ok(Self::Beta2),
-            channel::BETA_3 => Ok(Self::Beta3),
-            channel::BETA_4 => Ok(Self::Beta4),
-            channel::BETA_5 => Ok(Self::Beta5),
-            channel::DEVNET => Ok(Self::Devnet),
-            channel::TESTNET => Ok(Self::Testnet),
+            constants::LATEST => Ok(Self::Latest),
+            constants::NIGHTLY => Ok(Self::Nightly),
+            constants::BETA_1 => Ok(Self::Beta1),
+            constants::BETA_2 => Ok(Self::Beta2),
+            constants::BETA_3 => Ok(Self::Beta3),
+            constants::BETA_4 => Ok(Self::Beta4),
+            constants::BETA_5 => Ok(Self::Beta5),
+            constants::DEVNET => Ok(Self::Devnet),
+            constants::TESTNET => Ok(Self::Testnet),
             _ => bail!("Unknown name for toolchain: {}", s),
         }
     }
@@ -297,7 +284,7 @@ impl Toolchain {
     }
 
     pub fn is_distributed(&self) -> bool {
-        RESERVED_TOOLCHAIN_NAMES.contains(&self.name.split_once('-').unwrap_or((&self.name, "")).0)
+        CHANNELS.contains(&self.name.split_once('-').unwrap_or((&self.name, "")).0)
     }
 
     pub fn exists(&self) -> bool {
@@ -510,7 +497,7 @@ impl Toolchain {
 
 #[cfg(test)]
 mod tests {
-    use crate::channel::{CHANNELS, STABLE};
+    use crate::constants::{CHANNELS, STABLE};
 
     use super::*;
 

--- a/src/toolchain_override.rs
+++ b/src/toolchain_override.rs
@@ -1,6 +1,6 @@
 use crate::{
-    channel::{is_beta_toolchain, LATEST, NIGHTLY},
-    constants::{DATE_FORMAT, FUEL_TOOLCHAIN_TOML_FILE},
+    channel::is_beta_toolchain,
+    constants::{DATE_FORMAT, FUEL_TOOLCHAIN_TOML_FILE, LATEST, NIGHTLY},
     download::DownloadCfg,
     file,
     path::get_fuel_toolchain_toml,
@@ -213,7 +213,7 @@ impl OverrideCfg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::channel::{BETA_1, BETA_2, BETA_3, NIGHTLY};
+    use crate::constants::{BETA_1, BETA_2, BETA_3, NIGHTLY};
     use indoc::indoc;
 
     #[test]

--- a/src/toolchain_override.rs
+++ b/src/toolchain_override.rs
@@ -88,9 +88,9 @@ impl fmt::Display for Channel {
 impl FromStr for Channel {
     type Err = anyhow::Error;
     fn from_str(s: &str) -> Result<Self> {
-        if is_beta_toolchain(s) {
+        if let Some(beta_channel) = is_beta_toolchain(s) {
             return Ok(Self {
-                name: s.to_string(),
+                name: beta_channel.to_string(),
                 date: None,
             });
         };

--- a/tests/default.rs
+++ b/tests/default.rs
@@ -100,12 +100,49 @@ fn fuelup_default_nightly_and_nightly_date() -> Result<()> {
 }
 
 #[test]
+fn fuelup_default_override_skip_install() -> Result<()> {
+    testcfg::setup(FuelupState::LatestWithBetaOverride, &|cfg| {
+        let output = cfg.fuelup_with_input(&["default"], b"N\n");
+        let triple = TargetTriple::from_host().unwrap();
+
+        assert!(output
+            .stdout
+            .starts_with(&format!("Using override toolchain 'beta-1-{triple}'")));
+
+        assert!(output
+            .stdout
+            .contains("Override toolchain is not installed. Do you want to install it now?"));
+
+        assert!(output
+            .stdout
+            .contains(&format!("Override toolchain is not installed. Please run: 'fuelup toolchain install beta-1-{triple}'")));
+    })?;
+    Ok(())
+}
+
+#[test]
 fn fuelup_default_override() -> Result<()> {
     testcfg::setup(FuelupState::LatestWithBetaOverride, &|cfg| {
-        let output = cfg.fuelup(&["default"]);
+        let output = cfg.fuelup_with_input(&["default"], b"Y\n");
         let triple = TargetTriple::from_host().unwrap();
-        let expected_stdout = format!("beta-1-{triple} (override), latest-{triple} (default)\n");
-        assert_eq!(output.stdout, expected_stdout);
+
+        assert!(output
+            .stdout
+            .starts_with(&format!("Using override toolchain 'beta-1-{triple}'")));
+
+        assert!(output
+            .stdout
+            .contains("Override toolchain is not installed. Do you want to install it now?"));
+
+        assert!(output.stdout.contains("Downloading:"));
+
+        assert!(output
+            .stdout
+            .contains("The Fuel toolchain is installed and up to date"));
+
+        assert!(output
+            .stdout
+            .contains(&format!("beta-1-{triple} (override)")));
     })?;
     Ok(())
 }

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -173,39 +173,28 @@ fn fuelup_show_custom() -> Result<()> {
 #[test]
 fn fuelup_show_override() -> Result<()> {
     testcfg::setup(FuelupState::LatestWithBetaOverride, &|cfg| {
-        let stripped = strip_ansi_escapes::strip(cfg.fuelup(&["show"]).stdout);
+        let stripped = strip_ansi_escapes::strip(cfg.fuelup_with_input(&["show"], b"y\n").stdout);
         let stdout = String::from_utf8_lossy(&stripped);
         let target = TargetTriple::from_host().unwrap();
-        let fuelup_home = cfg.fuelup_dir();
-        let fuelup_home_str = fuelup_home.to_string_lossy();
-        let expected_stdout = formatdoc! {
-            r#"Default host: {target}
-            fuelup home: {fuelup_home_str}
 
-            Installed toolchains
-            --------------------
-            latest-{target} (default)
+        assert!(stdout
+          .starts_with(&format!("Using override toolchain 'beta-1-{target}'")));
 
-            active toolchain
-            ----------------
-            beta-1-{target} (override), path: {}
-              forc : not found
-                - forc-client
-                  - forc-deploy : not found
-                  - forc-run : not found
-                - forc-crypto : not found
-                - forc-debug : not found
-                - forc-doc : not found
-                - forc-fmt : not found
-                - forc-lsp : not found
-                - forc-tx : not found
-                - forc-wallet : not found
-              fuel-core : not found
-              fuel-core-keygen : not found
-            "#, cfg.home.join(FUEL_TOOLCHAIN_TOML_FILE).display()
-        };
-        assert_eq!(stdout, expected_stdout);
-    })?;
+        assert!(stdout
+          .contains("Override toolchain is not installed. Do you want to install it now?"));
+
+        assert!(stdout.contains("Downloading:"));
+
+        assert!(stdout.contains(&formatdoc! {"
+          Installed:
+          - forc 0.26.0
+          - forc-wallet 0.1.2
+          - fuel-core 0.10.1
+          "}));
+
+        assert!(stdout
+          .contains(&format!("beta-1-{target} (override)")));
+     })?;
     Ok(())
 }
 
@@ -267,7 +256,8 @@ fn fuelup_show_latest_then_override() -> Result<()> {
         stdout = String::from_utf8_lossy(&stripped);
 
         let expected_stdout = formatdoc! {
-            r#"Default host: {target}
+            r#"Using override toolchain 'nightly-2022-08-30-{target}'
+            Default host: {target}
             fuelup home: {fuelup_home_str}
 
             Installed toolchains

--- a/tests/toolchain.rs
+++ b/tests/toolchain.rs
@@ -4,7 +4,8 @@ pub mod testcfg;
 use anyhow::Result;
 use chrono::{Duration, Utc};
 use expects::expect_files_exist;
-use fuelup::{channel, fmt::format_toolchain_with_target, target_triple::TargetTriple};
+use fuelup::{constants, fmt::format_toolchain_with_target, target_triple::TargetTriple};
+use indoc::indoc;
 use testcfg::{FuelupState, ALL_BINS, CUSTOM_TOOLCHAIN_NAME, DATE};
 
 fn yesterday() -> String {
@@ -140,10 +141,10 @@ fn fuelup_toolchain_uninstall() -> Result<()> {
 fn fuelup_toolchain_new() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
         let output = cfg.fuelup(&["toolchain", "new", CUSTOM_TOOLCHAIN_NAME]);
-        let expected_stdout = format!(
-            "New toolchain initialized: {CUSTOM_TOOLCHAIN_NAME}
-Default toolchain set to '{CUSTOM_TOOLCHAIN_NAME}'\n"
-        );
+        let expected_stdout = format!(indoc! {"
+            New toolchain initialized: {}
+            Default toolchain set to '{}'
+        "}, CUSTOM_TOOLCHAIN_NAME, CUSTOM_TOOLCHAIN_NAME);
         assert_eq!(output.stdout, expected_stdout);
         assert!(cfg.toolchain_bin_dir(CUSTOM_TOOLCHAIN_NAME).is_dir());
         let default = cfg.default_toolchain();
@@ -155,7 +156,7 @@ Default toolchain set to '{CUSTOM_TOOLCHAIN_NAME}'\n"
 #[test]
 fn fuelup_toolchain_new_disallowed() -> Result<()> {
     testcfg::setup(FuelupState::Empty, &|cfg| {
-        for toolchain in [channel::LATEST, channel::NIGHTLY] {
+        for toolchain in [constants::LATEST, constants::NIGHTLY] {
             let output = cfg.fuelup(&["toolchain", "new", toolchain]);
             let expected_stderr = format!("error: invalid value '{toolchain}' for '<NAME>': Cannot use distributable toolchain name '{toolchain}' as a custom toolchain name\n\nFor more information, try '--help'.\n");
             assert_eq!(output.stderr, expected_stderr);


### PR DESCRIPTION
This PR is in relation to #652

When overriding toolchains, there are 2 places to be concerned with when a toolchain is missing:

1. When `fuelup` is the command run
2. When a proxy command is run

For 2, we are already covering this scenario by installing missing components and plugins on first run.

As for 1, this PR will now `bail!()` unless the command is to `install`, `uninstall`, or create a `new` toolkit.

...

No tests yet because I want to get feedback to see if I'm on the right track.