### PR TITLE
Add `forc-submit` to components.toml (sway #3875)

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -7,7 +7,7 @@ use toml_edit::de;
 // Keeping forc since some ways we handle forc is slightly different.
 pub const FORC: &str = "forc";
 pub const FUELUP: &str = "fuelup";
-// forc-client is handled differently - its actual binaries are 'forc-run' and 'forc-deploy'
+// forc-client is handled differently - its actual binaries are 'forc-run', 'forc-deploy', and 'forc-submit'
 pub const FORC_CLIENT: &str = "forc-client";
 
 const COMPONENTS_TOML: &str = include_str!("../../components.toml");

--- a/components.toml
+++ b/components.toml
@@ -51,7 +51,7 @@ targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 name = "forc-client"
 tarball_prefix = "forc-binaries"
 is_plugin = true
-executables = ["forc-deploy", "forc-run"]
+executables = ["forc-deploy", "forc-run", "forc-submit"]
 repository_name = "sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -43,6 +43,7 @@ forc-crypto --version
 forc-debug --version
 forc-lsp --version
 forc-run --version
+forc-submit --version
 ```
 
 [repository]: https://github.com/FuelLabs/fuelup

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -36,6 +36,7 @@ fn fuelup_show_latest() -> Result<()> {
                 - forc-client
                   - forc-deploy : 0.1.0
                   - forc-run : 0.1.0
+                  - forc-submit : 0.1.0
                 - forc-crypto : 0.1.0
                 - forc-debug : 0.1.0
                 - forc-doc : 0.1.0
@@ -78,6 +79,7 @@ fn fuelup_show_and_switch() -> Result<()> {
                 - forc-client
                   - forc-deploy : 0.1.0
                   - forc-run : 0.1.0
+                  - forc-submit : 0.1.0
                 - forc-crypto : 0.1.0
                 - forc-debug : 0.1.0
                 - forc-doc : 0.1.0
@@ -113,6 +115,7 @@ fn fuelup_show_and_switch() -> Result<()> {
                 - forc-client
                   - forc-deploy : 0.2.0
                   - forc-run : 0.2.0
+                  - forc-submit : 0.2.0
                 - forc-crypto : 0.2.0
                 - forc-debug : 0.2.0
                 - forc-doc : 0.2.0
@@ -154,6 +157,7 @@ fn fuelup_show_custom() -> Result<()> {
                 - forc-client
                   - forc-deploy : not found
                   - forc-run : not found
+                  - forc-submit : not found
                 - forc-crypto : not found
                 - forc-debug : not found
                 - forc-doc : not found
@@ -193,6 +197,7 @@ fn fuelup_show_override() -> Result<()> {
                 - forc-client
                   - forc-deploy : not found
                   - forc-run : not found
+                  - forc-submit : not found
                 - forc-crypto : not found
                 - forc-debug : not found
                 - forc-doc : not found
@@ -235,6 +240,7 @@ fn fuelup_show_latest_then_override() -> Result<()> {
                 - forc-client
                   - forc-deploy : 0.1.0
                   - forc-run : 0.1.0
+                  - forc-submit : 0.1.0
                 - forc-crypto : 0.1.0
                 - forc-debug : 0.1.0
                 - forc-doc : 0.1.0
@@ -283,6 +289,7 @@ fn fuelup_show_latest_then_override() -> Result<()> {
                 - forc-client
                   - forc-deploy : 0.2.0
                   - forc-run : 0.2.0
+                  - forc-submit : 0.2.0
                 - forc-crypto : 0.2.0
                 - forc-debug : 0.2.0
                 - forc-doc : 0.2.0

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -80,6 +80,7 @@ pub static ALL_BINS: &[&str] = &[
     "forc-index",
     "forc-lsp",
     "forc-run",
+    "forc-submit",
     "forc-tx",
     "forc-wallet",
     "fuel-core",

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -102,15 +102,11 @@ pub static ALL_BINS: &[&str] = &[
 /// assert!(re.is_match(&yesterday));
 /// ```
 pub fn yesterday() -> String {
-    // CI failed building linux binaries on 2024-10-25 which happens to be
-    // "yesterday" when I'm trying to push this PR, so we need to override this
-    // temporarily to pass CI over the weekend. I'll be merging on top of this
-    // PR in the next few days and will remove this temporary fix
-
     let current_date = Utc::now();
     let yesterday = current_date - Duration::days(1);
     let _ = yesterday.format("%Y-%m-%d").to_string();
-    "2024-10-23".to_string()
+    // TODO: point to a nightly that has `forc-submit`
+    "2024-11-16".to_string()
 }
 
 impl TestCfg {


### PR DESCRIPTION
Sway's https://github.com/FuelLabs/sway/pull/3885 added a new executable to submit transactions to the network, but it was missed in the `fuelup` repo.