### PR TITLE
Revert bumping testnet to use fuel-core 0.38.0 back to 0.37.1

### DIFF
--- a/channel-fuel-testnet.toml
+++ b/channel-fuel-testnet.toml
@@ -1,4 +1,4 @@
-date = "2024-10-08"
+date = "2024-10-07"
 
 [pkg.forc]
 version = "0.65.2"
@@ -39,39 +39,39 @@ url = "https://github.com/FuelLabs/forc-wallet/releases/download/v0.10.0/forc-wa
 hash = "8ed008a5d45f91ab92489a38ffeac3fb8347f3d4aa73d91012455985bf9a4bb3"
 
 [pkg.fuel-core]
-version = "0.38.0"
+version = "0.37.1"
 
 [pkg.fuel-core.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.38.0/fuel-core-0.38.0-aarch64-unknown-linux-gnu.tar.gz"
-hash = "b311390a34f970594b567b52f575f1fe7d4852fe88ce77adcdcf67a3ef880aa4"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.37.1/fuel-core-0.37.1-aarch64-unknown-linux-gnu.tar.gz"
+hash = "a99a7cbf88376070ade6dbbb02f87707ac0ad597f39b25f0556c6b84da6db1fe"
 
 [pkg.fuel-core.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.38.0/fuel-core-0.38.0-x86_64-unknown-linux-gnu.tar.gz"
-hash = "ec5a64e5da69f276d9837bea5cdacd38dd9c208d260334cd54d876bc08694150"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.37.1/fuel-core-0.37.1-x86_64-unknown-linux-gnu.tar.gz"
+hash = "e8905a99b484cf73643639a4852a74f68d85de05e88b0fc81fadc1a46b1411ac"
 
 [pkg.fuel-core.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.38.0/fuel-core-0.38.0-aarch64-apple-darwin.tar.gz"
-hash = "fe7527fca9bcb05bfea22e6a3b4b93b8517b0951d4785ed1d1e7e1900dd8117d"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.37.1/fuel-core-0.37.1-aarch64-apple-darwin.tar.gz"
+hash = "a20078d277f71837c2898c18a9b59d3e97eec896d8ab46ebf48a11b73add2d4d"
 
 [pkg.fuel-core.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.38.0/fuel-core-0.38.0-x86_64-apple-darwin.tar.gz"
-hash = "5b6afbc398663d4d14afd39cec89c7f6429818b424103216e87428609d0cabdd"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.37.1/fuel-core-0.37.1-x86_64-apple-darwin.tar.gz"
+hash = "a5e0309beefd184a6308a220c7d8f68bd28b8eadd19ea2e6610d83c514f4f21f"
 
 [pkg.fuel-core-keygen]
-version = "0.38.0"
+version = "0.37.1"
 
 [pkg.fuel-core-keygen.target.aarch64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.38.0/fuel-core-0.38.0-aarch64-unknown-linux-gnu.tar.gz"
-hash = "b311390a34f970594b567b52f575f1fe7d4852fe88ce77adcdcf67a3ef880aa4"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.37.1/fuel-core-0.37.1-aarch64-unknown-linux-gnu.tar.gz"
+hash = "a99a7cbf88376070ade6dbbb02f87707ac0ad597f39b25f0556c6b84da6db1fe"
 
 [pkg.fuel-core-keygen.target.x86_64-unknown-linux-gnu]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.38.0/fuel-core-0.38.0-x86_64-unknown-linux-gnu.tar.gz"
-hash = "ec5a64e5da69f276d9837bea5cdacd38dd9c208d260334cd54d876bc08694150"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.37.1/fuel-core-0.37.1-x86_64-unknown-linux-gnu.tar.gz"
+hash = "e8905a99b484cf73643639a4852a74f68d85de05e88b0fc81fadc1a46b1411ac"
 
 [pkg.fuel-core-keygen.target.aarch64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.38.0/fuel-core-0.38.0-aarch64-apple-darwin.tar.gz"
-hash = "fe7527fca9bcb05bfea22e6a3b4b93b8517b0951d4785ed1d1e7e1900dd8117d"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.37.1/fuel-core-0.37.1-aarch64-apple-darwin.tar.gz"
+hash = "a20078d277f71837c2898c18a9b59d3e97eec896d8ab46ebf48a11b73add2d4d"
 
 [pkg.fuel-core-keygen.target.x86_64-apple-darwin]
-url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.38.0/fuel-core-0.38.0-x86_64-apple-darwin.tar.gz"
-hash = "5b6afbc398663d4d14afd39cec89c7f6429818b424103216e87428609d0cabdd"
+url = "https://github.com/FuelLabs/fuel-core/releases/download/v0.37.1/fuel-core-0.37.1-x86_64-apple-darwin.tar.gz"
+hash = "a5e0309beefd184a6308a220c7d8f68bd28b8eadd19ea2e6610d83c514f4f21f"


### PR DESCRIPTION
Reverts FuelLabs/fuelup#674

