### PR TITLE
Fix Typo in Proxy Environment Variables Heading

### DIFF
--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -38,7 +38,7 @@ fuelup self update
 
 To configure `fuelup` to use your proxy setting you can change `http_proxy`(***other optional environments see below***) environment value. The value format is in [libcurl format](https://everything.curl.dev/usingcurl/proxies/type.html) as in `[protocol://]host[:port]`.
 
-### Supported proxy enviroment variables
+### Supported proxy environment variables
 
 - http_proxy
 - HTTP_PROXY


### PR DESCRIPTION

Description:  
This pull request corrects a typo in the "Supported proxy environment variables" heading in basics.md, ensuring accurate and professional documentation formatting.