### PR TITLE
add: forc-publish binary

### DIFF
--- a/components.toml
+++ b/components.toml
@@ -79,6 +79,14 @@ executables = ["forc-node"]
 repository_name = "sway"
 targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
 
+[component.forc-publish]
+name = "forc-publish"
+tarball_prefix = "forc-binaries"
+is_plugin = true
+executables = ["forc-publish"]
+repository_name = "sway"
+targets = ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64"]
+
 [component.fuel-core]
 name = "fuel-core"
 tarball_prefix = "fuel-core"

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -23,7 +23,7 @@ curl -fsSL https://install.fuel.network/ | sh
 ```
 <!-- install:example:end -->
 
-This will install `forc`, `forc-client`, `forc-fmt`, `forc-crypto`, `forc-debug`, `forc-migrate`, `forc-lsp`, `forc-node`,`forc-wallet` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
+This will install `forc`, `forc-client`, `forc-fmt`, `forc-crypto`, `forc-debug`, `forc-migrate`, `forc-lsp`, `forc-node`, `forc-publish`, `forc-wallet` as well as `fuel-core` in `~/.fuelup/bin`. The script will ask for permission to add `~/.fuelup/bin` to your `PATH`.
 
 Otherwise, you can also pass `--no-modify-path` so that `fuelup-init` does not modify your `PATH` and will not ask for permission to do so:
 
@@ -44,6 +44,7 @@ forc-debug --version
 forc-lsp --version
 forc-migrate --version
 forc-node --version
+forc-publish --version
 forc-run --version
 forc-submit --version
 ```

--- a/tests/show.rs
+++ b/tests/show.rs
@@ -44,6 +44,7 @@ fn fuelup_show_latest() -> Result<()> {
                 - forc-lsp : 0.1.0
                 - forc-migrate : 0.1.0
                 - forc-node : 0.1.0
+                - forc-publish : 0.1.0
                 - forc-tx : 0.1.0
                 - forc-wallet : 0.1.0
               fuel-core : 0.1.0
@@ -89,6 +90,7 @@ fn fuelup_show_and_switch() -> Result<()> {
                 - forc-lsp : 0.1.0
                 - forc-migrate : 0.1.0
                 - forc-node : 0.1.0
+                - forc-publish : 0.1.0
                 - forc-tx : 0.1.0
                 - forc-wallet : 0.1.0
               fuel-core : 0.1.0
@@ -127,6 +129,7 @@ fn fuelup_show_and_switch() -> Result<()> {
                 - forc-lsp : 0.2.0
                 - forc-migrate : 0.2.0
                 - forc-node : 0.2.0
+                - forc-publish : 0.2.0
                 - forc-tx : 0.2.0
                 - forc-wallet : 0.2.0
               fuel-core : 0.2.0
@@ -171,6 +174,7 @@ fn fuelup_show_custom() -> Result<()> {
                 - forc-lsp : not found
                 - forc-migrate : not found
                 - forc-node : not found
+                - forc-publish : not found
                 - forc-tx : not found
                 - forc-wallet : not found
               fuel-core : not found
@@ -213,6 +217,7 @@ fn fuelup_show_override() -> Result<()> {
                 - forc-lsp : not found
                 - forc-migrate : not found
                 - forc-node : not found
+                - forc-publish : not found
                 - forc-tx : not found
                 - forc-wallet : not found
               fuel-core : not found
@@ -258,6 +263,7 @@ fn fuelup_show_latest_then_override() -> Result<()> {
                 - forc-lsp : 0.1.0
                 - forc-migrate : 0.1.0
                 - forc-node : 0.1.0
+                - forc-publish : 0.1.0
                 - forc-tx : 0.1.0
                 - forc-wallet : 0.1.0
               fuel-core : 0.1.0
@@ -309,6 +315,7 @@ fn fuelup_show_latest_then_override() -> Result<()> {
                 - forc-lsp : 0.2.0
                 - forc-migrate : 0.2.0
                 - forc-node : 0.2.0
+                - forc-publish : 0.2.0
                 - forc-tx : 0.2.0
                 - forc-wallet : 0.2.0
               fuel-core : 0.2.0

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -81,6 +81,7 @@ pub static ALL_BINS: &[&str] = &[
     "forc-lsp",
     "forc-migrate",
     "forc-node",
+    "forc-publish",
     "forc-run",
     "forc-submit",
     "forc-tx",


### PR DESCRIPTION
Adds the `forc-publish` command to `fuelup` components list.

