### PR TITLE
  feat(toolchain): Add export command to generate fuel-toolchain.toml

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -5,6 +5,7 @@
 | `fuelup toolchain install latest`         | Installs the toolchain distributed by the `latest` channel                               |
 | `fuelup toolchain new my_toolchain`       | Creates a new custom toolchain named 'my_toolchain' and sets it as the default           |
 | `fuelup toolchain uninstall my_toolchain` | Uninstalls the toolchain named 'my_toolchain'                                            |
+| `fuelup toolchain export`                 | Exports the active toolchain configuration to `fuel-toolchain.toml`                      |
 | `fuelup default my_toolchain`             | Sets 'my_toolchain' as the active toolchain                                              |
 | `fuelup component add forc`               | Adds _[forc]_ to the currently active custom toolchain                                   |
 | `fuelup component add fuel-core@0.9.5`    | Adds _[fuel-core]_ v0.9.5 to the currently active custom toolchain                       |

--- a/docs/src/overrides.md
+++ b/docs/src/overrides.md
@@ -100,6 +100,13 @@ You can also export a specific toolchain by name:
 fuelup toolchain export my-custom-toolchain
 ```
 
+To export to a custom file path:
+
+```sh
+fuelup toolchain export -o my-backup.toml
+fuelup toolchain export --output /path/to/my-toolchain.toml
+```
+
 ### Export examples
 
 Exporting a `latest` toolchain produces a file like:
@@ -128,17 +135,23 @@ fuel-core = "0.45.1"
 
 ### Overwrite protection
 
-By default, `export` will fail if a `fuel-toolchain.toml` file already exists:
+By default, `export` will fail if a `fuel-toolchain.toml` file already exists in the current directory:
 
 ```console
 $ fuelup toolchain export
 error: fuel-toolchain.toml already exists in the current directory. Use --force to overwrite.
 ```
 
-Use the `--force` flag to overwrite an existing file:
+You can either use the `--force` flag to overwrite the existing file:
 
 ```sh
 fuelup toolchain export --force
