### PR TITLE
chore: bump version to v0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "fuelup"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "ansi_term",
  "ansiterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuelup"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
Bumps version to 0.27.0, this is a major bump as #677 is breaking.