### PR TITLE
Update component target tarball (#654)

### DIFF
--- a/components.toml
+++ b/components.toml
@@ -49,7 +49,7 @@ targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 
 [component.forc-client]
 name = "forc-client"
-tarball_prefix = "forc-client"
+tarball_prefix = "forc-binaries"
 is_plugin = true
 executables = ["forc-deploy", "forc-run"]
 repository_name = "sway"

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -130,7 +130,7 @@ impl TestCfg {
             .args(args)
             .current_dir(&self.home)
             .env("HOME", &self.home)
-            .env("CARGO_HOME", &self.home.join(".cargo"))
+            .env("CARGO_HOME", self.home.join(".cargo"))
             .env(
                 "PATH",
                 format!(


### PR DESCRIPTION
The `forc-client` component was still pointing to its old GItHub repository. This PR found while investigating #654 updates `forc-client` to where it lives now - the `forc-binaries` tarball release.