+```
+
+Or export to a different path to avoid the conflict entirely:
+
+```sh
+fuelup toolchain export -o backup-toolchain.toml
 ```
 
 [toolchain]: concepts/toolchains.md

--- a/docs/src/overrides.md
+++ b/docs/src/overrides.md
@@ -79,6 +79,68 @@ fuel-core = "0.41.7"         # use specific version of fuel-core
 
 Local paths can be either absolute or relative to the `fuel-toolchain.toml` file. When using local paths, `fuelup` will validate that the specified binaries exist and are executable.
 
+## Exporting toolchains
+
+<!-- This section should explain how to export toolchains -->
+<!-- export:example:start -->
+You can generate a `fuel-toolchain.toml` file from your current toolchain configuration using the `export` command. This is useful for sharing your exact toolchain setup with team members or documenting the specific tool versions used in your project.
+<!-- export:example:end -->
+
+To export your currently active toolchain:
+
+```sh
+fuelup toolchain export
+```
+
+This creates a `fuel-toolchain.toml` file in the current directory containing your active toolchain's channel and installed component versions.
+
+You can also export a specific toolchain by name:
+
+```sh
+fuelup toolchain export my-custom-toolchain
+```
+
+### Export examples
+
+Exporting a `latest` toolchain produces a file like:
+
+```toml
+[toolchain]
+channel = "latest-2025-09-03"
+
+[components]
+forc = "0.69.1"
+fuel-core = "0.45.1"
+fuel-core-keygen = "0.45.1"
+forc-wallet = "0.15.1"
+```
+
+Exporting a custom toolchain preserves the custom name:
+
+```toml
+[toolchain]
+channel = "my-dev-toolchain"
+
+[components]
+forc = "0.69.1"
+fuel-core = "0.45.1"
+```
+
+### Overwrite protection
+
+By default, `export` will fail if a `fuel-toolchain.toml` file already exists:
+
+```console
+$ fuelup toolchain export
+error: fuel-toolchain.toml already exists in the current directory. Use --force to overwrite.
+```
+
+Use the `--force` flag to overwrite an existing file:
+
+```sh
+fuelup toolchain export --force
+```
+
 [toolchain]: concepts/toolchains.md
 [distributed toolchains]: concepts/toolchains.md#toolchains
 [`testnet`]: concepts/channels.md#the-testnet-channel

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -1,4 +1,6 @@
-use crate::ops::fuelup_toolchain::{export::export, install::install, new::new, uninstall::uninstall};
+use crate::ops::fuelup_toolchain::{
+    export::export, install::install, new::new, uninstall::uninstall,
+};
 use crate::target_triple::TargetTriple;
 use crate::toolchain::RESERVED_TOOLCHAIN_NAMES;
 use anyhow::{bail, Result};

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -1,4 +1,4 @@
-use crate::ops::fuelup_toolchain::{install::install, new::new, uninstall::uninstall};
+use crate::ops::fuelup_toolchain::{export::export, install::install, new::new, uninstall::uninstall};
 use crate::target_triple::TargetTriple;
 use crate::toolchain::RESERVED_TOOLCHAIN_NAMES;
 use anyhow::{bail, Result};
@@ -12,6 +12,8 @@ pub enum ToolchainCommand {
     New(NewCommand),
     /// Uninstall a toolchain
     Uninstall(UninstallCommand),
+    /// Export a toolchain configuration to fuel-toolchain.toml
+    Export(ExportCommand),
 }
 
 #[derive(Debug, Parser)]
@@ -31,6 +33,15 @@ pub struct NewCommand {
 pub struct UninstallCommand {
     /// Toolchain to uninstall
     pub name: String,
+}
+
+#[derive(Debug, Parser)]
+pub struct ExportCommand {
+    /// Toolchain to export (defaults to active toolchain)
+    pub name: Option<String>,
+    /// Overwrite existing fuel-toolchain.toml file
+    #[clap(long)]
+    pub force: bool,
 }
 
 fn name_allowed(s: &str) -> Result<String> {
@@ -60,6 +71,7 @@ pub fn exec(command: ToolchainCommand) -> Result<()> {
         ToolchainCommand::Install(command) => install(command)?,
         ToolchainCommand::New(command) => new(command)?,
         ToolchainCommand::Uninstall(command) => uninstall(command)?,
+        ToolchainCommand::Export(command) => export(command)?,
     };
 
     Ok(())

--- a/src/commands/toolchain.rs
+++ b/src/commands/toolchain.rs
@@ -39,7 +39,10 @@ pub struct UninstallCommand {
 pub struct ExportCommand {
     /// Toolchain to export (defaults to active toolchain)
     pub name: Option<String>,
-    /// Overwrite existing fuel-toolchain.toml file
+    /// Output file path (defaults to fuel-toolchain.toml)
+    #[clap(short, long)]
+    pub output: Option<String>,
+    /// Overwrite existing file
     #[clap(long)]
     pub force: bool,
 }

--- a/src/ops/fuelup_toolchain/export.rs
+++ b/src/ops/fuelup_toolchain/export.rs
@@ -8,7 +8,7 @@ use anyhow::{bail, Result};
 use component::Components;
 use std::{collections::HashMap, path::Path, str::FromStr};
 use time::OffsetDateTime;
-use tracing::{info, warn};
+use tracing::info;
 
 pub fn export(command: ExportCommand) -> Result<()> {
     let output_path = Path::new("fuel-toolchain.toml");
@@ -38,15 +38,6 @@ pub fn export(command: ExportCommand) -> Result<()> {
     
     // Collect installed components
     let components = collect_toolchain_components(&toolchain)?;
-    
-    // Check for local paths and warn user
-    let local_components = check_for_local_paths(&components);
-    if !local_components.is_empty() {
-        warn!(
-            "⚠️  Local paths detected in toolchain. These may not work for other users:\n{}",
-            local_components.iter().map(|c| format!("  - {}", c)).collect::<Vec<_>>().join("\n")
-        );
-    }
     
     // Create override config
     let cfg = OverrideCfg::new(
@@ -117,14 +108,3 @@ fn collect_toolchain_components(toolchain: &Toolchain) -> Result<HashMap<String,
     Ok(components)
 }
 
-fn check_for_local_paths(components: &HashMap<String, ComponentSpec>) -> Vec<String> {
-    components.iter()
-        .filter_map(|(name, spec)| {
-            if spec.is_path() {
-                Some(name.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}

--- a/src/ops/fuelup_toolchain/export.rs
+++ b/src/ops/fuelup_toolchain/export.rs
@@ -1,0 +1,130 @@
+use crate::{
+    commands::toolchain::ExportCommand,
+    file::{get_bin_version, write_file},
+    toolchain::{DistToolchainDescription, DistToolchainName, Toolchain},
+    toolchain_override::{Channel, ComponentSpec, OverrideCfg, ToolchainCfg},
+};
+use anyhow::{bail, Result};
+use component::Components;
+use std::{collections::HashMap, path::Path, str::FromStr};
+use time::OffsetDateTime;
+use tracing::{info, warn};
+
+pub fn export(command: ExportCommand) -> Result<()> {
+    let output_path = Path::new("fuel-toolchain.toml");
+    
+    // Check if file exists
+    if output_path.exists() && !command.force {
+        bail!(
+            "fuel-toolchain.toml already exists in the current directory. \
+             Use --force to overwrite."
+        );
+    }
+    
+    // Get toolchain to export
+    let toolchain = match command.name {
+        Some(name) => {
+            let toolchain = Toolchain::from_path(&name);
+            if !toolchain.exists() {
+                bail!("Toolchain '{}' not found", name);
+            }
+            toolchain
+        }
+        None => Toolchain::from_settings()?,
+    };
+    
+    // Parse toolchain name to get channel info
+    let channel = parse_toolchain_channel(&toolchain.name)?;
+    
+    // Collect installed components
+    let components = collect_toolchain_components(&toolchain)?;
+    
+    // Check for local paths and warn user
+    let local_components = check_for_local_paths(&components);
+    if !local_components.is_empty() {
+        warn!(
+            "⚠️  Local paths detected in toolchain. These may not work for other users:\n{}",
+            local_components.iter().map(|c| format!("  - {}", c)).collect::<Vec<_>>().join("\n")
+        );
+    }
+    
+    // Create override config
+    let cfg = OverrideCfg::new(
+        ToolchainCfg { channel },
+        if components.is_empty() { None } else { Some(components) },
+    );
+    
+    // Write to file
+    let toml_content = cfg.to_string_pretty()?;
+    write_file(output_path, &toml_content)?;
+    
+    info!("Exported toolchain '{}' to fuel-toolchain.toml", toolchain.name);
+    Ok(())
+}
+
+fn parse_toolchain_channel(toolchain_name: &str) -> Result<Channel> {
+    // Handle distributable toolchains (e.g., "latest-x86_64-apple-darwin")
+    if let Ok(desc) = DistToolchainDescription::from_str(toolchain_name) {
+        match desc.name {
+            DistToolchainName::Latest | DistToolchainName::Nightly => {
+                if desc.date.is_some() {
+                    // Handle dated channels (e.g. "latest-2023-01-15")
+                    Ok(Channel {
+                        name: desc.name.to_string(),
+                        date: desc.date,
+                    })
+                } else {
+                    // For latest/nightly without date, use today's date to make it valid
+                    let today = OffsetDateTime::now_utc().date();
+                    Ok(Channel {
+                        name: desc.name.to_string(),
+                        date: Some(today),
+                    })
+                }
+            }
+            DistToolchainName::Testnet | DistToolchainName::Mainnet => {
+                // These are dateless channels
+                Ok(Channel {
+                    name: desc.name.to_string(),
+                    date: None,
+                })
+            }
+        }
+    } else {
+        // Handle custom toolchains
+        Ok(Channel {
+            name: toolchain_name.to_string(),
+            date: None,
+        })
+    }
+}
+
+fn collect_toolchain_components(toolchain: &Toolchain) -> Result<HashMap<String, ComponentSpec>> {
+    let mut components = HashMap::new();
+    
+    for component in Components::collect_publishables()? {
+        if toolchain.has_component(&component.name) {
+            let bin_path = toolchain.bin_path.join(&component.name);
+            if let Ok(version) = get_bin_version(&bin_path) {
+                components.insert(
+                    component.name.clone(),
+                    ComponentSpec::Version(version),
+                );
+            }
+        }
+    }
+    
+    Ok(components)
+}
+
+fn check_for_local_paths(components: &HashMap<String, ComponentSpec>) -> Vec<String> {
+    components.iter()
+        .filter_map(|(name, spec)| {
+            if spec.is_path() {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}

--- a/src/ops/fuelup_toolchain/export.rs
+++ b/src/ops/fuelup_toolchain/export.rs
@@ -11,10 +11,13 @@ use time::OffsetDateTime;
 use tracing::info;
 
 pub fn export(command: ExportCommand) -> Result<()> {
-    let output_path = Path::new("fuel-toolchain.toml");
+    let output_path = match &command.output {
+        Some(path) => Path::new(path),
+        None => Path::new("fuel-toolchain.toml"),
+    };
     
-    // Check if file exists
-    if output_path.exists() && !command.force {
+    // Check if file exists (only when using default path)
+    if command.output.is_none() && output_path.exists() && !command.force {
         bail!(
             "fuel-toolchain.toml already exists in the current directory. \
              Use --force to overwrite."
@@ -49,7 +52,7 @@ pub fn export(command: ExportCommand) -> Result<()> {
     let toml_content = cfg.to_string_pretty()?;
     write_file(output_path, &toml_content)?;
     
-    info!("Exported toolchain '{}' to fuel-toolchain.toml", toolchain.name);
+    info!("Exported toolchain '{}' to {}", toolchain.name, output_path.display());
     Ok(())
 }
 

--- a/src/ops/fuelup_toolchain/mod.rs
+++ b/src/ops/fuelup_toolchain/mod.rs
@@ -1,3 +1,4 @@
+pub mod export;
 pub mod install;
 pub mod new;
 pub mod uninstall;

--- a/tests/toolchain.rs
+++ b/tests/toolchain.rs
@@ -283,23 +283,22 @@ fn fuelup_toolchain_export_active() -> Result<()> {
     testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
         let output = cfg.fuelup(&["toolchain", "export"]);
         assert!(output.status.success());
-        
+
         // Check that fuel-toolchain.toml was created
         let toml_path = cfg.home.join("fuel-toolchain.toml");
         assert!(toml_path.exists(), "fuel-toolchain.toml should be created");
-        
+
         // Verify the TOML content is valid
         let content = std::fs::read_to_string(&toml_path)
             .expect("Should be able to read fuel-toolchain.toml");
-        
+
         // Parse the TOML to ensure it's valid
-        let parsed: fuelup::toolchain_override::OverrideCfg = 
-            toml_edit::de::from_str(&content)
-                .expect("Generated TOML should be valid");
-        
+        let parsed: fuelup::toolchain_override::OverrideCfg =
+            toml_edit::de::from_str(&content).expect("Generated TOML should be valid");
+
         // Verify it has a toolchain section
         assert!(!parsed.toolchain.channel.name.is_empty());
-        
+
         // Clean up
         std::fs::remove_file(&toml_path).ok();
     })?;
@@ -309,23 +308,23 @@ fn fuelup_toolchain_export_active() -> Result<()> {
 #[test]
 fn fuelup_toolchain_export_specific() -> Result<()> {
     testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
-        let expected_toolchain_name = 
+        let expected_toolchain_name =
             "latest-".to_owned() + &TargetTriple::from_host().unwrap().to_string();
-        
+
         let output = cfg.fuelup(&["toolchain", "export", &expected_toolchain_name]);
         assert!(output.status.success());
-        
+
         // Check that fuel-toolchain.toml was created
         let toml_path = cfg.home.join("fuel-toolchain.toml");
         assert!(toml_path.exists(), "fuel-toolchain.toml should be created");
-        
+
         // Verify the TOML content contains the correct toolchain
         let content = std::fs::read_to_string(&toml_path)
             .expect("Should be able to read fuel-toolchain.toml");
-            
+
         assert!(content.contains("[toolchain]"));
         assert!(content.contains("channel"));
-        
+
         // Clean up
         std::fs::remove_file(&toml_path).ok();
     })?;
@@ -338,13 +337,15 @@ fn fuelup_toolchain_export_file_exists_error() -> Result<()> {
         // Create a fuel-toolchain.toml file first
         let toml_path = cfg.home.join("fuel-toolchain.toml");
         std::fs::write(&toml_path, "# existing file").unwrap();
-        
+
         // Try to export without --force flag
         let output = cfg.fuelup(&["toolchain", "export"]);
-        
+
         // Check stderr for error message (main.rs logs errors but doesn't exit with error code)
-        assert!(output.stderr.contains("already exists") || output.stdout.contains("already exists"));
-        
+        assert!(
+            output.stderr.contains("already exists") || output.stdout.contains("already exists")
+        );
+
         // Clean up
         std::fs::remove_file(&toml_path).ok();
     })?;
@@ -357,18 +358,18 @@ fn fuelup_toolchain_export_force_overwrite() -> Result<()> {
         // Create a fuel-toolchain.toml file first
         let toml_path = cfg.home.join("fuel-toolchain.toml");
         std::fs::write(&toml_path, "# existing file").unwrap();
-        
+
         // Export with --force flag
         let output = cfg.fuelup(&["toolchain", "export", "--force"]);
         assert!(output.status.success());
-        
+
         // Verify the file was overwritten with valid content
         let content = std::fs::read_to_string(&toml_path)
             .expect("Should be able to read fuel-toolchain.toml");
-        
+
         assert!(content.contains("[toolchain]"));
         assert!(!content.contains("# existing file"));
-        
+
         // Clean up
         std::fs::remove_file(&toml_path).ok();
     })?;
@@ -379,7 +380,7 @@ fn fuelup_toolchain_export_force_overwrite() -> Result<()> {
 fn fuelup_toolchain_export_nonexistent_toolchain() -> Result<()> {
     testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
         let output = cfg.fuelup(&["toolchain", "export", "nonexistent-toolchain"]);
-        
+
         // Check stderr for error message (main.rs logs errors but doesn't exit with error code)
         assert!(output.stderr.contains("not found") || output.stdout.contains("not found"));
     })?;
@@ -392,16 +393,16 @@ fn fuelup_toolchain_export_custom_output_path() -> Result<()> {
         let custom_path = cfg.home.join("my-custom-toolchain.toml");
         let output = cfg.fuelup(&["toolchain", "export", "-o", "my-custom-toolchain.toml"]);
         assert!(output.status.success());
-        
+
         // Check that custom file was created
         assert!(custom_path.exists(), "Custom output file should be created");
-        
+
         // Verify TOML content is valid
-        let content = std::fs::read_to_string(&custom_path)
-            .expect("Should be able to read custom file");
+        let content =
+            std::fs::read_to_string(&custom_path).expect("Should be able to read custom file");
         assert!(content.contains("[toolchain]"));
         assert!(content.contains("channel"));
-        
+
         // Clean up
         std::fs::remove_file(&custom_path).ok();
     })?;
@@ -414,18 +415,18 @@ fn fuelup_toolchain_export_bypass_force_with_custom_path() -> Result<()> {
         // Create default fuel-toolchain.toml
         let default_path = cfg.home.join("fuel-toolchain.toml");
         std::fs::write(&default_path, "# existing file").unwrap();
-        
+
         // Export to custom path should work without --force
         let custom_path = cfg.home.join("backup.toml");
         let output = cfg.fuelup(&["toolchain", "export", "-o", "backup.toml"]);
         assert!(output.status.success());
-        
+
         // Verify custom file was created
         assert!(custom_path.exists(), "Custom output file should be created");
-        let content = std::fs::read_to_string(&custom_path)
-            .expect("Should be able to read custom file");
+        let content =
+            std::fs::read_to_string(&custom_path).expect("Should be able to read custom file");
         assert!(content.contains("[toolchain]"));
-        
+
         // Clean up
         std::fs::remove_file(&default_path).ok();
         std::fs::remove_file(&custom_path).ok();


### PR DESCRIPTION
## Description:
Adds `fuelup toolchain export` command to generate shareable toolchain configurations.

### Features
- Exports active or specified toolchain to `fuel-toolchain.toml`
- Auto-detects installed components with versions
- Supports custom output paths with `--output/-o` flag
- Handles latest/nightly channels with date formatting for validity
- Includes `--force` flag to overwrite existing files

### Usage
```sh
fuelup toolchain export                   # Export active toolchain
fuelup toolchain export my-custom         # Export specific toolchain
fuelup toolchain export -o backup.toml    # Export to custom path
```

Closes #322
Supersedes #526