### PR TITLE
ci: lock build-channel workflow installs

### DIFF
--- a/.github/workflows/publish-nightly-channel.yml
+++ b/.github/workflows/publish-nightly-channel.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install build-channel script
-        run: cargo install --debug --path ./ci/build-channel
+        run: cargo install --locked --debug --path ./ci/build-channel
 
       - name: Publish nightly channel
         id: setup

--- a/.github/workflows/update-channel.yml
+++ b/.github/workflows/update-channel.yml
@@ -53,7 +53,7 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
 
       - name: Install build-channel script
-        run: cargo install --debug --path ./ci/build-channel
+        run: cargo install --locked --debug --path ./ci/build-channel
 
       - name: Switch to gh-pages branch
         run: |

--- a/tests/testcfg/mod.rs
+++ b/tests/testcfg/mod.rs
@@ -67,6 +67,8 @@ pub struct TestOutput {
 
 pub const DATE: &str = "2022-08-30";
 pub const CUSTOM_TOOLCHAIN_NAME: &str = "my-toolchain";
+/// Archived nightly used for override-based tests so they don't depend on the latest nightly publish.
+pub const OVERRIDE_DATE: &str = "2025-12-31";
 
 const VERSION: &Version = &Version::new(0, 1, 0);
 const VERSION_2: &Version = &Version::new(0, 2, 0);
@@ -262,15 +264,16 @@ pub fn delete_toolchain(cfg: &TestCfg, toolchain: &Toolchain) {
 /// # Examples
 ///
 /// ```no_run
-/// use testcfg::{self, get_default_toolchain_override_toolchain, FuelupState};
+/// use testcfg::{self, get_default_toolchain_override_toolchain, FuelupState, OVERRIDE_DATE};
 ///
 /// testcfg::setup(FuelupState::LatestToolchainInstalled, &|cfg| {
 ///     let toolchain = get_default_toolchain_override_toolchain();
-///     assert_eq!(toolchain.name, format!("nightly-{}", yesterday()));
+///     assert_eq!(toolchain.name, format!("nightly-{OVERRIDE_DATE}"));
 /// });
 /// ```
 pub fn get_default_toolchain_override_toolchain() -> Toolchain {
-    Toolchain::new(format!("nightly-{}", yesterday()).as_str()).unwrap()
+    // Use an archived nightly so these tests don't depend on yesterday's publish succeeding.
+    Toolchain::new(format!("nightly-{OVERRIDE_DATE}").as_str()).unwrap()
 }
 
 fn setup_toolchain(fuelup_home_path: &Path, toolchain: &str) -> Result<()> {
@@ -349,7 +352,7 @@ pub fn setup_default_override_file(cfg: &TestCfg, component_name: Option<&str>) 
     let toolchain_override = ToolchainOverride {
         cfg: OverrideCfg::new(
             ToolchainCfg {
-                channel: toolchain_override::Channel::from_str(&format!("nightly-{}", yesterday()))
+                channel: toolchain_override::Channel::from_str(&format!("nightly-{OVERRIDE_DATE}"))
                     .unwrap(),
             },
             component_name.map(|c| {


### PR DESCRIPTION
## Summary

Lock the `build-channel` workflow installs to the repository lockfile in the two workflows that install the helper binary:

- `Publish Channel (nightly)`
- `Update Channel`

## Why

The manual `Publish Channel (nightly)` run failed on the `Install build-channel script` step before it ever reached channel publishing or deployment.

Failing run:
- https://github.com/FuelLabs/fuelup/actions/runs/24062679117

The workflow currently runs:

- `cargo install --debug --path ./ci/build-channel`

Because that install is not locked, Cargo re-resolves dependencies on the runner instead of honoring the repo lockfile. In the failing run it pulled newer `icu_* 2.2.0` crates, which require Rust `1.86`, while the workflow is pinned to Rust `1.85.0`.

The repo lockfile already pins the same dependency family to compatible `1.5.x` versions, so this is dependency drift during CI install rather than a true project-wide Rust floor bump.

## Change

Add `--locked` to the `cargo install --path ./ci/build-channel` command in both workflows so CI uses the checked-in lockfile when installing the helper.

## Validation

Validated locally in Docker with `rust:1.85` against this checkout:

- `cargo install --debug --path ./ci/build-channel` failed and re-resolved to `icu_* 2.2.0`, which requires Rust `1.86`
- `cargo install --locked --debug --path ./ci/build-channel` succeeded on the same toolchain

That matches the GitHub Actions failure and confirms `--locked` is the correct fix without widening the workflow toolchain unnecessarily.
