### PR TITLE
Grant issues permission to coverage workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     permissions: # Write access to push changes to pages
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v3
       - name: Install nightly toolchain


### PR DESCRIPTION
allow the `check code coverage` job to create/update PR comments by granting `issues: write`

this should help fix the [failing](https://github.com/FuelLabs/fuelup/actions/runs/17601137369/job/51086468987?pr=776) step when external contributors submit a PR.
