### PR TITLE
tests: actually point to yesterday for nightly overrides

### DIFF
--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -108,9 +108,8 @@ pub static ALL_BINS: &[&str] = &[
 pub fn yesterday() -> String {
     let current_date = Utc::now();
     let yesterday = current_date - Duration::days(1);
-    let _ = yesterday.format("%Y-%m-%d").to_string();
     // NOTE: point to a version that includes `forc-call`.
-    "2025-05-19".to_string()
+    yesterday.format("%Y-%m-%d").to_string()
 }
 
 impl TestCfg {


### PR DESCRIPTION
When a new tool is added to the nightly channels, it becomes hard to test things because the override channel does not contain the tested binary.

To make this process easier I changed the nightly date we pin-to dynamic and point to yesterday anytime the tests are executed. This way if the new binary added to the nightly it will be available in the tests in the next day.

This was why #728 was blocked for some time.