### PR TITLE
write updated content back to disk so there and changes to commit

### DIFF
--- a/ci/update-compiler-explorer/src/main.rs
+++ b/ci/update-compiler-explorer/src/main.rs
@@ -57,13 +57,16 @@ fn update_compiler_explorer(version: &str, github_token: &str) -> Result<()> {
 
     // Make updates
     let content = fs::read_to_string(&ce_path.join(AMAZON_PROPERTIES_PATH))?;
-    update_amazon_properties(&content, version)?;
+    let updated_content = update_amazon_properties(&content, version)?;
+    fs::write(&ce_path.join(AMAZON_PROPERTIES_PATH), updated_content)?;
 
     let content = fs::read_to_string(&infra_path.join(SWAY_YAML_PATH))?;
-    update_sway_yaml(&content, version)?;
+    let updated_content = update_sway_yaml(&content, version)?;
+    fs::write(&infra_path.join(SWAY_YAML_PATH), updated_content)?;
 
     let content = fs::read_to_string(&infra_path.join(LIBRARIES_YAML_PATH))?;
-    update_libraries_yaml(&content, version)?;
+    let updated_content = update_libraries_yaml(&content, version)?;
+    fs::write(&infra_path.join(LIBRARIES_YAML_PATH), updated_content)?;
 
     println!("Updated for Sway version {}", version);
 


### PR DESCRIPTION
we forgot to write the result of the changes back to disk so git could find the changes to commit

See [this run](https://github.com/FuelLabs/fuelup/actions/runs/15695115990/job/44218614156).

```
HEAD is now at c702bed51 Prefer Release builds for MSVC compilers in ceconan (#7760)
Switched to a new branch 'update-sway-0.68.7'
Updated for Sway version 0.68.7
On branch update-sway-0.68.7
nothing to commit, working tree clean
No changes to commit for version 0.68.7.
```