### PR TITLE
Fix: Correct upstream repository mapping in update-compiler-explorer script

### DIFF
--- a/ci/update-compiler-explorer/src/git.rs
+++ b/ci/update-compiler-explorer/src/git.rs
@@ -34,8 +34,13 @@ pub fn clone_fork(
         ));
     }
 
+    // Map the repo to the upstream name
     let upstream_name = if repo.starts_with("FuelLabs/") {
-        repo.split('/').nth(1).unwrap_or(dir_name)
+        match repo {
+            "FuelLabs/compiler-explorer-infra" => "infra",
+            "FuelLabs/compiler-explorer" => "compiler-explorer", 
+            _ => unreachable!("Unexpected repo: {}", repo),
+        }
     } else {
         dir_name
     };

--- a/ci/update-compiler-explorer/src/git.rs
+++ b/ci/update-compiler-explorer/src/git.rs
@@ -38,7 +38,7 @@ pub fn clone_fork(
     let upstream_name = if repo.starts_with("FuelLabs/") {
         match repo {
             "FuelLabs/compiler-explorer-infra" => "infra",
-            "FuelLabs/compiler-explorer" => "compiler-explorer", 
+            "FuelLabs/compiler-explorer" => "compiler-explorer",
             _ => unreachable!("Unexpected repo: {}", repo),
         }
     } else {


### PR DESCRIPTION
Fixes the upstream repository URL mapping in the `update-compiler-explorer` script.

The script was incorrectly trying to fetch from `https://github.com/compiler-explorer/compiler-explorer-infra.git` (which doesn't exist) instead of the actual upstream `https://github.com/compiler-explorer/infra.git`.
