### PR TITLE
feat: add forc-call binary

### DIFF
--- a/component/src/lib.rs
+++ b/component/src/lib.rs
@@ -7,7 +7,7 @@ use toml_edit::de;
 // Keeping forc since some ways we handle forc is slightly different.
 pub const FORC: &str = "forc";
 pub const FUELUP: &str = "fuelup";
-// forc-client is handled differently - its actual binaries are 'forc-run', 'forc-deploy', and 'forc-submit'
+// forc-client is handled differently - its actual binaries are 'forc-call', 'forc-deploy', 'forc-run', and 'forc-submit'
 pub const FORC_CLIENT: &str = "forc-client";
 
 const COMPONENTS_TOML: &str = include_str!("../../components.toml");

--- a/components.toml
+++ b/components.toml
@@ -1,7 +1,7 @@
 [component.forc]
 name = "forc"
 tarball_prefix = "forc-binaries"
-executables = ["forc", "forc-fmt", "forc-lsp", "forc-doc", "forc-deploy", "forc-run"]
+executables = ["forc", "forc-fmt", "forc-lsp", "forc-doc", "forc-call", "forc-deploy", "forc-run"]
 repository_name = "sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 publish = true
@@ -51,7 +51,7 @@ targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 name = "forc-client"
 tarball_prefix = "forc-binaries"
 is_plugin = true
-executables = ["forc-deploy", "forc-run", "forc-submit"]
+executables = ["forc-call", "forc-deploy", "forc-run", "forc-submit"]
 repository_name = "sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -23,7 +23,7 @@ curl -fsSL https://install.fuel.network/ | sh
 ```
 <!-- install:example:end -->
 
-This will install `forc`, `forc-client`, `forc-fmt`, `forc-crypto`, `forc-debug`, `forc-migrate`, `forc-lsp`, `forc-node`, `forc-publish`, `forc-wallet` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
+This will install `forc`, `forc-client`, `forc-fmt`, `forc-crypto`, `forc-call`, `forc-debug`, `forc-migrate`, `forc-lsp`, `forc-node`, `forc-publish`, `forc-wallet` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
 
 Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so:
 
@@ -40,6 +40,7 @@ fuel-core --version
 forc-deploy --version
 forc-fmt --version
 forc-crypto --version
+forc-call --version
 forc-debug --version
 forc-lsp --version
 forc-migrate --version

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -34,6 +34,7 @@ fn fuelup_show_latest() -> Result<()> {
             latest-{target} (default)
               forc : 0.1.0
                 - forc-client
+                  - forc-call : 0.1.0
                   - forc-deploy : 0.1.0
                   - forc-run : 0.1.0
                   - forc-submit : 0.1.0
@@ -80,6 +81,7 @@ fn fuelup_show_and_switch() -> Result<()> {
             latest-{target} (default)
               forc : 0.1.0
                 - forc-client
+                  - forc-call : 0.1.0
                   - forc-deploy : 0.1.0
                   - forc-run : 0.1.0
                   - forc-submit : 0.1.0
@@ -119,6 +121,7 @@ fn fuelup_show_and_switch() -> Result<()> {
             nightly-{target} (default)
               forc : 0.2.0
                 - forc-client
+                  - forc-call : 0.2.0
                   - forc-deploy : 0.2.0
                   - forc-run : 0.2.0
                   - forc-submit : 0.2.0
@@ -164,6 +167,7 @@ fn fuelup_show_custom() -> Result<()> {
             my_toolchain (default)
               forc : not found
                 - forc-client
+                  - forc-call : not found
                   - forc-deploy : not found
                   - forc-run : not found
                   - forc-submit : not found
@@ -207,6 +211,7 @@ fn fuelup_show_override() -> Result<()> {
             testnet-{target} (override), path: {}
               forc : not found
                 - forc-client
+                  - forc-call : not found
                   - forc-deploy : not found
                   - forc-run : not found
                   - forc-submit : not found
@@ -253,6 +258,7 @@ fn fuelup_show_latest_then_override() -> Result<()> {
             latest-{target} (default)
               forc : 0.1.0
                 - forc-client
+                  - forc-call : 0.1.0
                   - forc-deploy : 0.1.0
                   - forc-run : 0.1.0
                   - forc-submit : 0.1.0
@@ -305,6 +311,7 @@ fn fuelup_show_latest_then_override() -> Result<()> {
             nightly-2022-08-30-{target} (override), path: {ovveride_path_str}
               forc : 0.2.0
                 - forc-client
+                  - forc-call : 0.2.0
                   - forc-deploy : 0.2.0
                   - forc-run : 0.2.0
                   - forc-submit : 0.2.0

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -109,8 +109,8 @@ pub fn yesterday() -> String {
     let current_date = Utc::now();
     let yesterday = current_date - Duration::days(1);
     let _ = yesterday.format("%Y-%m-%d").to_string();
-    // TODO: point to a nightly that has `forc-submit`
-    "2024-11-16".to_string()
+    // NOTE: point to a version that includes `forc-call`.
+    "2025-05-19".to_string()
 }
 
 impl TestCfg {

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -72,6 +72,7 @@ const VERSION_2: &Version = &Version::new(0, 2, 0);
 
 pub static ALL_BINS: &[&str] = &[
     "forc",
+    "forc-call",
     "forc-crypto",
     "forc-debug",
     "forc-deploy",


### PR DESCRIPTION
Adds `forc-call` command to fuelup components list.

closes https://github.com/FuelLabs/fuelup/issues/727.