### PR TITLE
ci: update rust version to 1.85.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.84.1
+  RUST_VERSION: 1.85.0
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION_COV: 1.84.1
+  RUST_VERSION: 1.84.1
   REGISTRY: ghcr.io
 
 jobs:
@@ -44,16 +44,16 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
-      - name: Install latest Rust
-        uses: dtolnay/rust-toolchain@master
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.RUST_VERSION_COV }}
+          toolchain: "nightly"
 
       - name: Install cargo-llvm-codecov
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Code coverage report
-        run: cargo  +${{ env.RUST_VERSION_COV }} llvm-cov --all-features --lcov --branch --output-path lcov.info
+        run: cargo +nightly llvm-cov --all-features --lcov --branch --output-path lcov.info
 
       - name: Setup LCOV
         uses: hrishikesh-kadam/setup-lcov@v1
@@ -90,6 +90,8 @@ jobs:
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - uses: Swatinem/rust-cache@v1
 
@@ -104,6 +106,8 @@ jobs:
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Check Formatting
         run: cargo fmt --all -- --check
@@ -116,6 +120,8 @@ jobs:
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Run tests
         run: cargo test --locked --workspace
@@ -130,6 +136,8 @@ jobs:
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install Cargo.toml linter
         uses: baptiste0928/cargo-install@v1
@@ -184,6 +192,7 @@ jobs:
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.job.target }}
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "nightly"
+          toolchain: nightly
 
       - name: Install cargo-llvm-codecov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -92,6 +92,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
+          components: clippy
 
       - uses: Swatinem/rust-cache@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
+          components: rustfmt
 
       - name: Check Formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION_COV: nightly-2024-06-05
+  RUST_VERSION_COV: 1.84.1
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/publish-nightly-channel.yml
+++ b/.github/workflows/publish-nightly-channel.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install build-channel script
         run: cargo install --debug --path ./ci/build-channel

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -38,7 +38,7 @@ fuelup self update
 
 To configure `fuelup` to use your proxy setting you can change `http_proxy`(***other optional enviroments see below***) environment value. The value format is in [libcurl format](https://everything.curl.dev/usingcurl/proxies/type.html) as in `[protocol://]host[:port]`.
 
-### Supported proxy enviroment variables
+### Supported proxy environment variables
 
 - http_proxy
 - HTTP_PROXY

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -38,7 +38,7 @@ fuelup self update
 
 To configure `fuelup` to use your proxy setting you can change `http_proxy`(***other optional enviroments see below***) environment value. The value format is in [libcurl format](https://everything.curl.dev/usingcurl/proxies/type.html) as in `[protocol://]host[:port]`.
 
-### Supported proxy environment variables
+### Supported proxy enviroment variables
 
 - http_proxy
 - HTTP_PROXY

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,7 +19,7 @@ impl SettingsFile {
 
     fn write_settings(&self) -> Result<()> {
         let s = self.cache.borrow().as_ref().unwrap().clone();
-        let parent_exists = self.path.parent().map_or(true, |dir| dir.exists());
+        let parent_exists = self.path.parent().is_none_or(|dir| dir.exists());
         if !parent_exists {
             std::fs::create_dir_all(self.path.parent().unwrap())?;
         }


### PR DESCRIPTION
Fixing CI errors seen in https://github.com/FuelLabs/fuelup/pull/705

Makes it so we:
- use the newest nightly for codecov workflow, which requires nightly (this fixes the codecov failure)
- uses a fixed version of rust for all of the other workflows (previously it was using the only nightly version for everything)
- this fixes the clippy error