### PR TITLE
Revert "Remove workflow files from git tracking to avoid permission issues"

### DIFF
--- a/ci/update-compiler-explorer/src/git.rs
+++ b/ci/update-compiler-explorer/src/git.rs
@@ -108,19 +108,6 @@ pub fn clone_fork(
         ));
     }
 
-    // Remove workflow files from git tracking to avoid permission issues
-    let rm_status = Command::new("git")
-        .current_dir(&repo_path)
-        .args(["rm", "-r", "--cached", ".github/workflows/"])
-        .status();
-
-    // Don't fail if .github/workflows doesn't exist
-    if let Ok(status) = rm_status {
-        if status.success() {
-            println!("Removed .github/workflows/ from git tracking");
-        }
-    }
-
     Ok((temp_dir, repo_path))
 }
 


### PR DESCRIPTION
Reverts FuelLabs/fuelup#747

Mike is going to update the permission on the app token so this work around isn't needed. 