### PR TITLE
fix: update reserved names

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -27,6 +27,8 @@ use tracing::{error, info};
 pub const RESERVED_TOOLCHAIN_NAMES: &[&str] = &[
     channel::LATEST,
     channel::NIGHTLY,
+    channel::TESTNET,
+    channel::MAINNET,
     // Stable is reserved, although currently unused.
     channel::STABLE,
     // Ignition is reserved, although currently unused.


### PR DESCRIPTION
Somehow this list got clobbered. This resulted in a bug where `fuelup update` would not update mainnet and testnet. 