### PR TITLE
Fix component URL if bundled within the forc tarball (#654)

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -187,12 +187,15 @@ impl Components {
         Ok(executables)
     }
 
-    pub fn is_distributed_by_forc(plugin_name: &str) -> bool {
-        let components = Self::from_toml(COMPONENTS_TOML).expect("Failed to parse components toml");
-        if let Some(forc) = components.component.get(FORC) {
-            return forc.executables.contains(&plugin_name.to_string());
-        };
-        false
+    pub fn is_distributed_by_forc(component: &str) -> bool {
+        Component::from_name(component)
+            .map(|comp| {
+                comp.name == FORC
+                    || Component::from_name(FORC)
+                        .map(|forc| comp.tarball_prefix == forc.tarball_prefix)
+                        .unwrap_or(false)
+            })
+            .unwrap_or(false)
     }
 }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -52,7 +52,7 @@ impl DownloadCfg {
                 .map_err(|e| anyhow!("Error getting latest tag for '{}': {}", name, e))?,
         };
 
-        let (tarball_name, tarball_url) = if name == FUELUP {
+        let (tarball_name, tarball_url) = if component::Components::is_distributed_by_forc(name) {
             let tarball_name = tarball_name(FUELUP, &version, &target);
             let tarball_url = github_releases_download_url(FUELUP, &version, &tarball_name);
             (tarball_name, tarball_url)

--- a/src/target_triple.rs
+++ b/src/target_triple.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use component::{self, Component};
+use component::{self, Components};
 use std::fmt;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
@@ -53,40 +53,37 @@ impl TargetTriple {
     }
 
     pub fn from_component(component: &str) -> Result<Self> {
-        match Component::from_name(component).map(|c| c.name)?.as_str() {
-            component::FORC => {
-                let os = match std::env::consts::OS {
-                    "macos" => "darwin",
-                    "linux" => "linux",
-                    unsupported_os => bail!("Unsupported os: {}", unsupported_os),
-                };
-                let architecture = match std::env::consts::ARCH {
-                    "aarch64" => "arm64",
-                    "x86_64" => "amd64",
-                    unsupported_arch => bail!("Unsupported architecture: {}", unsupported_arch),
-                };
+        if Components::is_distributed_by_forc(component) {
+            let os = match std::env::consts::OS {
+                "macos" => "darwin",
+                "linux" => "linux",
+                unsupported_os => bail!("Unsupported os: {}", unsupported_os),
+            };
+            let architecture = match std::env::consts::ARCH {
+                "aarch64" => "arm64",
+                "x86_64" => "amd64",
+                unsupported_arch => bail!("Unsupported architecture: {}", unsupported_arch),
+            };
 
-                Ok(Self(format!("{os}_{architecture}")))
-            }
-            _ => {
-                let architecture = match std::env::consts::ARCH {
-                    "aarch64" | "x86_64" => std::env::consts::ARCH,
-                    unsupported_arch => bail!("Unsupported architecture: {}", unsupported_arch),
-                };
+            Ok(Self(format!("{os}_{architecture}")))
+        } else {
+            let architecture = match std::env::consts::ARCH {
+                "aarch64" | "x86_64" => std::env::consts::ARCH,
+                unsupported_arch => bail!("Unsupported architecture: {}", unsupported_arch),
+            };
 
-                let vendor = match std::env::consts::OS {
-                    "macos" => "apple",
-                    _ => "unknown",
-                };
+            let vendor = match std::env::consts::OS {
+                "macos" => "apple",
+                _ => "unknown",
+            };
 
-                let os = match std::env::consts::OS {
-                    "macos" => "darwin",
-                    "linux" => "linux-gnu",
-                    unsupported_os => bail!("Unsupported os: {}", unsupported_os),
-                };
+            let os = match std::env::consts::OS {
+                "macos" => "darwin",
+                "linux" => "linux-gnu",
+                unsupported_os => bail!("Unsupported os: {}", unsupported_os),
+            };
 
-                Ok(Self(format!("{architecture}-{vendor}-{os}")))
-            }
+            Ok(Self(format!("{architecture}-{vendor}-{os}")))
         }
     }
 }

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -130,7 +130,7 @@ impl TestCfg {
             .args(args)
             .current_dir(&self.home)
             .env("HOME", &self.home)
-            .env("CARGO_HOME", &self.home.join(".cargo"))
+            .env("CARGO_HOME", self.home.join(".cargo"))
             .env(
                 "PATH",
                 format!(


### PR DESCRIPTION
This PR fixes components that are bundled within the `forc` tarball...

From the following shell session, we can see that when we proxy out to `forc tx` which then triggers a download, we trying to download the component from an incorrect URL:

```
> rm -Rf ~/.fuelup
> rm -f fuel-toolchain.toml
> curl https://install.fuel.network | sh
...

> cat fuel-toolchain.toml
[toolchain]
channel = "nightly-2024-09-15"

[components]
forc = "0.62.0"
fuel-core = "0.33.0"
forc-tx = "0.61.0"

> fuelup show
Default host: x86_64-unknown-linux-gnu
fuelup home: /home/alfie/.fuelup

Installed toolchains
--------------------
latest-x86_64-unknown-linux-gnu (default)

active toolchain
----------------
nightly-2024-09-15-x86_64-unknown-linux-gnu (override), path: fuel-toolchain.toml
  forc : not found
    - forc-client
      - forc-deploy : not found
      - forc-run : not found
    - forc-crypto : not found
    - forc-debug : not found
    - forc-doc : not found
    - forc-fmt : not found
    - forc-lsp : not found
    - forc-tx : not found
    - forc-wallet : not found
  fuel-core : not found
  fuel-core-keygen : not found

> forc --version
Caching fuels version at /home/alfie/.fuelup/store/forc-0.62.0/fuels_version
Fetching binary from https://github.com/FuelLabs/sway/releases/download/v0.62.0/forc-binaries-linux_amd64.tar.gz
Downloading component forc without verifying checksum
...
forc 0.62.0

> fuelup show
Default host: x86_64-unknown-linux-gnu
fuelup home: /home/alfie/.fuelup

Installed toolchains
--------------------
latest-x86_64-unknown-linux-gnu (default)
nightly-2024-09-15-x86_64-unknown-linux-gnu (override)

active toolchain
----------------
nightly-2024-09-15-x86_64-unknown-linux-gnu (override), path: fuel-toolchain.toml
  forc : 0.63.5+nightly.20240915.e1a05fccec
    - forc-client
      - forc-deploy : not found
      - forc-run : not found
    - forc-crypto : not found
    - forc-debug : not found
    - forc-doc : not found
    - forc-fmt : not found
    - forc-lsp : not found
    - forc-tx : not found
    - forc-wallet : 0.9.0+nightly.20240915.29d9b25c2c
  fuel-core : 0.35.0+nightly.20240915.8c67681a5b
  fuel-core-keygen : 0.35.0+nightly.20240915.8c67681a5b

> forc run --version
forc-client 0.62.0

> forc fmt --version
forc-fmt 0.62.0

> forc tx --version
Fetching binary from https://github.com/FuelLabs/sway/releases/download/v0.61.0/forc-binaries-x86_64-unknown-linux-gnu.tar.gz
Downloading component forc-tx without verifying checksum
Failed to download from https://github.com/FuelLabs/sway/releases/download/v0.61.0/forc-binaries-x86_64-unknown-linux-gnu.tar.gz
Retrying..
Failed to download from https://github.com/FuelLabs/sway/releases/download/v0.61.0/forc-binaries-x86_64-unknown-linux-gnu.tar.gz
Retrying..
Failed to download from https://github.com/FuelLabs/sway/releases/download/v0.61.0/forc-binaries-x86_64-unknown-linux-gnu.tar.gz
Retrying..
Failed to download forc-binaries-x86_64-unknown-linux-gnu.tar.gz - Could not download file. The release may not be ready yet.

> fuel-core --version
Fetching binary from https://github.com/FuelLabs/fuel-core/releases/download/v0.33.0/fuel-core-0.33.0-x86_64-unknown-linux-gnu.tar.gz
Downloading component fuel-core without verifying checksum
...
fuel-core 0.33.0

> fuelup show
Default host: x86_64-unknown-linux-gnu
fuelup home: /home/alfie/.fuelup

Installed toolchains
--------------------
latest-x86_64-unknown-linux-gnu (default)
nightly-2024-09-15-x86_64-unknown-linux-gnu (override)

active toolchain
----------------
nightly-2024-09-15-x86_64-unknown-linux-gnu (override), path: fuel-toolchain.toml
  forc : 0.63.5+nightly.20240915.e1a05fccec
    - forc-client
      - forc-deploy : not found
      - forc-run : not found
    - forc-crypto : not found
    - forc-debug : not found
    - forc-doc : not found
    - forc-fmt : not found
    - forc-lsp : not found
    - forc-tx : not found
    - forc-wallet : 0.9.0+nightly.20240915.29d9b25c2c
  fuel-core : 0.35.0+nightly.20240915.8c67681a5b
  fuel-core-keygen : 0.35.0+nightly.20240915.8c67681a5b

> ls -l ~/.fuelup/toolchains/
total 8
drwxr-xr-x 3 alfie 4096 Sep 29 07:42 latest-x86_64-unknown-linux-gnu
drwxr-xr-x 3 alfie 4096 Sep 29 07:48 nightly-2024-09-15-x86_64-unknown-linux-gnu

> ls -l ~/.fuelup/store/
total 40
drwxr-xr-x 2 alfie 4096 Sep 29 07:48 forc-0.62.0
drwxr-xr-x 2 alfie 4096 Sep 29 07:48 forc-0.63.5+nightly.20240915.e1a05fccec
drwxr-xr-x 2 alfie 4096 Sep 29 07:42 forc-0.64.0
drwxr-xr-x 2 alfie 4096 Sep 29 07:50 fuel-tx-0.61.0
drwxr-xr-x 2 alfie 4096 Sep 29 07:48 forc-wallet-0.9.0+nightly.20240915.29d9b25c2c
drwxr-xr-x 2 alfie 4096 Sep 29 07:42 forc-wallet-0.9.1
drwxr-xr-x 2 alfie 4096 Sep 29 07:50 fuel-core-0.33.0
drwxr-xr-x 2 alfie 4096 Sep 29 07:48 fuel-core-0.35.0+nightly.20240915.8c67681a5b
drwxr-xr-x 2 alfie 4096 Sep 29 07:42 fuel-core-0.36.0
drwxr-xr-x 2 alfie 4096 Sep 29 07:48 fuel-core-keygen-0.35.0+nightly.20240915.8c67681a5b
drwxr-xr-x 2 alfie 4096 Sep 29 07:42 fuel-core-keygen-0.36.0

> ls -l /home/alfie/.fuelup/store/forc-tx-0.61.0
total 0
```