### PR TITLE
Avoid coverage comment failures on forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           minimum-coverage: 0 # for now we are not enforcing any minimum coverage.
           artifact-name: code-coverage-report
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          update-comment: true
+          update-comment: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
   try-run-fuelup-init:
     needs: cancel-previous-runs


### PR DESCRIPTION
- allow the coverage workflow to write issue comments when GitHub grants the token permission
- skip the comment update when the PR comes from a forked repository so the step stops erroring
