### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -26,7 +26,7 @@ jobs:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Run shellcheck and shfmt on all scripts
         uses: luizm/action-sh-checker@master
         env:
@@ -44,7 +44,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -80,7 +80,7 @@ jobs:
           - os: macos-latest
     runs-on: ${{ matrix.job.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Attempt to install fuelup through fuelup-init.sh
         run: ./fuelup-init.sh
 
@@ -88,7 +88,7 @@ jobs:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -96,7 +96,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Check Clippy Linter
         run: cargo clippy --locked --all-features --all-targets -- -D warnings
@@ -105,7 +105,7 @@ jobs:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -120,7 +120,7 @@ jobs:
     needs: cancel-previous-runs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Verify tag version
         run: |
@@ -191,7 +191,7 @@ jobs:
             target: aarch64-apple-darwin
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -199,7 +199,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.job.target }}
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
           key: '${{ matrix.job.target }}'
@@ -275,7 +275,7 @@ jobs:
     runs-on: ${{ matrix.job.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Try fuelup installation with fuelup-init
         run: ./fuelup-init.sh
 

--- a/.github/workflows/gh-pages-meta.yml
+++ b/.github/workflows/gh-pages-meta.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: fuelup-bot
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Copy fuelup-init.sh
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: fuelup-bot
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
@@ -41,7 +41,7 @@ jobs:
       - name: Get tag
         id: branch_name
         run: |
-          echo ::set-output name=BRANCH_NAME::${GITHUB_REF#refs/tags/}
+          echo "BRANCH_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         if: startsWith(github.ref, 'refs/tags')
 
       - name: Deploy tag

--- a/.github/workflows/nightly-cargo-audit.yml
+++ b/.github/workflows/nightly-cargo-audit.yml
@@ -8,8 +8,8 @@ jobs:
   cargo_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-nightly-channel.yml
+++ b/.github/workflows/publish-nightly-channel.yml
@@ -17,7 +17,7 @@ jobs:
     environment: fuelup-bot
     steps:
       - name: checkout master
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -40,7 +40,7 @@ jobs:
 
           cp $CHANNEL_TOML ${{ env.NIGHTLY_CHANNEL_DIR }}
 
-          echo "::set-output name=archive_dir::channels/nightly/${FORMATTED_PUBLISHED_DATE}"
+          echo "archive_dir=channels/nightly/${FORMATTED_PUBLISHED_DATE}" >> $GITHUB_OUTPUT
 
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/update-compiler-explorer.yml
+++ b/.github/workflows/update-compiler-explorer.yml
@@ -10,7 +10,7 @@ jobs:
     environment: fuelup-bot
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
 


### PR DESCRIPTION
 Fixes deprecated GitHub Actions and updates dependencies to prevent future CI failures.

  **Critical fixes:**
  - Replace deprecated `set-output` command with `$GITHUB_OUTPUT` (will stop working soon per [GitHub's deprecation
  notice](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
  - Replace unmaintained `actions-rs/audit-check` with actively maintained `rustsec/audit-check@v2`

  **Dependency updates:**
  - `actions/checkout`: v1/v2/v3 → v4 (standardize across all workflows)
  - `Swatinem/rust-cache`: v1 → v2 (performance improvements)
  - `styfle/cancel-workflow-action`: 0.9.1 → 0.12.1 (bug fixes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes workflows on latest Actions (checkout v4, rust-cache v2, cancel-workflow-action 0.12.1), replaces deprecated set-output with GITHUB_OUTPUT, and migrates cargo audit to rustsec/audit-check v2.
> 
> - **CI workflows** (`.github/workflows/ci.yml`):
>   - Upgrade `actions/checkout` to `v4` and `Swatinem/rust-cache` to `v2` across jobs.
>   - Bump `styfle/cancel-workflow-action` to `0.12.1`.
> - **GitHub Pages**:
>   - `gh-pages.yml`: use `actions/checkout@v4`; replace deprecated `set-output` with `$GITHUB_OUTPUT`.
>   - `gh-pages-meta.yml`: use `actions/checkout@v4`; bump `cancel-workflow-action` to `0.12.1`.
> - **Nightly cargo audit** (`nightly-cargo-audit.yml`):
>   - Switch from `actions-rs/audit-check@v1` to `rustsec/audit-check@v2` and use `actions/checkout@v4`.
> - **Publish nightly channel** (`publish-nightly-channel.yml`):
>   - Use `actions/checkout@v4` and `$GITHUB_OUTPUT` for outputs.
> - **Update Compiler Explorer** (`update-compiler-explorer.yml`):
>   - Use `actions/checkout@v4`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dce939c7d90e6cb31ce2fd8ff5097321254dd0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->