### PR TITLE
Add tests and highlight issues with should_panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "flate2",
  "indicatif",
  "indoc",
+ "regex",
  "semver",
  "serde",
  "serde_json",
@@ -870,14 +871,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -891,13 +892,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -908,9 +909,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = ["component", "ci/build-channel", "ci/compare-versions"]
 
 [dev-dependencies]
 chrono = "0.4.33"
+regex = "1.11"
 strip-ansi-escapes = "0.2.0"
 
 [lints.clippy]

--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -61,6 +61,11 @@ impl Component {
             && name != FORC)
             || name == FORC_CLIENT
     }
+
+    pub fn is_in_same_distribution(forc: &Component, component: &Component) -> bool {
+        component.repository_name == forc.repository_name
+            && component.tarball_prefix == forc.tarball_prefix
+    }
 }
 
 #[derive(Debug)]
@@ -252,5 +257,108 @@ mod tests {
     #[test]
     fn test_collect_plugin_executables() {
         assert!(Components::collect_plugin_executables().is_ok());
+    }
+
+    #[test]
+    fn test_from_name_forc() {
+        let component = Component::from_name(FORC).unwrap();
+        assert_eq!(component.name, FORC, "forc is a publishable component");
+    }
+
+    #[test]
+    fn test_from_name_publishables() {
+        for publishable in Components::collect_publishables().unwrap() {
+            let component = Component::from_name(&publishable.name).unwrap();
+            assert_eq!(
+                component.name, publishable.name,
+                "{} is a publishable component",
+                publishable.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_name_plugins() {
+        for plugin in Components::collect_plugins().unwrap() {
+            let component = Component::from_name(&plugin.name).unwrap();
+            assert_eq!(
+                component.name, plugin.name,
+                "{} is a plugin in {}",
+                plugin.name, component.name
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic] // TODO: #654 will fix this
+    fn test_from_name_executables() {
+        for executable in &Components::collect_plugin_executables().unwrap() {
+            let component = Component::from_name(executable).unwrap();
+            assert!(
+                component.executables.contains(executable),
+                "{} is an executable in {}",
+                executable,
+                component.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_distributed_by_forc_forc() {
+        assert!(
+            Components::is_distributed_by_forc("forc"),
+            "forc is distributed by forc"
+        );
+    }
+
+    #[test]
+    fn test_is_distributed_by_forc_publishables() {
+        for publishable in Components::collect_publishables().unwrap() {
+            let component = Component::from_name(&publishable.name).unwrap();
+            is_distributed_by_forc(&component);
+        }
+    }
+
+    #[test]
+    #[should_panic] // TODO: #654 will fix this
+    fn test_is_distributed_by_forc_plugins() {
+        for plugin in Components::collect_plugins().unwrap() {
+            let component = Component::from_name(&plugin.name).unwrap();
+            is_distributed_by_forc(&component);
+        }
+    }
+
+    #[test]
+    #[should_panic] // TODO: #654 will fix this
+    fn test_is_distributed_by_forc_executables() {
+        for executable in Components::collect_plugin_executables().unwrap() {
+            let components = Components::collect().unwrap();
+            let component = components
+                .component
+                .values()
+                .find(|c| c.executables.contains(&executable))
+                .unwrap();
+
+            is_distributed_by_forc(component);
+        }
+    }
+
+    fn is_distributed_by_forc(component: &Component) {
+        let forc = Component::from_name(FORC).unwrap();
+        let is_distributed = Components::is_distributed_by_forc(&component.name);
+
+        if Component::is_in_same_distribution(&forc, component) {
+            assert!(
+                is_distributed,
+                "{:?} is distributed by forc",
+                component.name
+            )
+        } else {
+            assert!(
+                !is_distributed,
+                "{:?} is not distributed by forc",
+                component.name
+            )
+        }
     }
 }

--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -62,9 +62,30 @@ impl Component {
             || name == FORC_CLIENT
     }
 
-    pub fn is_in_same_distribution(forc: &Component, component: &Component) -> bool {
-        component.repository_name == forc.repository_name
-            && component.tarball_prefix == forc.tarball_prefix
+    /// Tests if the supplied `Component`s come from same distribution
+    ///
+    /// # Arguments
+    ///
+    /// * `first` - The first `Component` to compare with
+    ///
+    /// * `second` - The second `Component` to compare with
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use component::Component;
+    ///
+    /// let forc = Component::from_name("forc").unwrap();
+    /// let forc_fmt = Component::from_name("forc-fmt").unwrap();
+    ///
+    /// assert!(Component::is_in_same_distribution(&forc, &forc_fmt));
+    /// ```
+    pub fn is_in_same_distribution(first: &Component, second: &Component) -> bool {
+        // Components come from the same distribution if:
+        //  - their repository names are the same, and
+        //  - their tarball prefixes are the same
+        first.repository_name == second.repository_name
+            && first.tarball_prefix == second.tarball_prefix
     }
 }
 

--- a/src/toolchain_override.rs
+++ b/src/toolchain_override.rs
@@ -21,27 +21,27 @@ use tracing::{info, warn};
 // additional info to OverrideCfg (representation of 'fuel-toolchain.toml').
 // In this case, we want the path to the toml file. More info might be
 // needed in future.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ToolchainOverride {
     pub cfg: OverrideCfg,
     pub path: PathBuf,
 }
 
 // Representation of the entire 'fuel-toolchain.toml'.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct OverrideCfg {
     pub toolchain: ToolchainCfg,
     pub components: Option<HashMap<String, Version>>,
 }
 
 // Represents the [toolchain] table in 'fuel-toolchain.toml'.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ToolchainCfg {
     #[serde(deserialize_with = "deserialize_channel")]
     pub channel: Channel,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Channel {
     pub name: String,
     pub date: Option<Date>,


### PR DESCRIPTION
This PR contains tests that demonstrate inconsistencies found in #654.

Once this PR is merged, the following PRs can then be updated along with removing corresponding `should_panic` test attributes:

- #665
- #666
- #667

Since #668 builds on top of the fixes in #666 and #667 and so will have conflicts and duplication, it will need to wait for the above PRs to be merged first before being mergeable.