### PR TITLE
Fix typo in verify_tag.sh

### DIFF
--- a/.github/workflows/scripts/verify_tag.sh
+++ b/.github/workflows/scripts/verify_tag.sh
@@ -23,7 +23,7 @@ if [ -z "$MANIFEST" ]; then
     exit 1
 fi
 
-# strip preceeding 'v' if it exists on tag
+# strip preceding 'v' if it exists on tag
 REF=${REF/#v/}
 TOML_VERSION=$(dasel -f "$MANIFEST" -r toml 'package.version')
 


### PR DESCRIPTION

```markdown


## 🔧 Changes

- Corrected typo in `.github/workflows/scripts/verify_tag.sh`
- Changed `preceeding` to `preceding` in line 26 comment

## 🎯 Type of Change

- [x] Documentation/Comment fix
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change


```

