### PR TITLE
fix: use app-key and fuelup-env for publishing last version metadata

### DIFF
--- a/.github/workflows/gh-pages-meta.yml
+++ b/.github/workflows/gh-pages-meta.yml
@@ -20,6 +20,7 @@ jobs:
   deploy:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
+    environment: fuelup-bot
     steps:
       - uses: actions/checkout@v2
 
@@ -29,10 +30,16 @@ jobs:
           cp fuelup-init.sh ${{ env.FUELUP_INIT_DIR }}
           cp fuelup-init.sh ${{ env.FUELUP_INIT_DIR }}/index.html
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_KEY }}
+
       - name: Deploy latest fuelup init
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           keep_files: true
           publish_dir: ${{ env.FUELUP_INIT_DIR }}
           destination_dir: ./
@@ -51,7 +58,7 @@ jobs:
       - name: Deploy latest fuelup version
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           keep_files: true
           publish_dir: ${{ env.FUELUP_VERSION_DIR }}
           destination_dir: ./


### PR DESCRIPTION
closes #718.

I realized we used to have a similar issue for other stuff in gh-pages. #700 and #701 is merged to fix that. This PR brings the fuelup env and key generation steps to publishing the metadata as well.