### PR TITLE
chore: migrate from REPO_TOKEN to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           coverage-files: lcov.info
           minimum-coverage: 0 # for now we are not enforcing any minimum coverage.
           artifact-name: code-coverage-report
-          github-token: ${{ secrets.REPO_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           update-comment: true
 
   try-run-fuelup-init:

--- a/.github/workflows/gh-pages-meta.yml
+++ b/.github/workflows/gh-pages-meta.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Deploy latest fuelup init
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           keep_files: true
           publish_dir: ${{ env.FUELUP_INIT_DIR }}
           destination_dir: ./
@@ -51,7 +51,7 @@ jobs:
       - name: Deploy latest fuelup version
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           keep_files: true
           publish_dir: ${{ env.FUELUP_VERSION_DIR }}
           destination_dir: ./

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Deploy master
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book
           destination_dir: master
           cname: install.fuel.network
@@ -40,7 +40,7 @@ jobs:
       - name: Deploy tag
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book
           destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}
           cname: install.fuel.network
@@ -62,7 +62,7 @@ jobs:
       - name: Set latest to point to tag
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./latest/
           destination_dir: ./latest/
           cname: install.fuel.network

--- a/.github/workflows/publish-nightly-channel.yml
+++ b/.github/workflows/publish-nightly-channel.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Deploy nightly channel (latest version)
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ env.NIGHTLY_CHANNEL_DIR }}
           keep_files: true
           destination_dir: ./
@@ -51,7 +51,7 @@ jobs:
       - name: Deploy nightly channel (archive)
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.REPO_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ env.NIGHTLY_CHANNEL_DIR }}
           keep_files: true
           destination_dir: ${{ steps.setup.outputs.archive_dir }}


### PR DESCRIPTION
Switch to using GitHub's built-in GITHUB_TOKEN instead of our custom REPO_TOKEN in CI workflows.
